### PR TITLE
Sync Claude auto-review reliability fixes from MtgCsvHelper

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -54,11 +54,22 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Enabled for debug visibility while auto-review reliability is being verified.
+          # Safe for our review prompts: no secrets in the input. Disable once auto-review is reliably commenting.
+          show_full_output: true
+          # Inject the PR number explicitly. Without this the agent intermittently can't infer
+          # which PR to review and falls back to AskUserQuestion, which terminates silently in CI.
           prompt: |
-            Please review this pull request for:
+            Review pull request #${{ github.event.pull_request.number }} on ${{ github.repository }}.
+
+            Fetch the diff with: gh pr diff ${{ github.event.pull_request.number }}
+            Fetch metadata with: gh pr view ${{ github.event.pull_request.number }}
+
+            Review for:
             - Code quality and .NET/MAUI best practices
             - Potential bugs or issues
             - MVVM pattern adherence
+            - Security implications
             - Test coverage
 
             Use inline comments for specific issues and a summary comment for overall feedback.


### PR DESCRIPTION
## Summary
- Inject PR number/repo into the auto-review prompt so the agent doesn't fall back to `AskUserQuestion` (which silently terminates in CI). This was tracked down on MtgCsvHelper after two PRs ran the workflow successfully but posted nothing.
- Enable `show_full_output: true` for debug visibility while reliability is being verified — to be removed once auto-review is consistently commenting.
- Add "Security implications" to the review checklist; keep MAUI / MVVM-specific guidance (project-relevant).

## Why
Standardizing the Claude review workflow across hobby repos. MtgCsvHelper found these two fixes the hard way; FantasyFootball gets them for free before the upcoming Blazor-port PRs.

## Test plan
- [ ] Auto-review fires on this PR
- [ ] Comments are actually posted (inline + summary)
- [ ] After verified working, follow-up to remove `show_full_output: true`