### PR TITLE
Blazor port — Phase 0: Decouple core library from MAUI

### DIFF
--- a/src/FantasyFootball/FantasyFootball.csproj
+++ b/src/FantasyFootball/FantasyFootball.csproj
@@ -4,7 +4,6 @@
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>preview</LangVersion>
-    <UseMaui>true</UseMaui>
     <Nullable>enable</Nullable>
     <NeutralLanguage>en</NeutralLanguage>
     <EnforceCodeStyleInBuild>True</EnforceCodeStyleInBuild>
@@ -23,7 +22,6 @@
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
     <PackageReference Include="CsvHelper" Version="33.1.0" />
     <PackageReference Include="MathNet.Numerics" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Maui.Controls" Version="10.0.11" />
     <PackageReference Include="Serilog" Version="4.3.0" />
     <PackageReference Include="Serilog.Sinks.Debug" Version="3.0.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />


### PR DESCRIPTION
## Summary
- Strip `<UseMaui>true</UseMaui>` and the `Microsoft.Maui.Controls` package reference from `src/FantasyFootball/FantasyFootball.csproj`. The core library had no real MAUI API usage — only the csproj declared MAUI affinity, which would have blocked referencing it from an upcoming Blazor WebAssembly project.
- The MAUI UI project (`src/FantasyFootball.UI`) brings its own MAUI references and continues to build unchanged.

## Why
First step of the Web + Hybrid port tracked in #10. With this change, the core library is a plain `Microsoft.NET.Sdk` `net10.0` library that any consumer — including future Blazor WASM + MAUI BlazorWebView hosts — can reference.

Closes #4.

## Test plan
- [x] `dotnet build src/FantasyFootball/FantasyFootball.csproj` — Build succeeded, 0 errors.
- [x] `dotnet test src/FantasyFootball.Tests` — 23 passing. One pre-existing flake (`RoundAdvancerTests.ExpandedWorldCupFormat_FullSimulationProducesDistinctR32Teams`) confirmed unrelated to this PR; passes 5/5 in isolation and passes on `master`. Tracked separately in #12.
- [x] `dotnet build src/FantasyFootball.UI/FantasyFootball.UI.csproj -f net10.0-windows10.0.19041.0` — Build succeeded, 0 errors (24 pre-existing XAML binding warnings, unrelated).