### PR TITLE
Adopt develop/main branching with deferred gh-pages workflow

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -44,4 +44,16 @@ dotnet workload install maui
 - MVVM pattern: ViewModels in UI project, Models/Services in core library
 - XAML formatting governed by Settings.XamlStyler
 - Follow .editorconfig rules
-- Default branch is `master`
+
+## Branching & Releases
+
+- **`develop`** is the default branch. Feature branches branch off `develop`
+  and PR back to `develop`.
+- **`main`** is the release branch. When `develop` is release-ready, open a PR
+  from `develop` → `main`, bump version, tag the merge commit (e.g. `0.3.0`).
+- **`gh-pages`** is force-pushed by `.github/workflows/github-pages.yml` on each
+  push to `main` once Phase 4 of the Blazor port (#10) flips the trigger from
+  `workflow_dispatch` to `push: branches: [main]`.
+- CI build/test (`.github/workflows/dotnet.yml`) runs only on push/PR to `main`.
+  PRs to `develop` get the Claude auto-review but not the .NET build — verify
+  locally before opening develop-targeted PRs.

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -2,9 +2,9 @@ name: .NET MAUI (Android only)
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   build:

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -1,0 +1,35 @@
+name: github pages
+
+# Manual-trigger only for now. Flip to `push: branches: [main]` in Phase 4 of #10
+# once the Blazor WASM project (FantasyFootball.Web) is production-ready. Until
+# then the workflow exists so it can be run on demand via `gh workflow run github-pages`
+# without touching the public site.
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET Core
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Install .NET WASM Build Tools
+        run: dotnet workload install wasm-tools
+
+      - name: Publish BlazorWebAssembly Project
+        run: dotnet publish src/FantasyFootball.Web/FantasyFootball.Web.csproj -c:Release -p:GHPages=true -o dist/Web --nologo
+
+      - name: Commit wwwroot to GitHub Pages
+        uses: JamesIves/github-pages-deploy-action@v4.5.0
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: gh-pages
+          FOLDER: dist/Web/wwwroot

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -28,8 +28,7 @@ jobs:
         run: dotnet publish src/FantasyFootball.Web/FantasyFootball.Web.csproj -c:Release -p:GHPages=true -o dist/Web --nologo
 
       - name: Commit wwwroot to GitHub Pages
-        uses: JamesIves/github-pages-deploy-action@v4.5.0
+        uses: JamesIves/github-pages-deploy-action@65b5dfd4f5bcd3a7403bbc2959c144256167464e # v4.5.0
         with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: gh-pages
           FOLDER: dist/Web/wwwroot


### PR DESCRIPTION
## Summary
Sets up the develop/main branching pattern to mirror StepKie/MtgCsvHelper:

- `dotnet.yml` now triggers on `main` instead of `master` (the branch rename to `main` happens immediately after this PR merges).
- New `github-pages.yml` workflow scaffolded from MtgCsvHelper, but **trigger is `workflow_dispatch` only** — no automatic deploys yet. Will be flipped to `push: branches: [main]` in Phase 4 of #10 once the Blazor WASM project (`src/FantasyFootball.Web/`) is production-ready.
- `.claude/CLAUDE.md` documents the new convention:
  - `develop` = default branch, feature work targets it.
  - `main` = release branch, version-tagged commits.
  - `gh-pages` = force-pushed by CI from `main` (once enabled).

## Why
Want better control over release publication. Feature integration on `develop` keeps `main` clean for release tagging and avoids accidental gh-pages deploys mid-port.

## Post-merge plan
1. Rename `master` → `main` on GitHub (auto-retargets any open PRs, redirects pushes).
2. Create `develop` from `main`, push.
3. Switch GitHub default branch to `develop`.
4. Phase 1 of #10 then branches off `develop`.

## Note on CI for this PR
Build CI **will not run** on this PR. `dotnet.yml`'s trigger is configured for `main`, which doesn't exist yet — by design. Claude auto-review (no branch filter) will fire as usual. No code changes anyway; just workflow + docs.