### PR TITLE
Blazor port — Phase 2: LocalStorage-backed IRepository for the web host

### DIFF
--- a/src/FantasyFootball.Core/Models/Game.cs
+++ b/src/FantasyFootball.Core/Models/Game.cs
@@ -1,4 +1,5 @@
-﻿using MathNet.Numerics.Distributions;
+﻿using System.Text.Json.Serialization;
+using MathNet.Numerics.Distributions;
 
 namespace FantasyFootball.Models;
 
@@ -6,6 +7,9 @@ namespace FantasyFootball.Models;
 /// TODO There is no good way to create a Game from a string, or create a Game with a result already set, or clear an existing result
 /// </summary>
 [Table(nameof(Game))]
+[JsonPolymorphic(TypeDiscriminatorPropertyName = "$kind")]
+[JsonDerivedType(typeof(Game), "game")]
+[JsonDerivedType(typeof(KoGame), "ko")]
 public class Game : NamedUniqueId
 {
 	[Ignore]

--- a/src/FantasyFootball.Core/Models/Qualifier.cs
+++ b/src/FantasyFootball.Core/Models/Qualifier.cs
@@ -1,6 +1,11 @@
-﻿namespace FantasyFootball.Models;
+﻿using System.Text.Json.Serialization;
+
+namespace FantasyFootball.Models;
 
 [Table(nameof(Qualifier))]
+[JsonPolymorphic(TypeDiscriminatorPropertyName = "$kind")]
+[JsonDerivedType(typeof(GroupQualifier), "group")]
+[JsonDerivedType(typeof(GameQualifier), "game")]
 public abstract class Qualifier : NamedUniqueId
 {
 	[OneToOne]

--- a/src/FantasyFootball.UI/Pages/Home.razor
+++ b/src/FantasyFootball.UI/Pages/Home.razor
@@ -1,4 +1,7 @@
 @page "/"
+@using FantasyFootball.Models
+@using FantasyFootball.Repositories
+@inject IRepository Repo
 
 <PageTitle>Fantasy Football</PageTitle>
 
@@ -6,3 +9,50 @@
 <MudText Typo="Typo.body1">
   Simulate football competitions in your browser. Pages and features will be wired up in later phases of #10.
 </MudText>
+
+@* Temporary storage smoke-test panel. Removed once real pages exercise the repo (Phase 3). *@
+<MudPaper Class="pa-4 mt-6" Elevation="1">
+  <MudText Typo="Typo.h6" GutterBottom="true">Storage diagnostic</MudText>
+  <MudText Typo="Typo.body2" Class="mb-3">
+    Stored confederations: <strong>@_stored.Count</strong>. Add one, hard-refresh the page (F5),
+    and verify the count persists. DevTools → Application → Local Storage → <code>fantasy-football:Confederation</code>
+    should hold the JSON.
+  </MudText>
+  <MudStack Row="true" Spacing="2" AlignItems="AlignItems.Center" Class="mb-3">
+    <MudTextField @bind-Value="_newName" Label="Name" Variant="Variant.Outlined" Margin="Margin.Dense" />
+    <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="Add" Disabled="@string.IsNullOrWhiteSpace(_newName)">Add</MudButton>
+    <MudSpacer />
+    <MudButton Variant="Variant.Outlined" Color="Color.Error" OnClick="Reset" Disabled="@(_stored.Count == 0)">Reset all</MudButton>
+  </MudStack>
+  @if (_stored.Count > 0)
+  {
+    <MudList T="Confederation" Dense="true">
+      @foreach (var c in _stored)
+      {
+        <MudListItem T="Confederation" Value="@c">@c.Id — @c.Name (@c.Continent)</MudListItem>
+      }
+    </MudList>
+  }
+</MudPaper>
+
+@code {
+  string _newName = "";
+  List<Confederation> _stored = [];
+
+  protected override void OnInitialized() => Refresh();
+
+  void Add()
+  {
+    Repo.Save(new Confederation { Name = _newName, Continent = "—", NoOfWmParticipants = 0 });
+    _newName = "";
+    Refresh();
+  }
+
+  void Reset()
+  {
+    Repo.Reset();
+    Refresh();
+  }
+
+  void Refresh() => _stored = Repo.GetAll<Confederation>();
+}

--- a/src/FantasyFootball.Web/FantasyFootball.Web.csproj
+++ b/src/FantasyFootball.Web/FantasyFootball.Web.csproj
@@ -20,6 +20,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.8" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.8" PrivateAssets="all" />
+    <PackageReference Include="Blazored.LocalStorage" Version="4.5.0" />
     <PackageReference Include="MudBlazor" Version="9.4.0" />
     <PackageReference Include="PublishSPAforGitHubPages.Build" Version="3.0.3" />
   </ItemGroup>

--- a/src/FantasyFootball.Web/Program.cs
+++ b/src/FantasyFootball.Web/Program.cs
@@ -1,4 +1,7 @@
+using Blazored.LocalStorage;
+using FantasyFootball.Repositories;
 using FantasyFootball.UI;
+using FantasyFootball.Web.Services;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
 using MudBlazor.Services;
@@ -9,5 +12,7 @@ builder.RootComponents.Add<Routes>("#app");
 builder.RootComponents.Add<HeadOutlet>("head::after");
 
 builder.Services.AddMudServices();
+builder.Services.AddBlazoredLocalStorage();
+builder.Services.AddScoped<IRepository, LocalStorageRepository>();
 
 await builder.Build().RunAsync();

--- a/src/FantasyFootball.Web/Services/IgnoreAttributeTypeInfoResolver.cs
+++ b/src/FantasyFootball.Web/Services/IgnoreAttributeTypeInfoResolver.cs
@@ -1,0 +1,31 @@
+using System.Text.Json;
+using System.Text.Json.Serialization.Metadata;
+using SQLite;
+
+namespace FantasyFootball.Web.Services;
+
+/// <summary>
+/// JSON type-info resolver that excludes properties marked with sqlite-net-pcl's
+/// <see cref="IgnoreAttribute"/>. The core models use [Ignore] to mark computed /
+/// derived properties (Winner, IsFinished, GamesByDate, etc.) that shouldn't be
+/// persisted. The default System.Text.Json resolver doesn't know about [Ignore]
+/// and would serialize them — both bloating the payload and re-walking the graph
+/// in ways that surface cycles.
+/// </summary>
+public sealed class IgnoreAttributeTypeInfoResolver : DefaultJsonTypeInfoResolver
+{
+    public override JsonTypeInfo GetTypeInfo(Type type, JsonSerializerOptions options)
+    {
+        var info = base.GetTypeInfo(type, options);
+        foreach (var property in info.Properties)
+        {
+            if (property.AttributeProvider?.GetCustomAttributes(typeof(IgnoreAttribute), inherit: true).Length > 0)
+            {
+                property.ShouldSerialize = static (_, _) => false;
+                property.Get = null;
+                property.Set = null;
+            }
+        }
+        return info;
+    }
+}

--- a/src/FantasyFootball.Web/Services/IgnoreAttributeTypeInfoResolver.cs
+++ b/src/FantasyFootball.Web/Services/IgnoreAttributeTypeInfoResolver.cs
@@ -22,8 +22,6 @@ public sealed class IgnoreAttributeTypeInfoResolver : DefaultJsonTypeInfoResolve
             if (property.AttributeProvider?.GetCustomAttributes(typeof(IgnoreAttribute), inherit: true).Length > 0)
             {
                 property.ShouldSerialize = static (_, _) => false;
-                property.Get = null;
-                property.Set = null;
             }
         }
         return info;

--- a/src/FantasyFootball.Web/Services/LocalStorageRepository.cs
+++ b/src/FantasyFootball.Web/Services/LocalStorageRepository.cs
@@ -1,0 +1,144 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Blazored.LocalStorage;
+using FantasyFootball.Models;
+using FantasyFootball.Repositories;
+
+namespace FantasyFootball.Web.Services;
+
+/// <summary>
+/// IRepository implementation that persists each aggregate-root type as a JSON list
+/// under its own browser LocalStorage key. Non-root nested types (Stage, Round, Game,
+/// Qualifier, …) live inside their containing Competition's JSON; saving a Game walks
+/// up to the Competition and re-persists the aggregate.
+///
+/// Differs from the SQLite Repository in two intentional ways:
+///   1. No background table for nested types — GetAll&lt;Round&gt; / GetAll&lt;Game&gt; will throw.
+///      Callers should navigate through Competition.Stages / Rounds / AllGames instead.
+///   2. Save is synchronous: in-memory dictionary mutation followed by a synchronous
+///      JSON serialize + SetItem call. Acceptable in WASM because LocalStorage I/O is
+///      already main-thread; under our data volume (low hundreds of KB) latency is sub-ms.
+/// </summary>
+public sealed class LocalStorageRepository : IRepository
+{
+  const string KeyPrefix = "fantasy-football:";
+
+  static readonly HashSet<Type> AggregateRoots =
+  [
+    typeof(Competition),
+    typeof(Team),
+    typeof(Confederation),
+    typeof(Country),
+  ];
+
+  readonly ISyncLocalStorageService _localStorage;
+  readonly JsonSerializerOptions _jsonOptions;
+  readonly Dictionary<Type, Dictionary<int, NamedUniqueId>> _buckets = [];
+
+  public LocalStorageRepository(ISyncLocalStorageService localStorage)
+  {
+    _localStorage = localStorage;
+    _jsonOptions = new JsonSerializerOptions
+    {
+      TypeInfoResolver = new IgnoreAttributeTypeInfoResolver(),
+      ReferenceHandler = ReferenceHandler.Preserve,
+    };
+  }
+
+  public List<T> GetAll<T>() where T : NamedUniqueId, new()
+  {
+    ThrowIfNotAggregateRoot(typeof(T));
+    return LoadBucket<T>().Values.Cast<T>().ToList();
+  }
+
+  public Task<List<T>> GetAllAsync<T>() where T : NamedUniqueId, new() => Task.FromResult(GetAll<T>());
+
+  public T? Get<T>(int id) where T : NamedUniqueId, new()
+  {
+    ThrowIfNotAggregateRoot(typeof(T));
+    return LoadBucket<T>().TryGetValue(id, out var item) ? (T)item : null;
+  }
+
+  public int Count<T>() where T : NamedUniqueId, new()
+  {
+    ThrowIfNotAggregateRoot(typeof(T));
+    return LoadBucket<T>().Count;
+  }
+
+  public void Save<T>(T item) where T : NamedUniqueId, new()
+  {
+    // Non-root types defer to the containing Competition. CompetitionSimulator
+    // calls Repo.Save(game) mid-simulation; we treat that as a Competition update.
+    if (item is Game game)
+    {
+      var competition = game.Round?.Stage?.Competition
+        ?? throw new InvalidOperationException(
+          $"Cannot save Game {game.Id}: missing Round.Stage.Competition back-reference.");
+      Save(competition);
+      return;
+    }
+
+    ThrowIfNotAggregateRoot(typeof(T));
+    var bucket = LoadBucket<T>();
+    if (item.Id == 0)
+    {
+      item.Id = bucket.Keys.DefaultIfEmpty(0).Max() + 1;
+    }
+    bucket[item.Id] = item;
+    PersistBucket<T>(bucket);
+  }
+
+  public void Delete<T>(T item) where T : NamedUniqueId, new()
+  {
+    ThrowIfNotAggregateRoot(typeof(T));
+    var bucket = LoadBucket<T>();
+    if (bucket.Remove(item.Id))
+    {
+      PersistBucket<T>(bucket);
+    }
+  }
+
+  public void Reset()
+  {
+    var ourKeys = _localStorage.Keys().Where(k => k.StartsWith(KeyPrefix)).ToList();
+    foreach (var key in ourKeys)
+    {
+      _localStorage.RemoveItem(key);
+    }
+    _buckets.Clear();
+  }
+
+  public void Dispose() { }
+
+  Dictionary<int, NamedUniqueId> LoadBucket<T>() where T : NamedUniqueId, new()
+  {
+    if (_buckets.TryGetValue(typeof(T), out var cached)) return cached;
+
+    var raw = _localStorage.GetItemAsString(KeyFor<T>());
+    var items = string.IsNullOrEmpty(raw)
+      ? []
+      : JsonSerializer.Deserialize<List<T>>(raw, _jsonOptions) ?? [];
+    var bucket = items.ToDictionary(x => x.Id, x => (NamedUniqueId)x);
+    _buckets[typeof(T)] = bucket;
+    return bucket;
+  }
+
+  void PersistBucket<T>(Dictionary<int, NamedUniqueId> bucket) where T : NamedUniqueId, new()
+  {
+    var items = bucket.Values.Cast<T>().ToList();
+    var raw = JsonSerializer.Serialize(items, _jsonOptions);
+    _localStorage.SetItemAsString(KeyFor<T>(), raw);
+  }
+
+  static string KeyFor<T>() => KeyPrefix + typeof(T).Name;
+
+  static void ThrowIfNotAggregateRoot(Type t)
+  {
+    if (!AggregateRoots.Contains(t))
+    {
+      throw new NotSupportedException(
+        $"{t.Name} is not an aggregate root in LocalStorageRepository. " +
+        $"Access nested types through Competition (e.g. competition.Rounds[i].AllGames[j]).");
+    }
+  }
+}

--- a/src/FantasyFootball.Web/Services/LocalStorageRepository.cs
+++ b/src/FantasyFootball.Web/Services/LocalStorageRepository.cs
@@ -31,18 +31,19 @@ public sealed class LocalStorageRepository : IRepository
     typeof(Country),
   ];
 
+  // STJ freezes JsonSerializerOptions on first use; one shared instance is the documented best practice.
+  static readonly JsonSerializerOptions JsonOptions = new()
+  {
+    TypeInfoResolver = new IgnoreAttributeTypeInfoResolver(),
+    ReferenceHandler = ReferenceHandler.Preserve,
+  };
+
   readonly ISyncLocalStorageService _localStorage;
-  readonly JsonSerializerOptions _jsonOptions;
   readonly Dictionary<Type, Dictionary<int, NamedUniqueId>> _buckets = [];
 
   public LocalStorageRepository(ISyncLocalStorageService localStorage)
   {
     _localStorage = localStorage;
-    _jsonOptions = new JsonSerializerOptions
-    {
-      TypeInfoResolver = new IgnoreAttributeTypeInfoResolver(),
-      ReferenceHandler = ReferenceHandler.Preserve,
-    };
   }
 
   public List<T> GetAll<T>() where T : NamedUniqueId, new()
@@ -117,7 +118,7 @@ public sealed class LocalStorageRepository : IRepository
     var raw = _localStorage.GetItemAsString(KeyFor<T>());
     var items = string.IsNullOrEmpty(raw)
       ? []
-      : JsonSerializer.Deserialize<List<T>>(raw, _jsonOptions) ?? [];
+      : JsonSerializer.Deserialize<List<T>>(raw, JsonOptions) ?? [];
     var bucket = items.ToDictionary(x => x.Id, x => (NamedUniqueId)x);
     _buckets[typeof(T)] = bucket;
     return bucket;
@@ -126,7 +127,7 @@ public sealed class LocalStorageRepository : IRepository
   void PersistBucket<T>(Dictionary<int, NamedUniqueId> bucket) where T : NamedUniqueId, new()
   {
     var items = bucket.Values.Cast<T>().ToList();
-    var raw = JsonSerializer.Serialize(items, _jsonOptions);
+    var raw = JsonSerializer.Serialize(items, JsonOptions);
     _localStorage.SetItemAsString(KeyFor<T>(), raw);
   }
 


### PR DESCRIPTION
## Summary
Phase 2 of the Blazor port (#10, #6). The web target now persists data to browser LocalStorage; MAUI continues to use SQLite. Both behind the same `IRepository` interface, so ViewModels don't change.

Two commits:

1. **Add `[JsonPolymorphic]` discriminators to `Game` and `Qualifier`** (`3160417`) — Core lib touch. `Game/KoGame` and `Qualifier/GroupQualifier/GameQualifier` round-trip through `System.Text.Json` with a `$kind` discriminator. Chose `$kind` to avoid colliding with the `$type` STJ already uses for `ReferenceHandler.Preserve`.
2. **Add `LocalStorageRepository`** (`9ee4e96` or whatever the second commit ends up as) — Web project + UI smoke-test panel.

## Design

- **Aggregate-root storage**: each of `Competition`, `Team`, `Confederation`, `Country` gets its own LocalStorage key (`fantasy-football:<Type>`). Nested types (Stage / Round / Game / Qualifier) travel inside their containing `Competition`'s JSON. `Save<Game>` walks `game.Round.Stage.Competition` and re-persists the aggregate — this matches `CompetitionSimulator`'s existing call pattern (`Repo.Save(game); ... Repo.Save(Competition);`).
- **`IgnoreAttributeTypeInfoResolver`**: tells STJ to skip properties marked with sqlite-net-pcl's `[Ignore]` attribute. Without it, computed properties (`Winner`, `IsFinished`, `GamesByDate`, …) would serialize too, bloating the JSON and re-walking the graph in ways that surface cycles.
- **`ReferenceHandler.Preserve`**: handles `Competition → Stage → Round → Game → Round` cycles via `$id`/`$ref`.
- **Scoped DI** (not Singleton): Blazored.LocalStorage registers `ISyncLocalStorageService` as Scoped, so the repository has to match. In a WASM standalone app, Scoped and Singleton are effectively the same anyway (one user, one scope).

## Out of scope (deferred)

- **`GetAll<Round>` / `GetAll<Game>` etc.** throw `NotSupportedException`. No callers exist; nested types are accessed through `Competition`. Easy to add when a real use case shows up.
- **Export / Import JSON** (listed as a checkbox in #6) — defer to a small follow-up once Phase 3 page ports surface UI for it.
- **SQLite WASM warnings** (8 × `WASM0001` from `SQLitePCLRaw.provider.e_sqlite3`) — Core lib still references SQLite. Phase 2 doesn't remove it (web doesn't use it, but the dependency is transitively pulled in by `FantasyFootball.Core`). Worth excluding SQLite packages from the Web build in a future cleanup; not blocking.

## Test plan

- [x] `dotnet build` succeeds for `Core`, `UI`, `Web` (0 errors, 8 pre-existing SQLite WASM warnings).
- [x] `dotnet run --project src/FantasyFootball.Web` → page loads at `http://localhost:5225`.
- [x] **Round-trip verified manually**: type a name, Add → entry shows up in the diagnostic list. F5 → entries persist. DevTools → Application → Local Storage → `fantasy-football:Confederation` shows the JSON blob with `$id` / `$values`. Reset All → key removed.
- [ ] Polymorphism + cycle handling still untested in this PR — Confederation is flat. Will be exercised by Phase 3 when real `Competition` saves happen.

## UI note

There's a temporary "Storage diagnostic" `<MudPaper>` on Home.razor. **It's a dev aid, not a feature** — it'll be removed in the first Phase 3 PR when real pages take the home route.