### PR TITLE
Blazor port — Phase 3 (Settings): first page port

### DIFF
--- a/src/FantasyFootball.UI/GlobalUsings.cs
+++ b/src/FantasyFootball.UI/GlobalUsings.cs
@@ -1,0 +1,2 @@
+// Contains global usings imported into all files in the project
+global using System.Globalization;

--- a/src/FantasyFootball.UI/GlobalUsings.cs
+++ b/src/FantasyFootball.UI/GlobalUsings.cs
@@ -1,2 +1,1 @@
-// Contains global usings imported into all files in the project
 global using System.Globalization;

--- a/src/FantasyFootball.UI/Layout/NavMenu.razor
+++ b/src/FantasyFootball.UI/Layout/NavMenu.razor
@@ -1,3 +1,4 @@
 <MudNavMenu>
   <MudNavLink Href="" Match="NavLinkMatch.All" Icon="@Icons.Material.Filled.Home">Home</MudNavLink>
+  <MudNavLink Href="settings" Icon="@Icons.Material.Filled.Settings">Settings</MudNavLink>
 </MudNavMenu>

--- a/src/FantasyFootball.UI/Pages/Home.razor
+++ b/src/FantasyFootball.UI/Pages/Home.razor
@@ -1,58 +1,13 @@
 @page "/"
-@using FantasyFootball.Models
-@using FantasyFootball.Repositories
-@inject IRepository Repo
 
 <PageTitle>Fantasy Football</PageTitle>
 
 <MudText Typo="Typo.h3" HtmlTag="h1" GutterBottom="true">Fantasy Football</MudText>
-<MudText Typo="Typo.body1">
-  Simulate football competitions in your browser. Pages and features will be wired up in later phases of #10.
+<MudText Typo="Typo.body1" GutterBottom="true">
+  Simulate football competitions — World Cups and Euros — directly in your browser.
+  Your saved competitions live in this browser's local storage; nothing is sent to a server.
 </MudText>
-
-@* Temporary storage smoke-test panel. Removed once real pages exercise the repo (Phase 3). *@
-<MudPaper Class="pa-4 mt-6" Elevation="1">
-  <MudText Typo="Typo.h6" GutterBottom="true">Storage diagnostic</MudText>
-  <MudText Typo="Typo.body2" Class="mb-3">
-    Stored confederations: <strong>@_stored.Count</strong>. Add one, hard-refresh the page (F5),
-    and verify the count persists. DevTools → Application → Local Storage → <code>fantasy-football:Confederation</code>
-    should hold the JSON.
-  </MudText>
-  <MudStack Row="true" Spacing="2" AlignItems="AlignItems.Center" Class="mb-3">
-    <MudTextField @bind-Value="_newName" Label="Name" Variant="Variant.Outlined" Margin="Margin.Dense" />
-    <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="Add" Disabled="@string.IsNullOrWhiteSpace(_newName)">Add</MudButton>
-    <MudSpacer />
-    <MudButton Variant="Variant.Outlined" Color="Color.Error" OnClick="Reset" Disabled="@(_stored.Count == 0)">Reset all</MudButton>
-  </MudStack>
-  @if (_stored.Count > 0)
-  {
-    <MudList T="Confederation" Dense="true">
-      @foreach (var c in _stored)
-      {
-        <MudListItem T="Confederation" Value="@c">@c.Id — @c.Name (@c.Continent)</MudListItem>
-      }
-    </MudList>
-  }
-</MudPaper>
-
-@code {
-  string _newName = "";
-  List<Confederation> _stored = [];
-
-  protected override void OnInitialized() => Refresh();
-
-  void Add()
-  {
-    Repo.Save(new Confederation { Name = _newName, Continent = "—", NoOfWmParticipants = 0 });
-    _newName = "";
-    Refresh();
-  }
-
-  void Reset()
-  {
-    Repo.Reset();
-    Refresh();
-  }
-
-  void Refresh() => _stored = Repo.GetAll<Confederation>();
-}
+<MudText Typo="Typo.body2" Class="mud-text-secondary">
+  Use the menu on the left to navigate. Settings let you tweak simulation speed and reset
+  saved data; the competition pages (coming next) let you run and inspect tournaments.
+</MudText>

--- a/src/FantasyFootball.UI/Pages/Settings.razor
+++ b/src/FantasyFootball.UI/Pages/Settings.razor
@@ -36,7 +36,7 @@
     <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="3">
       <MudButton Variant="Variant.Outlined"
                  Color="Color.Error"
-                 OnClick="@(() => ViewModel.ResetDatabaseCommand.ExecuteAsync(null))"
+                 OnClick="ViewModel.ResetDatabaseCommand.ExecuteAsync"
                  Disabled="ViewModel.IsBusy">
         Reset database
       </MudButton>

--- a/src/FantasyFootball.UI/Pages/Settings.razor
+++ b/src/FantasyFootball.UI/Pages/Settings.razor
@@ -1,5 +1,4 @@
 @page "/settings"
-@using System.Globalization
 @using FantasyFootball.UI.ViewModels
 @inject SettingsViewModel ViewModel
 @implements IDisposable
@@ -37,7 +36,7 @@
     <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="3">
       <MudButton Variant="Variant.Outlined"
                  Color="Color.Error"
-                 OnClick="ViewModel.ResetDatabaseCommand.ExecuteAsync"
+                 OnClick="@(() => ViewModel.ResetDatabaseCommand.ExecuteAsync(null))"
                  Disabled="ViewModel.IsBusy">
         Reset database
       </MudButton>

--- a/src/FantasyFootball.UI/Pages/Settings.razor
+++ b/src/FantasyFootball.UI/Pages/Settings.razor
@@ -1,0 +1,63 @@
+@page "/settings"
+@using System.Globalization
+@using FantasyFootball.UI.ViewModels
+@inject SettingsViewModel ViewModel
+@implements IDisposable
+
+<PageTitle>Settings — Fantasy Football</PageTitle>
+
+<MudText Typo="Typo.h3" HtmlTag="h1" GutterBottom="true">Settings</MudText>
+
+<MudPaper Class="pa-4" Elevation="1">
+  <MudStack Spacing="4">
+    <MudSelect T="CultureInfo"
+               Label="Language"
+               Value="ViewModel.SelectedLanguage"
+               ValueChanged="@(c => ViewModel.SelectedLanguage = c)"
+               ToStringFunc="@(c => c?.DisplayName ?? "")">
+      @foreach (var c in ViewModel.SupportedLanguages)
+      {
+        <MudSelectItem Value="@c">@c.DisplayName</MudSelectItem>
+      }
+    </MudSelect>
+
+    <div>
+      <MudText Typo="Typo.body2" Class="mb-2">
+        Simulation speed: <strong>@ViewModel.SimulationSpeedMs.ToString("F0") ms</strong> per game
+      </MudText>
+      <MudSlider T="double"
+                 Min="0" Max="500" Step="10"
+                 Value="ViewModel.SimulationSpeedMs"
+                 ValueChanged="@(v => ViewModel.SimulationSpeedMs = v)"
+                 Color="Color.Primary" />
+    </div>
+
+    <MudDivider />
+
+    <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="3">
+      <MudButton Variant="Variant.Outlined"
+                 Color="Color.Error"
+                 OnClick="ViewModel.ResetDatabaseCommand.ExecuteAsync"
+                 Disabled="ViewModel.IsBusy">
+        Reset database
+      </MudButton>
+      @if (ViewModel.IsBusy)
+      {
+        <MudProgressCircular Size="Size.Small" Indeterminate="true" />
+        <MudText Typo="Typo.body2">Resetting…</MudText>
+      }
+    </MudStack>
+
+    <MudDivider />
+
+    <MudText Typo="Typo.caption">App version: @ViewModel.AppVersion</MudText>
+  </MudStack>
+</MudPaper>
+
+@code {
+  protected override void OnInitialized() => ViewModel.PropertyChanged += OnViewModelChanged;
+
+  void OnViewModelChanged(object? sender, EventArgs e) => InvokeAsync(StateHasChanged);
+
+  public void Dispose() => ViewModel.PropertyChanged -= OnViewModelChanged;
+}

--- a/src/FantasyFootball.UI/ViewModels/SettingsViewModel.cs
+++ b/src/FantasyFootball.UI/ViewModels/SettingsViewModel.cs
@@ -23,14 +23,9 @@ public partial class SettingsViewModel : ObservableObject
     _settings = settings;
     _dataService = dataService;
 
-    SupportedLanguages = [new("en"), new("de")];
-    // Clamp to a supported language: the stored value may be the browser locale on first run
-    // (e.g. "fr"), which is valid but not in our two-language dropdown. Without this fallback
-    // MudSelect renders blank because the selected CultureInfo isn't among the options.
-    var stored = settings.LastUsedLanguage;
-    SelectedLanguage = SupportedLanguages.FirstOrDefault(c => c.TwoLetterISOLanguageName == stored.TwoLetterISOLanguageName)
-      ?? SupportedLanguages[0];
+    SelectedLanguage = settings.LastUsedLanguage;
     SimulationSpeedMs = settings.SimulationSpeed.TotalMilliseconds;
+    SupportedLanguages = [new("en"), new("de")];
   }
 
   public IList<CultureInfo> SupportedLanguages { get; }

--- a/src/FantasyFootball.UI/ViewModels/SettingsViewModel.cs
+++ b/src/FantasyFootball.UI/ViewModels/SettingsViewModel.cs
@@ -60,7 +60,7 @@ public partial class SettingsViewModel : ObservableObject
     IsBusy = true;
     try
     {
-      await Task.Run(_dataService.Reset);
+      await Task.Run(_dataService.Reset).ConfigureAwait(false);
     }
     finally
     {

--- a/src/FantasyFootball.UI/ViewModels/SettingsViewModel.cs
+++ b/src/FantasyFootball.UI/ViewModels/SettingsViewModel.cs
@@ -39,7 +39,9 @@ public partial class SettingsViewModel : ObservableObject
   [ObservableProperty]
   public partial bool IsBusy { get; set; }
 
-  public string AppVersion => Assembly.GetExecutingAssembly().GetName().Version?.ToString() ?? "dev";
+  // GetEntryAssembly returns the host (FantasyFootball.Web or FantasyFootball.Maui),
+  // not this Razor library — so the displayed version reflects the running app.
+  public string AppVersion => Assembly.GetEntryAssembly()?.GetName().Version?.ToString() ?? "dev";
 
   partial void OnSelectedLanguageChanged(CultureInfo value)
   {

--- a/src/FantasyFootball.UI/ViewModels/SettingsViewModel.cs
+++ b/src/FantasyFootball.UI/ViewModels/SettingsViewModel.cs
@@ -1,0 +1,68 @@
+using System.Reflection;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using FantasyFootball.Services;
+
+namespace FantasyFootball.UI.ViewModels;
+
+/// <summary>
+/// Settings page view-model. Lives in the shared UI library so the same instance
+/// works in both Blazor WASM and the future MAUI BlazorWebView host.
+///
+/// Uses constructor DI (no service-locator). The MAUI XAML version of this VM
+/// still exists in the FantasyFootball.Maui project and continues to back the
+/// XAML SettingsPage until the BlazorWebView host (Phase 5) takes over.
+/// </summary>
+public partial class SettingsViewModel : ObservableObject
+{
+  readonly ISettingsService _settings;
+  readonly IDataService _dataService;
+
+  public SettingsViewModel(ISettingsService settings, IDataService dataService)
+  {
+    _settings = settings;
+    _dataService = dataService;
+
+    SelectedLanguage = settings.LastUsedLanguage;
+    SimulationSpeedMs = settings.SimulationSpeed.TotalMilliseconds;
+    SupportedLanguages = [new("en"), new("de")];
+  }
+
+  public IList<CultureInfo> SupportedLanguages { get; }
+
+  [ObservableProperty]
+  public partial CultureInfo SelectedLanguage { get; set; }
+
+  [ObservableProperty]
+  public partial double SimulationSpeedMs { get; set; }
+
+  [ObservableProperty]
+  public partial bool IsBusy { get; set; }
+
+  public string AppVersion => Assembly.GetExecutingAssembly().GetName().Version?.ToString() ?? "dev";
+
+  partial void OnSelectedLanguageChanged(CultureInfo value)
+  {
+    _settings.LastUsedLanguage = value;
+    // TODO: applying the culture to running localized strings in Blazor WASM requires
+    // a separate i18n strategy (e.g., IStringLocalizer + StateHasChanged broadcasting).
+    // Tracked as a follow-up; for now the choice persists but only takes effect on reload.
+  }
+
+  partial void OnSimulationSpeedMsChanged(double value)
+    => _settings.SimulationSpeed = TimeSpan.FromMilliseconds(value);
+
+  [RelayCommand]
+  async Task ResetDatabase()
+  {
+    IsBusy = true;
+    try
+    {
+      await Task.Run(_dataService.Reset);
+    }
+    finally
+    {
+      IsBusy = false;
+    }
+  }
+}

--- a/src/FantasyFootball.UI/ViewModels/SettingsViewModel.cs
+++ b/src/FantasyFootball.UI/ViewModels/SettingsViewModel.cs
@@ -23,9 +23,14 @@ public partial class SettingsViewModel : ObservableObject
     _settings = settings;
     _dataService = dataService;
 
-    SelectedLanguage = settings.LastUsedLanguage;
-    SimulationSpeedMs = settings.SimulationSpeed.TotalMilliseconds;
     SupportedLanguages = [new("en"), new("de")];
+    // Clamp to a supported language: the stored value may be the browser locale on first run
+    // (e.g. "fr"), which is valid but not in our two-language dropdown. Without this fallback
+    // MudSelect renders blank because the selected CultureInfo isn't among the options.
+    var stored = settings.LastUsedLanguage;
+    SelectedLanguage = SupportedLanguages.FirstOrDefault(c => c.TwoLetterISOLanguageName == stored.TwoLetterISOLanguageName)
+      ?? SupportedLanguages[0];
+    SimulationSpeedMs = settings.SimulationSpeed.TotalMilliseconds;
   }
 
   public IList<CultureInfo> SupportedLanguages { get; }

--- a/src/FantasyFootball.Web/GlobalUsings.cs
+++ b/src/FantasyFootball.Web/GlobalUsings.cs
@@ -1,0 +1,2 @@
+// Contains global usings imported into all files in the project
+global using System.Globalization;

--- a/src/FantasyFootball.Web/Program.cs
+++ b/src/FantasyFootball.Web/Program.cs
@@ -1,6 +1,8 @@
 using Blazored.LocalStorage;
 using FantasyFootball.Repositories;
+using FantasyFootball.Services;
 using FantasyFootball.UI;
+using FantasyFootball.UI.ViewModels;
 using FantasyFootball.Web.Services;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
@@ -14,5 +16,8 @@ builder.RootComponents.Add<HeadOutlet>("head::after");
 builder.Services.AddMudServices();
 builder.Services.AddBlazoredLocalStorage();
 builder.Services.AddScoped<IRepository, LocalStorageRepository>();
+builder.Services.AddScoped<ISettingsService, LocalStorageSettingsService>();
+builder.Services.AddScoped<IDataService, CsvDataService>();
+builder.Services.AddScoped<SettingsViewModel>();
 
 await builder.Build().RunAsync();

--- a/src/FantasyFootball.Web/Services/LocalStorageSettingsService.cs
+++ b/src/FantasyFootball.Web/Services/LocalStorageSettingsService.cs
@@ -1,0 +1,55 @@
+using Blazored.LocalStorage;
+using FantasyFootball.Services;
+
+namespace FantasyFootball.Web.Services;
+
+/// <summary>
+/// Browser LocalStorage-backed ISettingsService. Mirrors the key names used by
+/// the MAUI <see cref="SettingsService"/> so a user migrating between hosts (or
+/// the future MAUI BlazorWebView host sharing the same component tree) sees the
+/// same preferences.
+/// </summary>
+public sealed class LocalStorageSettingsService : ISettingsService
+{
+  const string LanguageKey = "id_language";
+  const string SimSpeedKey = "id_simspeed";
+  const string LastCompetitionKey = "id_token";
+
+  readonly ISyncLocalStorageService _localStorage;
+
+  public LocalStorageSettingsService(ISyncLocalStorageService localStorage)
+  {
+    _localStorage = localStorage;
+  }
+
+  public string LastUsedCompetition
+  {
+    get => GetValueOrDefault(LastCompetitionKey, "");
+    set => AddOrUpdateValue(LastCompetitionKey, value);
+  }
+
+  public TimeSpan SimulationSpeed
+  {
+    get => TimeSpan.FromMilliseconds(GetValueOrDefault(SimSpeedKey, 100d));
+    set => AddOrUpdateValue(SimSpeedKey, value.TotalMilliseconds);
+  }
+
+  public CultureInfo LastUsedLanguage
+  {
+    get => CultureInfo.GetCultureInfo(GetValueOrDefault(LanguageKey, CultureInfo.CurrentUICulture.TwoLetterISOLanguageName));
+    set => AddOrUpdateValue(LanguageKey, value?.TwoLetterISOLanguageName ?? "en");
+  }
+
+  public bool GetValueOrDefault(string key, bool defaultValue)
+    => _localStorage.ContainKey(key) ? _localStorage.GetItem<bool>(key) : defaultValue;
+
+  public string GetValueOrDefault(string key, string defaultValue)
+    => _localStorage.ContainKey(key) ? _localStorage.GetItem<string>(key) ?? defaultValue : defaultValue;
+
+  public double GetValueOrDefault(string key, double defaultValue)
+    => _localStorage.ContainKey(key) ? _localStorage.GetItem<double>(key) : defaultValue;
+
+  public void AddOrUpdateValue(string key, bool value) => _localStorage.SetItem(key, value);
+  public void AddOrUpdateValue(string key, string value) => _localStorage.SetItem(key, value);
+  public void AddOrUpdateValue(string key, double value) => _localStorage.SetItem(key, value);
+}

--- a/src/FantasyFootball.Web/Services/LocalStorageSettingsService.cs
+++ b/src/FantasyFootball.Web/Services/LocalStorageSettingsService.cs
@@ -36,7 +36,7 @@ public sealed class LocalStorageSettingsService : ISettingsService
 
   public CultureInfo LastUsedLanguage
   {
-    get => CultureInfo.GetCultureInfo(GetValueOrDefault(LanguageKey, CultureInfo.CurrentUICulture.TwoLetterISOLanguageName));
+    get => CultureInfo.GetCultureInfo(GetValueOrDefault(LanguageKey, "en"));
     set => AddOrUpdateValue(LanguageKey, value?.TwoLetterISOLanguageName ?? "en");
   }
 


### PR DESCRIPTION
## Summary
First page of the Phase 3 port (#7). Settings is the simplest of the eight XAML pages — well-bounded, exercises the LocalStorage repo end-to-end with non-trivial models when **Reset database** kicks off `CsvDataService.Reset()` (which loads ~200 teams + their countries + confederations through the JSON serializer for the first time with real data).

## Two commits (preserve at merge)

1. **Add Settings page** (`8c3787f`-ish) — `SettingsViewModel` (UI lib), `Settings.razor`, `LocalStorageSettingsService` (Web), DI wiring, nav link, `GlobalUsings.cs` in both UI lib and Web project so the `CommunityToolkit.Mvvm` source generator can resolve `CultureInfo`.
2. **Remove temporary Storage diagnostic from Home** (`18e653d`) — cleanup promised in #16. Replaces it with a proper welcome blurb.

**Use `--merge` (not `--squash`) at merge time** so the two commits stay separate on `develop`, per project convention for meaningful multi-commit PRs.

## Design notes

- **`SettingsViewModel` lives in `FantasyFootball.UI`** (the shared Razor lib), constructor-DI'd. The XAML version in `FantasyFootball.Maui` stays put until Phase 5 retires the XAML pages — for now both hosts have their own VM; they'll converge when MAUI BlazorWebView (#9) takes over.
- **Language switching is cosmetic-only**. The selection persists, but doesn't actually re-load resource strings. Blazor WASM i18n needs an `IStringLocalizer` + a broadcast `StateHasChanged` pattern; deferred with a TODO in the VM.
- **`GlobalUsings.cs`** in both projects: `global using System.Globalization;`. The `[ObservableProperty]` source generator emits code that doesn't see file-level usings, so `CultureInfo` must be globally available for `SettingsViewModel.g.cs` to compile.

## Test plan

- [x] `dotnet build` (Web) — 0 errors, 8 pre-existing SQLite WASM warnings.
- [x] `dotnet run --project src/FantasyFootball.Web` → page loads.
- [x] **Manual round-trip verified**: Home loads with new welcome content (no diagnostic panel); Settings link works; sim speed slider updates "X ms per game" live; F5 → value persists; Reset database button shows busy spinner then re-populates `fantasy-football:Team`/`:Country`/`:Confederation` LocalStorage keys from the embedded CSV (real model round-trip working — this is the first time polymorphism + cycles got exercised, no errors).
- [ ] Language picker — confirmed: persists to LocalStorage but doesn't switch live strings (expected, deferred).

## Out of scope

- xUnit tests for VM/service — will land alongside more pages in subsequent Phase 3 PRs once test patterns settle.
- Live language switching — separate i18n follow-up; tracked as TODO in VM.