### PR TITLE
Auto-review: allow gh api, disallow AskUserQuestion

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -73,5 +73,14 @@ jobs:
             - Test coverage
 
             Use inline comments for specific issues and a summary comment for overall feedback.
+            You are running in CI with no interactive user — never call AskUserQuestion. If a
+            tool you need is not allowed, post a summary comment via `gh pr comment` explaining
+            what's blocked, then stop.
+          # gh api is allowed because the agent occasionally needs it to post review-level
+          # summary comments (the create_inline_comment MCP tool only handles inline). Without
+          # this the agent falls back to AskUserQuestion asking permission to call gh api,
+          # which terminates silently in CI. Disallowing AskUserQuestion explicitly is the
+          # belt-and-suspenders fix.
           claude_args: |
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api:*)"
+            --disallowedTools "AskUserQuestion"


### PR DESCRIPTION
## Summary
The auto-review on PR #17 ran a successful workflow but posted zero comments. Diagnosed in the CI log: the agent decided it needed `gh api` to post the review-level summary (the `create_inline_comment` MCP tool only handles inline comments), `gh api` wasn't in `--allowedTools`, so it called `AskUserQuestion` to ask permission. No interactive user in CI → silent termination → green workflow with no output. Same pattern affects MtgCsvHelper (PR #79 also has zero auto-review comments).

Two-pronged fix:

1. **Add `Bash(gh api:*)` to `--allowedTools`** — gives the agent the access it tried to ask for.
2. **Add `--disallowedTools "AskUserQuestion"`** plus a prompt directive — the agent literally cannot fall back to asking, even if a new edge case appears later. If a tool is blocked, it must post a summary explaining and stop.

## Why this PR's own auto-review will fail (expected)

The `anthropics/claude-code-action` validates that the workflow file in the PR matches the version on the default branch. Since this PR *is* the workflow change, that validation fails with a 401 ("workflow file must exist and have identical content to the version on the repository's default branch"). Same self-fix problem we hit on PR #11. The action's docs say to ignore this error on first-time workflow edits. Merge despite.

## After merge

Will propose the same patch on `StepKie/MtgCsvHelper` to fix that repo's auto-review too.

## Test plan

- [ ] PR auto-review fails on the workflow-validation check (expected).
- [ ] Merge to `develop`.
- [ ] Trigger a new PR (e.g. re-run #17's auto-review) — verify comments actually get posted this time.