### PR TITLE
Blazor port — Phase 3 (Teams): list + filter

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+  </packageSources>
+</configuration>

--- a/src/FantasyFootball.UI/Layout/NavMenu.razor
+++ b/src/FantasyFootball.UI/Layout/NavMenu.razor
@@ -1,4 +1,5 @@
 <MudNavMenu>
   <MudNavLink Href="" Match="NavLinkMatch.All" Icon="@Icons.Material.Filled.Home">Home</MudNavLink>
+  <MudNavLink Href="teams" Icon="@Icons.Material.Filled.Groups">Teams</MudNavLink>
   <MudNavLink Href="settings" Icon="@Icons.Material.Filled.Settings">Settings</MudNavLink>
 </MudNavMenu>

--- a/src/FantasyFootball.UI/Pages/Teams.razor
+++ b/src/FantasyFootball.UI/Pages/Teams.razor
@@ -1,0 +1,76 @@
+@page "/teams"
+@using FantasyFootball.UI.ViewModels
+@inject TeamsViewModel ViewModel
+@inject NavigationManager Nav
+@implements IDisposable
+
+<PageTitle>Teams — Fantasy Football</PageTitle>
+
+<MudStack Spacing="3">
+  <MudText Typo="Typo.h3" HtmlTag="h1">Teams</MudText>
+
+  <MudSelect T="string"
+             Label="Confederation"
+             Value="ViewModel.SelectedConfederation"
+             ValueChanged="@(v => ViewModel.SelectedConfederation = v)"
+             FullWidth="true">
+    @foreach (var c in ViewModel.Confederations)
+    {
+      <MudSelectItem Value="@c">@c</MudSelectItem>
+    }
+  </MudSelect>
+
+  <MudTable Items="ViewModel.TeamsInSelectedConfederation"
+            T="TeamListItem"
+            Loading="ViewModel.IsBusy"
+            Hover="true"
+            Dense="true"
+            Breakpoint="Breakpoint.None"
+            OnRowClick="OnRowClick">
+    @* Virtualize="true" was tried but collapses the empty-header flag column under
+       MudTable's virtualized layout. Pre-warming IDataService already takes most
+       of the perceived wait off this page; 200 rows render fine in one go. Revisit
+       via MudDataGrid if a much larger list lands later. *@
+    <HeaderContent>
+      <MudTh Style="width: 3rem;">#</MudTh>
+      <MudTh Style="width: 2.5rem;"></MudTh>
+      <MudTh>Team</MudTh>
+      <MudTh Style="width: 4rem; text-align: right;">Elo</MudTh>
+    </HeaderContent>
+    <RowTemplate>
+      <MudTd>@context.Rank</MudTd>
+      <MudTd>
+        @if (!string.IsNullOrEmpty(context.Team.Country?.Code2))
+        {
+          <img src="@FlagUrl(context.Team.Country.Code2)"
+               alt="@context.Team.Country.Name"
+               style="width: 1.75rem; height: auto; vertical-align: middle;" />
+        }
+      </MudTd>
+      <MudTd>@context.Team.Name</MudTd>
+      <MudTd Style="text-align: right;">@context.Team.Elo</MudTd>
+    </RowTemplate>
+  </MudTable>
+
+  @* +new-team: deliberately omitted — MAUI version is [Obsolete] and shows
+     "under construction". Lands as a MudDialog when the feature is built. *@
+</MudStack>
+
+@code {
+  protected override void OnInitialized() => ViewModel.PropertyChanged += OnViewModelChanged;
+
+  void OnViewModelChanged(object? sender, EventArgs e) => InvokeAsync(StateHasChanged);
+
+  // Flags via flagcdn.com keyed off ISO 3166-1 alpha-2 (Country.Code2). SVG so the
+  // same asset stays crisp from list rows to TeamDetail headers. Avoids shipping
+  // ~250 images in the WASM payload; URL pattern hinted at in IconStrings.
+  static string FlagUrl(string code2) => $"https://flagcdn.com/{code2.ToLower()}.svg";
+
+  void OnRowClick(TableRowClickEventArgs<TeamListItem> args)
+  {
+    // /teams/{id} lands with the TeamDetail page port (#7). 404 expected for now.
+    Nav.NavigateTo($"/teams/{args.Item!.Team.Id}");
+  }
+
+  public void Dispose() => ViewModel.PropertyChanged -= OnViewModelChanged;
+}

--- a/src/FantasyFootball.UI/ViewModels/TeamsViewModel.cs
+++ b/src/FantasyFootball.UI/ViewModels/TeamsViewModel.cs
@@ -1,9 +1,7 @@
 using System.Collections.ObjectModel;
 using CommunityToolkit.Mvvm.ComponentModel;
-using CommunityToolkit.Mvvm.Input;
 using CommunityToolkit.Mvvm.Messaging;
 using FantasyFootball.Models;
-using FantasyFootball.Repositories;
 using FantasyFootball.Services;
 using static FantasyFootball.Messaging;
 
@@ -26,7 +24,7 @@ public partial class TeamsViewModel : ObservableObject
 
   List<TeamListItem> _allTeams = [];
 
-  public TeamsViewModel(IDataService dataService, IRepository repo)
+  public TeamsViewModel(IDataService dataService)
   {
     _dataService = dataService;
 
@@ -53,7 +51,6 @@ public partial class TeamsViewModel : ObservableObject
   [ObservableProperty]
   public partial bool IsBusy { get; set; }
 
-  [RelayCommand]
   void LoadTeams()
   {
     IsBusy = true;

--- a/src/FantasyFootball.UI/ViewModels/TeamsViewModel.cs
+++ b/src/FantasyFootball.UI/ViewModels/TeamsViewModel.cs
@@ -1,0 +1,91 @@
+using System.Collections.ObjectModel;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using CommunityToolkit.Mvvm.Messaging;
+using FantasyFootball.Models;
+using FantasyFootball.Repositories;
+using FantasyFootball.Services;
+using static FantasyFootball.Messaging;
+
+namespace FantasyFootball.UI.ViewModels;
+
+/// <summary>
+/// Teams page view-model. Lives in the shared UI library so the same instance
+/// works in both Blazor WASM and the future MAUI BlazorWebView host.
+///
+/// Differences from the MAUI VM (FantasyFootball.ViewModels.TeamsViewModel):
+/// - No Shell navigation; the .razor page handles row-click navigation via NavigationManager.
+/// - No SelectionMode / QueryProperty plumbing; that flow was MAUI-Shell specific and will
+///   be replaced by a dialog/route on the web side as the CompetitionSetup port lands.
+/// - +new-team is deliberately omitted: the MAUI version is [Obsolete] and shows an
+///   "under construction" dialog. Will land as a MudDialog when the feature is built.
+/// </summary>
+public partial class TeamsViewModel : ObservableObject
+{
+  readonly IDataService _dataService;
+
+  List<TeamListItem> _allTeams = [];
+
+  public TeamsViewModel(IDataService dataService, IRepository repo)
+  {
+    _dataService = dataService;
+
+    MessageBus.Register<TeamUpdatedMessage>(this, (_, _) => LoadTeams());
+
+    Confederations = Confederation.ALL.Select(c => c.Name).Prepend(AllLabel).ToList();
+    SelectedConfederation = AllLabel;
+    LoadTeams();
+  }
+
+  // "All" sentinel used to show every confederation. AppResources.All exists but the
+  // resource manager isn't reliably initialized in Blazor WASM without extra wiring;
+  // a fixed English string is fine here until the i18n follow-up lands.
+  public const string AllLabel = "All";
+
+  public IList<string> Confederations { get; }
+
+  [ObservableProperty]
+  public partial string SelectedConfederation { get; set; }
+
+  [ObservableProperty]
+  public partial ObservableCollection<TeamListItem> TeamsInSelectedConfederation { get; set; } = [];
+
+  [ObservableProperty]
+  public partial bool IsBusy { get; set; }
+
+  [RelayCommand]
+  void LoadTeams()
+  {
+    IsBusy = true;
+    try
+    {
+      _allTeams = _dataService.AllTeams
+        .OrderByDescending(t => t.Elo)
+        .Select((t, i) => new TeamListItem(i + 1, t))
+        .ToList();
+      UpdateFilteredTeams();
+    }
+    finally
+    {
+      IsBusy = false;
+    }
+  }
+
+  partial void OnSelectedConfederationChanged(string value) => UpdateFilteredTeams();
+
+  void UpdateFilteredTeams()
+  {
+    var filtered = _allTeams.Where(item =>
+      SelectedConfederation == AllLabel ||
+      item.Team.Country.Confederation.Name == SelectedConfederation);
+
+    TeamsInSelectedConfederation = new ObservableCollection<TeamListItem>(filtered);
+  }
+}
+
+/// <summary>
+/// Lightweight projection for the Teams list. Rank is computed once at load time
+/// from the global Elo ordering; the full TeamViewModel (with editing/save logic)
+/// will land with the TeamDetail page port.
+/// </summary>
+public record TeamListItem(int Rank, Team Team);

--- a/src/FantasyFootball.Web/Program.cs
+++ b/src/FantasyFootball.Web/Program.cs
@@ -19,5 +19,13 @@ builder.Services.AddScoped<IRepository, LocalStorageRepository>();
 builder.Services.AddScoped<ISettingsService, LocalStorageSettingsService>();
 builder.Services.AddScoped<IDataService, CsvDataService>();
 builder.Services.AddScoped<SettingsViewModel>();
+builder.Services.AddScoped<TeamsViewModel>();
 
-await builder.Build().RunAsync();
+var app = builder.Build();
+
+// Pre-warm IDataService so the embedded-CSV parse / LocalStorage polymorphic
+// deserialize (~200 teams + countries + confederations) runs during the WASM
+// boot splash rather than stalling the first navigation to Teams / Competitions.
+_ = app.Services.GetRequiredService<IDataService>();
+
+await app.RunAsync();

--- a/src/FantasyFootball.Web/Services/IgnoreAttributeTypeInfoResolver.cs
+++ b/src/FantasyFootball.Web/Services/IgnoreAttributeTypeInfoResolver.cs
@@ -1,16 +1,33 @@
 using System.Text.Json;
 using System.Text.Json.Serialization.Metadata;
 using SQLite;
+using SQLiteNetExtensions.Attributes;
 
 namespace FantasyFootball.Web.Services;
 
 /// <summary>
-/// JSON type-info resolver that excludes properties marked with sqlite-net-pcl's
-/// <see cref="IgnoreAttribute"/>. The core models use [Ignore] to mark computed /
-/// derived properties (Winner, IsFinished, GamesByDate, etc.) that shouldn't be
-/// persisted. The default System.Text.Json resolver doesn't know about [Ignore]
-/// and would serialize them — both bloating the payload and re-walking the graph
-/// in ways that surface cycles.
+/// JSON type-info resolver that strips properties we don't want persisted to LocalStorage.
+///
+/// SQLite-Net-Extensions' relationship attributes (<c>[ManyToOne]</c>, <c>[OneToOne]</c>,
+/// <c>[OneToMany]</c>, <c>[ManyToMany]</c>) all derive from <c>RelationshipAttribute</c>
+/// which derives from sqlite-net's <see cref="IgnoreAttribute"/> — so a naive
+/// "filter by IgnoreAttribute inheritance" sweep also wipes navigation properties out
+/// of the JSON. For our model that means <c>Team.Country</c> and <c>Country.Confederation</c>
+/// get dropped, leaving deserialized Teams with <c>Country = null</c> (and no flags to
+/// render off Code2).
+///
+/// What we actually want filtered:
+///   - Exact-type <see cref="IgnoreAttribute"/>: computed / derived properties like
+///     <c>Game.Winner</c>, <c>Competition.GamesByDate</c>, <c>Team.IsNationalTeam</c>.
+///   - <see cref="OneToManyAttribute"/> / <see cref="ManyToManyAttribute"/>: back-pointer
+///     collections (<c>Confederation.Countries</c>, <c>Country.Clubs</c>) that would
+///     explode the persisted graph if walked.
+///
+/// What stays:
+///   - <see cref="ManyToOneAttribute"/> / <see cref="OneToOneAttribute"/>: single forward
+///     navigation refs. STJ's <c>ReferenceHandler.Preserve</c> resolves the small cycles
+///     these create (Team → Country → Team via NationalTeam) via $id / $ref.
+///   - <see cref="ForeignKeyAttribute"/>: it's just an <c>int</c>, no inheritance from Ignore.
 /// </summary>
 public sealed class IgnoreAttributeTypeInfoResolver : DefaultJsonTypeInfoResolver
 {
@@ -19,7 +36,15 @@ public sealed class IgnoreAttributeTypeInfoResolver : DefaultJsonTypeInfoResolve
         var info = base.GetTypeInfo(type, options);
         foreach (var property in info.Properties)
         {
-            if (property.AttributeProvider?.GetCustomAttributes(typeof(IgnoreAttribute), inherit: true).Length > 0)
+            var attrs = property.AttributeProvider?.GetCustomAttributes(typeof(IgnoreAttribute), inherit: true);
+            if (attrs is null || attrs.Length == 0) { continue; }
+
+            var shouldFilter = attrs.Any(a =>
+                a.GetType() == typeof(IgnoreAttribute) ||
+                a is OneToManyAttribute ||
+                a is ManyToManyAttribute);
+
+            if (shouldFilter)
             {
                 property.ShouldSerialize = static (_, _) => false;
             }


### PR DESCRIPTION
Closes the Teams checkbox in #7. Second page of the Phase 3 port (Settings landed in #17).

## Summary

- **Teams page** at `/teams`: confederation filter + ranked list (#/flag/team/Elo). Row click navigates to `/teams/{id}` — TeamDetail page lands in a follow-up PR (404 expected for now).
- **Twin VM** in `FantasyFootball.UI.ViewModels` per the established pattern; MAUI's `FantasyFootball.ViewModels.TeamsViewModel` stays put until Phase 5 retires the XAML pages.
- **`+ new team` deliberately omitted** — MAUI version is `[Obsolete]` and shows under-construction. Lands as a `MudDialog` when the feature is actually built.
- **Flags via `flagcdn.com` SVG** keyed off `Country.Code2` — avoids shipping ~250 PNGs in the WASM payload, stays crisp at any size.

## Bug fix: navigation refs were being stripped from LocalStorage JSON

While wiring up Teams I found that `Team.Country` had never been persisted. Root cause: `IgnoreAttributeTypeInfoResolver` filtered every property whose attribute inherits from sqlite-net's `IgnoreAttribute`, sweeping up SQLite-Net-Extensions' `[ManyToOne]` / `[OneToOne]` / `[OneToMany]` / `[ManyToMany]` along with it — they all derive from `RelationshipAttribute : IgnoreAttribute`. Result: every deserialized Team had `Country = null`.

Tightened the resolver to filter only:
- exact-type `[Ignore]` (computed / derived properties — `Game.Winner`, `Competition.GamesByDate`, etc.)
- `[OneToMany]` / `[ManyToMany]` back-pointer collections (would explode the persisted graph)

Forward refs (`[ManyToOne]` / `[OneToOne]`) now serialize properly; STJ's `ReferenceHandler.Preserve` resolves the small cycles via `$id`/`$ref`. Latent bug — Settings PR didn't hit it because settings doesn't read `Country.Code2`.

**Existing LocalStorage needs a Reset Database to repopulate with the new JSON shape.**

## Perf: pre-warm IDataService

First navigation to Teams was 10-15s in dev (interpreter) — polymorphic JSON deserialize of ~200 teams + countries + confederations from LocalStorage stalled mid-route. Eagerly resolving `IDataService` in `Program.cs` after `builder.Build()` pushes that work into the WASM boot splash, where there's already visual feedback. First Teams click now feels near-instant.

## Repo-local NuGet.config

Clears inherited package sources and re-adds only `nuget.org`. Stops the NU1801 spam from a per-user local-Nuget feed that lives on a different machine. Build-environment hygiene; no functional change.

## Test plan

- [x] `dotnet build` — 0 errors
- [x] `dotnet run --project src/FantasyFootball.Web` → `/teams` loads
- [x] **Manual round-trip**: hard-refresh, confederation picker filters in real time, rows render with rank/flag/name/Elo, Argentina #1 at 1858 (sensible Elo ordering), row click navigates to `/teams/{id}` (404 expected — TeamDetail is the next PR)
- [x] LocalStorage written by the fixed resolver includes nested `Country` (with `Code2`) — verified via DevTools → Application → LocalStorage
- [x] Pre-warm verified: first Teams nav after a hard refresh no longer stalls

## Out of scope

- TeamDetail page (`/teams/{id}` profile view) — next PR
- `+ new team` dialog — deferred behind the model-edit story
- Live i18n for language switching — still deferred from Settings PR