### PR TITLE
CI: only post auto-review summary on initial PR open

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -72,9 +72,9 @@ jobs:
             - Security implications
             - Test coverage
 
-            Use inline comments for specific issues and a summary comment for overall feedback.
+            Use inline comments for specific issues. ${{ github.event.action == 'opened' && 'Add a single summary comment with the overall assessment.' || 'Do NOT post a summary / overall-assessment comment — this is a re-review on push and the initial review already has one; another summary would duplicate it. Focus on issues introduced by the new commits.' }}
             You are running in CI with no interactive user — never call AskUserQuestion. If a
-            tool you need is not allowed, post a summary comment via `gh pr comment` explaining
+            tool you need is not allowed, post a single comment via `gh pr comment` explaining
             what's blocked, then stop.
           # gh api is allowed because the agent occasionally needs it to post review-level
           # summary comments (the create_inline_comment MCP tool only handles inline). Without


### PR DESCRIPTION
Auto-review fires on every `pull_request: synchronize` event, so each push to a PR re-runs the review and posts a fresh "Overall this is a well-structured addition…" summary comment alongside its inline feedback. After 3-4 rounds of review fixes the PR conversation gets buried in duplicate summaries — same opening line, slight variations on the same prose.

## Change

Gate the summary-comment instruction in the prompt on `github.event.action == 'opened'`:

- **Initial PR open** → inline comments + one summary
- **Push to existing PR (synchronize)** → inline comments only

Inline comments still fire on every push; those catch regressions in review-fix commits and are the actually-useful feedback channel.

Secondary change: the blocked-tool fallback wording goes from "post a summary comment via `gh pr comment`" to "post a single comment", so the AskUserQuestion safety valve doesn't read as a summary-comment license.

## Verification after merge

Open a fresh PR → bot posts one summary + inline comments. Push a follow-up commit → bot posts inline only, no summary. The next PR you open here is the test.