### PR TITLE
UI polish PR 2: Identity

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -50,6 +50,17 @@ dotnet workload install maui
 - XAML formatting governed by Settings.XamlStyler
 - Follow .editorconfig rules
 
+## Out of scope
+
+**Accessibility (a11y) is not a priority at this stage.** Do not invest effort
+in alt-text wording, ARIA attributes, role / tabindex / focus-visible /
+keyboard-trap fixes, screen-reader copy, or semantic-HTML refactors aimed at
+assistive tech. Auto-review bots and human reviewers: please **skip** a11y
+suggestions and nits on this repo — they will be declined.
+
+Visible-to-sighted-mouse-user concerns (contrast, layout, hover tooltips that
+also happen to be accessible) remain in scope under their non-a11y framing.
+
 ## Branching & Releases
 
 - **`develop`** is the default branch. Feature branches branch off `develop`

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,9 @@
 [Oo]bj/
 bin/
 
+# Locally-placed official competition logos — owner asserts fair use; not for redistribution via the public repo.
+src/FantasyFootball.Web/wwwroot/competition-icons/official/
+
 
 # temporary and other unwanted files #
 ######################

--- a/docs/ui-polish-plan.md
+++ b/docs/ui-polish-plan.md
@@ -49,6 +49,10 @@ doc captures only the directives we're acting on.
   competition-type picker. Drop the two-line wrapping pill.
 - **Standings column headers**: drop `Team` (obvious), consider dropping
   `#` or merging it into the team cell as a dim leading number.
+- **Delete competitions from the list, not the detail page.** Move the
+  trash icon off `/competitions/{id}` (where it sits next to back-nav and
+  is dangerously easy to mis-click) into a per-row delete on the
+  `/competitions` Active and Finished tables, with a confirmation dialog.
 
 ### Flag rendering
 
@@ -75,6 +79,32 @@ doc captures only the directives we're acting on.
 - Replace the current body-text "Czech Republic 2-1 South Africa" list
   with proper game cards with subtle backgrounds and visible delimiters
   between groups.
+- **Day-grouping dividers.** When the games panel shows games spanning
+  multiple `PlayedOn.Date` values, insert a subtle date label
+  (e.g. `Mon 25 Jun`) above each day's first card. Tiny text, secondary
+  colour, single-pixel divider below — visible structure without
+  competing with the cards.
+- **Single-line scoreboard stays.** Multi-line layouts in apps like
+  OneFootball exist to pack live status / scorer ticker / links to match
+  pages — we don't have that data, so the symmetric single-row scoreboard
+  is the right shape. Confirmed deliberate choice; do not multi-line.
+- **`GameListMode` setting: `OnePerRound` vs `AllOfStage`.** The round
+  picker on `/competitions/{id}` forces Round 1 → Round 2 → Round 3
+  clicking to see everything. Add an alternative mode where the entire
+  current Stage renders in one scrollable list, with day-grouping
+  dividers between matchdays (and group letters where the stage has
+  groups). The round picker stays but switches to "scroll-to-round"
+  behaviour in this mode. Default and persisted via Settings.
+- **Round picker shows date ranges next to round name.** Currently
+  `Sechzehntelfinale` / `Final` — no temporal context. kicker.de:
+  `Achtelfinale (10.03. - 18.03.)`. Annotate each picker entry with the
+  min/max `PlayedOn` of the round so users see when it happens before
+  switching. Same treatment for the stage picker.
+- **Sub-score for extra-time / penalty games.** Currently the Result
+  string crams "5-4 a.e.t." into one line. Separate: main 90-minute
+  score on top, smaller sub-score below (matches the kicker.de pattern
+  — `5:4` then `3:2` under). Cleaner visual hierarchy on KO bracket
+  rows that ran past full time.
 - **Configurable pre-match detail** via a `GameRowDetail` setting:
   - `Minimal` (default, current behaviour) — team names + score only.
   - `Probabilities` — pre-match win % shown subtly greyed inline,
@@ -150,6 +180,12 @@ doc captures only the directives we're acting on.
   otherwise we still pay 72 re-renders for a group stage).
 - Implementation: make `Simulator.GameDelay` mutable, set before each
   sim call; add a `Quiet` flag to suppress per-game messaging.
+- **Unify Settings UI with the detail picker.** Replace the 0–500 ms
+  slider on `/settings` with the same Slow / Normal / Fast / Instant
+  preset picker. Loses arbitrary-ms granularity, gains a single shared
+  vocabulary — settings persists the global default, detail overrides
+  per visit. Avoids the current clash where the slider's value
+  (e.g. 75 ms) doesn't map to any of the four detail buckets.
 
 ### Keyboard navigation
 
@@ -321,21 +357,33 @@ around third-place resolve, corrupt-blob quarantine on load.
 
 ### PR 2 — Identity
 
-- Favicon + wordmark.
-- Primary colour off purple → green accent ≤10% usage.
-- Typography: Barlow Condensed / Oswald for tournament titles + scores;
-  tabular-numerics globally on score / numeric cells.
-- `<FlagIcon>` component with `FlagStyle` setting
-  (`Square` / `Round` / `RoundTier`).
-- Scoreboard-style game cards (symmetric, winner-bolded), with
-  configurable pre-match detail (`GameRowDetail` setting:
-  `Minimal` / `Probabilities` / `EloAndProbabilities`).
-- Group cards with header band / letter badge.
-- Elo number colour tone-down.
+**Status**: in flight on branch `feature/ui-polish-2-identity`.
+
+- [ ] Favicon (asset still to source/design).
+- [x] Wordmark in top app bar (Barlow Condensed bold uppercase + ball glyph).
+- [x] Primary colour off purple → green accent (`#00B86B`).
+- [x] Typography: Inter body + Barlow Condensed display; tabular numerics
+  globally on `:root`.
+- [x] `<FlagIcon>` component (Team / Code / Size / Elo) with `FlagStyle`
+  setting (`Square` / `Round` / `RoundTier`) wired to Settings.
+- [x] Scoreboard-style game cards (symmetric, winner-bolded, loser dimmed,
+  score in Barlow Condensed). Configurable pre-match detail
+  (`GameRowDetail`) deferred to PR 3.
+- [x] Group letter heading (typographic OneFootball-style, no chip, no
+  noun).
+- [x] Elo number tone-down on Teams + TeamDetail.
 
 ### PR 3 — Sim feel
 
 - Speed control (Slow / Normal / Fast / Instant) on competition page.
+- **Unify Settings speed UI with the detail picker** — replace the
+  0–500 ms slider with the same 4-preset picker (decision noted under
+  Functionality § Speed control).
+- **Delete competitions from the list, not the detail page** — move the
+  trash icon off `/competitions/{id}` to per-row delete on `/competitions`
+  with a confirm dialog.
+- **Day-grouping dividers in the games panel** when `PlayedOn.Date`
+  varies (`Mon 25 Jun` subtle separator).
 - Keyboard navigation (full mapping; help overlay; About reference).
 - Undo stack (in-memory, JSON-snapshot-per-action, capped at 50).
 - Just-finished game highlight (game row + standings rows pulse).

--- a/src/FantasyFootball.Core/Services/FlagStyle.cs
+++ b/src/FantasyFootball.Core/Services/FlagStyle.cs
@@ -1,0 +1,16 @@
+namespace FantasyFootball.Services;
+
+/// <summary>
+/// Persisted visual style for flag rendering, picked on Settings.
+/// </summary>
+public enum FlagStyle
+{
+	/// <summary>Rectangular flag, no clip. The default before PR 2 of the polish work.</summary>
+	Square,
+
+	/// <summary>Circular clip via clip-path + object-fit cover, with a subtle inset border.</summary>
+	Round,
+
+	/// <summary>Circular clip plus an Elo-tiered border (gold ≥1700, silver ≥1500, bronze ≥1300, none below).</summary>
+	RoundTier,
+}

--- a/src/FantasyFootball.Core/Services/ISettingsService.cs
+++ b/src/FantasyFootball.Core/Services/ISettingsService.cs
@@ -16,6 +16,8 @@ public interface ISettingsService
 	string LastUsedCompetition { get; set; }
 	TimeSpan SimulationSpeed { get; set; }
 	public CultureInfo LastUsedLanguage { get; set; }
+	FlagStyle FlagStyle { get; set; }
+	bool UseOfficialCompetitionLogos { get; set; }
 
 	bool GetValueOrDefault(string key, bool defaultValue);
 	string GetValueOrDefault(string key, string defaultValue);

--- a/src/FantasyFootball.Maui/Services/SettingsService.cs
+++ b/src/FantasyFootball.Maui/Services/SettingsService.cs
@@ -5,6 +5,8 @@ public class SettingsService : ISettingsService
 	public static readonly string idConfigKey = "id_token";
 	public static readonly string idSimSpeedMs = "id_simspeed";
 	public static readonly string idLanguage = "id_language";
+	public static readonly string idFlagStyle = "id_flagstyle";
+	public static readonly string idUseOfficialLogos = "id_useofficiallogos";
 
 	static readonly string _codeDefaultLanguage = (Resources.AppResources.Culture ?? Thread.CurrentThread.CurrentUICulture).TwoLetterISOLanguageName;
 
@@ -25,6 +27,18 @@ public class SettingsService : ISettingsService
 	{
 		get => CultureInfo.GetCultureInfo(GetValueOrDefault(idLanguage, _codeDefaultLanguage));
 		set => AddOrUpdateValue(idLanguage, value?.TwoLetterISOLanguageName ?? idLanguage);
+	}
+
+	public FlagStyle FlagStyle
+	{
+		get => Enum.TryParse<FlagStyle>(GetValueOrDefault(idFlagStyle, ""), out var s) ? s : FlagStyle.Round;
+		set => AddOrUpdateValue(idFlagStyle, value.ToString());
+	}
+
+	public bool UseOfficialCompetitionLogos
+	{
+		get => GetValueOrDefault(idUseOfficialLogos, false);
+		set => AddOrUpdateValue(idUseOfficialLogos, value);
 	}
 
 	#endregion

--- a/src/FantasyFootball.UI/Components/CompetitionTypeIcon.razor
+++ b/src/FantasyFootball.UI/Components/CompetitionTypeIcon.razor
@@ -1,0 +1,50 @@
+@using FantasyFootball.Data
+@using FantasyFootball.Services
+@inject ISettingsService Settings
+
+@if (FallbackIcon is { Length: > 0 } icon)
+{
+  @if (Settings.UseOfficialCompetitionLogos && OfficialPath is { } src)
+  {
+    @* Both layers render. img sits on top via CSS; if its src 404s, onerror hides it and the MudIcon underneath shows through — no broken-image placeholder. *@
+    <span class="comp-type-icon-stack" style="@StackStyle">
+      <MudIcon Icon="@icon" Style="@($"font-size: {Size}px;")" Color="Color.Inherit" Title="@AltText" />
+      <img src="@src" alt="@AltText" class="comp-type-icon-overlay" onerror="this.style.display='none';" />
+    </span>
+  }
+  else
+  {
+    <MudIcon Icon="@icon" Style="@($"font-size: {Size}px;")" Color="Color.Inherit" Title="@AltText" />
+  }
+}
+
+@code {
+  [Parameter] public CompetitionType Type { get; set; }
+  [Parameter] public int Size { get; set; } = 24;
+
+  // Material Icons used when the "official logos" flag is off OR the official file 404s. Default arm so an unhandled enum value still renders something.
+  string? FallbackIcon => Type switch
+  {
+    CompetitionType.WM => Icons.Material.Filled.EmojiEvents,
+    CompetitionType.EM => Icons.Material.Filled.Stars,
+    _ => Icons.Material.Filled.SportsSoccer,
+  };
+
+  // User drops their own assets under wwwroot/competition-icons/official/ (gitignored).
+  string? OfficialPath => Type switch
+  {
+    CompetitionType.WM => "competition-icons/official/wm.svg",
+    CompetitionType.EM => "competition-icons/official/em.svg",
+    _ => null,
+  };
+
+  // Human-readable alt/title — raw enum names ("WM", "EM") would be spelled out letter-by-letter by screen readers.
+  string AltText => Type switch
+  {
+    CompetitionType.WM => "FIFA World Cup",
+    CompetitionType.EM => "UEFA European Championship",
+    _ => Type.ToString(),
+  };
+
+  string StackStyle => $"width: {Size}px; height: {Size}px;";
+}

--- a/src/FantasyFootball.UI/Components/FlagIcon.razor
+++ b/src/FantasyFootball.UI/Components/FlagIcon.razor
@@ -1,0 +1,58 @@
+@using FantasyFootball.Models
+@using FantasyFootball.Services
+@using FantasyFootball.UI.Helpers
+@inject ISettingsService Settings
+
+@if (Resolved is { } code)
+{
+  <img src="@FlagHelper.Url(code)"
+       alt="@ResolvedAlt"
+       class="@CssClass"
+       style="@InlineStyle"
+       title="@Title" />
+}
+
+@code {
+  /// <summary>Team to render the flag for. Convenience parameter — reads <c>Team.Country.Code2</c> and <c>Team.Elo</c>.</summary>
+  [Parameter] public Team? Team { get; set; }
+
+  /// <summary>ISO 3166-1 alpha-2 code. Used when <see cref="Team"/> isn't passed.</summary>
+  [Parameter] public string? Code { get; set; }
+
+  /// <summary>Elo rating for RoundTier border colour. Used when <see cref="Team"/> isn't passed.</summary>
+  [Parameter] public int? Elo { get; set; }
+
+  /// <summary>Pixel size — 16 (table rows), 24 (match cards, default), 40 (headers).</summary>
+  [Parameter] public int Size { get; set; } = 24;
+
+  /// <summary>Override the alt text. Pass <c>""</c> for decorative use (suppresses screen-reader announcement). Defaults to country / team name, falling back to the ISO code.</summary>
+  [Parameter] public string? Alt { get; set; }
+
+  /// <summary>Optional tooltip.</summary>
+  [Parameter] public string? Title { get; set; }
+
+  string? Resolved => Team?.Country?.Code2 is { Length: > 0 } c ? c : (string.IsNullOrEmpty(Code) ? null : Code);
+
+  // Caller-set Alt wins (including "" for decorative). Otherwise prefer country name → team name → code as last resort.
+  string ResolvedAlt => Alt ?? Team?.Country?.Name ?? Team?.Name ?? Resolved ?? "";
+
+  int? ResolvedElo => Team?.Elo ?? Elo;
+
+  string CssClass => Settings.FlagStyle switch
+  {
+    FlagStyle.Round => "flag-icon flag-round",
+    FlagStyle.RoundTier => $"flag-icon flag-round flag-tier-{Tier(ResolvedElo)}",
+    _ => "flag-icon flag-square",
+  };
+
+  // Plain pixel dimensions only — max-width:100% collapses inside MudTable cells (the table-cell width is fluid, creating a circular constraint that resolves the img to 0 width).
+  string InlineStyle => $"width: {Size}px; height: {Size}px;";
+
+  static string Tier(int? elo) => elo switch
+  {
+    >= 1700 => "gold",
+    >= 1500 => "silver",
+    >= 1300 => "bronze",
+    _ => "none",
+  };
+}

--- a/src/FantasyFootball.UI/Components/GameViewRow.razor
+++ b/src/FantasyFootball.UI/Components/GameViewRow.razor
@@ -1,23 +1,29 @@
 @using FantasyFootball.Models
 
-<div class="d-flex align-center py-1" style="gap: 0.5rem;">
-  @if (Game.HomeTeam.Country?.Code2 is { Length: > 0 } homeCode)
-  {
-    <img src="@FlagHelper.Url(homeCode)" alt="@Game.HomeTeam.Name"
-         style="width: 1.5rem; height: auto;" />
-  }
-  <MudText Typo="Typo.body2" Style="flex: 1;">@Game.HomeTeam.Name</MudText>
-  <MudText Typo="Typo.body2" Style="min-width: 4rem; text-align: center; font-weight: bold;">
-    @Game.Result
-  </MudText>
-  <MudText Typo="Typo.body2" Style="flex: 1; text-align: right;">@Game.AwayTeam.Name</MudText>
-  @if (Game.AwayTeam.Country?.Code2 is { Length: > 0 } awayCode)
-  {
-    <img src="@FlagHelper.Url(awayCode)" alt="@Game.AwayTeam.Name"
-         style="width: 1.5rem; height: auto;" />
-  }
+<div class="scoreboard-row">
+  <div class="scoreboard-team scoreboard-team-home @TeamClass(HomeIsWinner)">
+    <span class="scoreboard-team-name">@Game.HomeTeam.Name</span>
+    <FlagIcon Team="Game.HomeTeam" Size="24" />
+  </div>
+  <div class="scoreboard-score @(HasResult ? "" : "scoreboard-pending")">@Game.Result</div>
+  <div class="scoreboard-team scoreboard-team-away @TeamClass(AwayIsWinner)">
+    <FlagIcon Team="Game.AwayTeam" Size="24" />
+    <span class="scoreboard-team-name">@Game.AwayTeam.Name</span>
+  </div>
 </div>
 
 @code {
   [Parameter] public Game Game { get; set; } = null!;
+
+  bool HasResult => Game.IsFinished;
+  bool IsDraw => HasResult && Game.Winner is null;
+  // Id compare instead of reference: NamedUniqueId overrides Equals but not operator==, and Winner from a deserialized graph could be a different instance.
+  bool HomeIsWinner => HasResult && Game.Winner?.Id == Game.HomeTeam.Id;
+  bool AwayIsWinner => HasResult && Game.Winner?.Id == Game.AwayTeam.Id;
+
+  // Winner: bolded. Loser: dimmed. Draw: both teams render at normal weight. Pre-game (no result): normal weight too.
+  string TeamClass(bool isThisSideWinner) =>
+    isThisSideWinner ? "scoreboard-winner" :
+    HasResult && !IsDraw ? "scoreboard-loser" :
+    "";
 }

--- a/src/FantasyFootball.UI/Components/GroupView.razor
+++ b/src/FantasyFootball.UI/Components/GroupView.razor
@@ -1,6 +1,6 @@
 @using FantasyFootball.Models
 
-<MudText Typo="Typo.subtitle2" Class="mt-2">@Group.Name</MudText>
+<div class="group-letter-heading mt-3 mb-1">@Letter</div>
 <MudTable Items="Group.GetStandings()"
           T="TeamRecord"
           Hover="false"
@@ -18,13 +18,7 @@
   </HeaderContent>
   <RowTemplate>
     <MudTd>@context.Position</MudTd>
-    <MudTd>
-      @if (context.Team.Country?.Code2 is { Length: > 0 } code)
-      {
-        <img src="@FlagHelper.Url(code)" alt="@context.Team.Country.Name"
-             style="width: 1.5rem; height: auto; vertical-align: middle;" />
-      }
-    </MudTd>
+    <MudTd><FlagIcon Team="context.Team" Size="20" /></MudTd>
     <MudTd>@context.Team.Name</MudTd>
     <MudTd Style="text-align: right;">@context.MatchesPlayed</MudTd>
     <MudTd Style="text-align: right;">@context.GoalDifference</MudTd>
@@ -34,4 +28,9 @@
 
 @code {
   [Parameter] public Group Group { get; set; } = null!;
+
+  // Last whitespace-separated token (e.g. "A" from "Gruppe A"). More robust than LastChar to future name changes.
+  string Letter => Group.Name?.Split(' ', StringSplitOptions.RemoveEmptyEntries) is { Length: > 0 } parts
+    ? parts[^1].ToUpperInvariant()
+    : "?";
 }

--- a/src/FantasyFootball.UI/Layout/MainLayout.razor
+++ b/src/FantasyFootball.UI/Layout/MainLayout.razor
@@ -1,6 +1,6 @@
 @inherits LayoutComponentBase
 
-<MudThemeProvider IsDarkMode="_isDarkMode" />
+<MudThemeProvider Theme="_theme" IsDarkMode="_isDarkMode" />
 <MudPopoverProvider />
 <MudDialogProvider />
 <MudSnackbarProvider />
@@ -9,7 +9,13 @@
   <MudAppBar Elevation="1">
     <MudIconButton Icon="@Icons.Material.Filled.Menu" Color="Color.Inherit" Edge="Edge.Start"
                    OnClick="@(() => _drawerOpen = !_drawerOpen)" />
-    <MudText Typo="Typo.h6" Class="ml-2">Fantasy Football</MudText>
+    <span class="brand-wordmark ml-2">
+      <svg class="brand-mark" viewBox="0 0 32 32" width="22" height="22" aria-hidden="true">
+        <circle cx="16" cy="16" r="15" fill="#00B86B" />
+        <polygon points="16,7.5 23.2,12.8 20.5,21.2 11.5,21.2 8.8,12.8" fill="#0F1F17" stroke="#0F1F17" stroke-width="1.5" stroke-linejoin="round" />
+      </svg>
+      FantasyFootball
+    </span>
     <MudSpacer />
     <MudIconButton Icon="@Icons.Material.Filled.HelpOutline"
                    Color="Color.Inherit"
@@ -32,4 +38,46 @@
 @code {
   bool _drawerOpen = true;
   bool _isDarkMode = true;
+
+  // PR 2 identity: off MudBlazor default purple, onto neutrals + competition green. Same accent for both palettes; surfaces invert.
+  static readonly MudTheme _theme = new()
+  {
+    PaletteLight = new PaletteLight
+    {
+      Primary = "#00B86B",
+      Secondary = "#1A1A1A",
+      AppbarBackground = "#FFFFFF",
+      AppbarText = "#1A1A1A",
+      Background = "#FAFAFA",
+      Surface = "#FFFFFF",
+      TextPrimary = "#1A1A1A",
+      TextSecondary = "#6B6B6B",
+      LinesDefault = "#E5E5E5",
+      TableStriped = "rgba(0,0,0,0.04)",
+      DrawerBackground = "#FFFFFF",
+      DrawerText = "#1A1A1A",
+    },
+    PaletteDark = new PaletteDark
+    {
+      Primary = "#00B86B",
+      Secondary = "#E5E5E5",
+      AppbarBackground = "#181818",
+      AppbarText = "#E5E5E5",
+      Background = "#121212",
+      Surface = "#1E1E1E",
+      TextPrimary = "#E5E5E5",
+      TextSecondary = "#9CA3AF",
+      LinesDefault = "#2A2A2A",
+      TableStriped = "rgba(255,255,255,0.04)",
+      DrawerBackground = "#181818",
+      DrawerText = "#E5E5E5",
+    },
+    Typography = new Typography
+    {
+      Default = new DefaultTypography
+      {
+        FontFamily = ["Inter", "system-ui", "-apple-system", "Segoe UI", "Roboto", "sans-serif"],
+      },
+    },
+  };
 }

--- a/src/FantasyFootball.UI/Pages/CompetitionDetail.razor
+++ b/src/FantasyFootball.UI/Pages/CompetitionDetail.razor
@@ -26,6 +26,7 @@ else
 {
   <MudStack Spacing="3">
     <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2" Wrap="Wrap.Wrap">
+      <CompetitionTypeIcon Type="@ViewModel.Competition.Type" Size="36" />
       <MudText Typo="Typo.h5" HtmlTag="h1">
         @ViewModel.Competition.ShortName <span style="opacity: 0.6;">#@ViewModel.Competition.Id</span>
       </MudText>

--- a/src/FantasyFootball.UI/Pages/CompetitionSetup.razor
+++ b/src/FantasyFootball.UI/Pages/CompetitionSetup.razor
@@ -61,12 +61,7 @@
           @foreach (var team in group.Teams)
           {
             <div class="d-flex align-center mb-1" style="gap: 0.5rem;">
-              @if (team.Country?.Code2 is { Length: > 0 } code)
-              {
-                <img src="@FlagHelper.Url(code)"
-                     alt="@team.Country.Name"
-                     style="width: 1.5rem; height: auto;" />
-              }
+              <FlagIcon Team="team" Size="20" />
               <MudText Typo="Typo.body2">@team.Name</MudText>
               <MudSpacer />
               <MudText Typo="Typo.caption" Color="Color.Secondary">@team.Elo</MudText>

--- a/src/FantasyFootball.UI/Pages/Competitions.razor
+++ b/src/FantasyFootball.UI/Pages/Competitions.razor
@@ -53,7 +53,12 @@
         </HeaderContent>
         <RowTemplate>
           <MudTd>@context.Id</MudTd>
-          <MudTd>@context.ShortName</MudTd>
+          <MudTd>
+            <div class="d-flex align-center" style="gap: 0.5rem;">
+              <CompetitionTypeIcon Type="@context.Type" Size="20" />
+              <span>@context.ShortName</span>
+            </div>
+          </MudTd>
           <MudTd>@context.SimulationStart.ToString("g")</MudTd>
           <MudTd>@context.CurrentStatus</MudTd>
         </RowTemplate>
@@ -83,16 +88,14 @@
           </HeaderContent>
           <RowTemplate>
             <MudTd>@context.Id</MudTd>
-            <MudTd>@context.ShortName</MudTd>
-            <MudTd>@context.SimulationStart.ToString("g")</MudTd>
             <MudTd>
-              @if (context.Winner?.Country?.Code2 is { Length: > 0 } code)
-              {
-                <img src="@FlagHelper.Url(code)"
-                     alt="@context.Winner.Country.Name"
-                     style="width: 1.75rem; height: auto; vertical-align: middle;" />
-              }
+              <div class="d-flex align-center" style="gap: 0.5rem;">
+                <CompetitionTypeIcon Type="@context.Type" Size="20" />
+                <span>@context.ShortName</span>
+              </div>
             </MudTd>
+            <MudTd>@context.SimulationStart.ToString("g")</MudTd>
+            <MudTd><FlagIcon Team="context.Winner" Size="24" /></MudTd>
             <MudTd>@context.Winner?.Name</MudTd>
           </RowTemplate>
         </MudTable>
@@ -119,13 +122,7 @@
               </HeaderContent>
               <RowTemplate>
                 <MudTd>@context.Position</MudTd>
-                <MudTd>
-                  @if (context.Team.Country?.Code2 is { Length: > 0 } code)
-                  {
-                    <img src="@FlagHelper.Url(code)" alt="@context.Team.Country.Name"
-                         style="width: 1.5rem; height: auto; vertical-align: middle;" />
-                  }
-                </MudTd>
+                <MudTd><FlagIcon Team="context.Team" Size="20" /></MudTd>
                 <MudTd>@context.Team.Name</MudTd>
                 <MudTd Style="text-align: right;">@context.MatchesPlayed</MudTd>
                 <MudTd Style="text-align: right;">@context.GoalsFor:@context.GoalsAgainst</MudTd>

--- a/src/FantasyFootball.UI/Pages/Settings.razor
+++ b/src/FantasyFootball.UI/Pages/Settings.razor
@@ -1,4 +1,6 @@
 @page "/settings"
+@using FantasyFootball.Data
+@using FantasyFootball.Services
 @using FantasyFootball.UI.ViewModels
 @inject SettingsViewModel ViewModel
 @implements IDisposable
@@ -11,10 +13,10 @@
                Label="Language"
                Value="ViewModel.SelectedLanguage"
                ValueChanged="@(c => ViewModel.SelectedLanguage = c)"
-               ToStringFunc="@(c => c?.DisplayName ?? "")">
+               ToStringFunc="@(c => c?.NativeName ?? "")">
       @foreach (var c in ViewModel.SupportedLanguages)
       {
-        <MudSelectItem Value="@c">@c.DisplayName</MudSelectItem>
+        <MudSelectItem Value="@c">@c.NativeName</MudSelectItem>
       }
     </MudSelect>
 
@@ -27,6 +29,45 @@
                  Value="ViewModel.SimulationSpeedMs"
                  ValueChanged="@(v => ViewModel.SimulationSpeedMs = v)"
                  Color="Color.Primary" />
+    </div>
+
+    <div>
+      <MudText Typo="Typo.body2" Class="mb-2"><strong>Flag style</strong></MudText>
+      <MudRadioGroup T="FlagStyle"
+                     Value="ViewModel.SelectedFlagStyle"
+                     ValueChanged="@(v => ViewModel.SelectedFlagStyle = v)">
+        <MudRadio Value="@FlagStyle.Square">Square</MudRadio>
+        <MudRadio Value="@FlagStyle.Round">Round</MudRadio>
+        <MudRadio Value="@FlagStyle.RoundTier">Round with Elo tier</MudRadio>
+      </MudRadioGroup>
+      <MudText Typo="Typo.caption" Color="Color.Secondary" Class="d-block mt-2 mb-2">
+        Preview (changes apply across the app immediately):
+      </MudText>
+      <div class="d-flex align-center" style="gap: 1.5rem;" @key="ViewModel.SelectedFlagStyle">
+        <FlagIcon Code="br" Elo="1850" Size="40" Title="Gold tier" Alt="" />
+        <FlagIcon Code="dk" Elo="1550" Size="40" Title="Silver tier" Alt="" />
+        <FlagIcon Code="sa" Elo="1400" Size="40" Title="Bronze tier" Alt="" />
+        <FlagIcon Code="bo" Elo="1200" Size="40" Title="No tier" Alt="" />
+      </div>
+    </div>
+
+    <div>
+      <MudText Typo="Typo.body2" Class="mb-2"><strong>Competition logos</strong></MudText>
+      <MudSwitch T="bool"
+                 Value="ViewModel.UseOfficialCompetitionLogos"
+                 ValueChanged="@(v => ViewModel.UseOfficialCompetitionLogos = v)"
+                 Color="Color.Primary"
+                 Label="Use official logos (if locally placed)" />
+      <MudText Typo="Typo.caption" Color="Color.Secondary" Class="d-block mt-1">
+        Off: built-in Material Icons. On: app loads from
+        <code>wwwroot/competition-icons/official/{type}.svg</code>. Files
+        not placed there yet fall back to the Material Icon automatically
+        (no broken-image placeholders).
+      </MudText>
+      <div class="d-flex align-center mt-3" style="gap: 1.5rem;">
+        <CompetitionTypeIcon Type="@CompetitionType.WM" Size="40" />
+        <CompetitionTypeIcon Type="@CompetitionType.EM" Size="40" />
+      </div>
     </div>
 
     <MudDivider />

--- a/src/FantasyFootball.UI/Pages/TeamDetail.razor
+++ b/src/FantasyFootball.UI/Pages/TeamDetail.razor
@@ -25,12 +25,9 @@ else
   <MudPaper Class="pa-4" Elevation="1">
     <MudGrid AlignItems="AlignItems.Center" Spacing="4">
       <MudItem xs="12" sm="3" md="2">
-        @if (!string.IsNullOrEmpty(ViewModel.Team.Country?.Code2))
-        {
-          <img src="@FlagHelper.Url(ViewModel.Team.Country.Code2)"
-               alt="@ViewModel.Team.Country.Name"
-               style="width: 100%; max-width: 7rem; height: auto;" />
-        }
+        <div style="width: 100%; max-width: 7rem;">
+          <FlagIcon Team="ViewModel.Team" Size="112" />
+        </div>
       </MudItem>
       <MudItem xs="12" sm="6" md="8">
         <MudText Typo="Typo.h5" HtmlTag="h1" GutterBottom="false">
@@ -41,7 +38,7 @@ else
           @ViewModel.Team.Country?.Confederation?.Continent
         </MudText>
         <MudText Typo="Typo.body1" Class="mt-2">
-          Rank <strong>#@ViewModel.Rank</strong> · Elo <strong>@ViewModel.Team.Elo</strong>
+          Rank <strong>#@ViewModel.Rank</strong> <span class="elo-muted">· Elo @ViewModel.Team.Elo</span>
         </MudText>
       </MudItem>
       <MudItem xs="12" sm="3" md="2" Class="d-flex justify-end">

--- a/src/FantasyFootball.UI/Pages/Teams.razor
+++ b/src/FantasyFootball.UI/Pages/Teams.razor
@@ -37,16 +37,9 @@
     </HeaderContent>
     <RowTemplate>
       <MudTd>@context.Rank</MudTd>
-      <MudTd>
-        @if (!string.IsNullOrEmpty(context.Team.Country?.Code2))
-        {
-          <img src="@FlagHelper.Url(context.Team.Country.Code2)"
-               alt="@context.Team.Country.Name"
-               style="width: 1.75rem; height: auto; vertical-align: middle;" />
-        }
-      </MudTd>
+      <MudTd><FlagIcon Team="context.Team" Size="24" /></MudTd>
       <MudTd>@context.Team.Name</MudTd>
-      <MudTd Style="text-align: right;">@context.Team.Elo</MudTd>
+      <MudTd Style="text-align: right;"><span class="elo-muted">@context.Team.Elo</span></MudTd>
     </RowTemplate>
   </MudTable>
 

--- a/src/FantasyFootball.UI/ViewModels/SettingsViewModel.cs
+++ b/src/FantasyFootball.UI/ViewModels/SettingsViewModel.cs
@@ -25,6 +25,8 @@ public partial class SettingsViewModel : ObservableObject
 
 		SelectedLanguage = settings.LastUsedLanguage;
 		SimulationSpeedMs = settings.SimulationSpeed.TotalMilliseconds;
+		SelectedFlagStyle = settings.FlagStyle;
+		UseOfficialCompetitionLogos = settings.UseOfficialCompetitionLogos;
 		SupportedLanguages = [new("en"), new("de")];
 	}
 
@@ -35,6 +37,12 @@ public partial class SettingsViewModel : ObservableObject
 
 	[ObservableProperty]
 	public partial double SimulationSpeedMs { get; set; }
+
+	[ObservableProperty]
+	public partial FlagStyle SelectedFlagStyle { get; set; }
+
+	[ObservableProperty]
+	public partial bool UseOfficialCompetitionLogos { get; set; }
 
 	[ObservableProperty]
 	public partial bool IsBusy { get; set; }
@@ -53,6 +61,12 @@ public partial class SettingsViewModel : ObservableObject
 
 	partial void OnSimulationSpeedMsChanged(double value)
 		=> _settings.SimulationSpeed = TimeSpan.FromMilliseconds(value);
+
+	partial void OnSelectedFlagStyleChanged(FlagStyle value)
+		=> _settings.FlagStyle = value;
+
+	partial void OnUseOfficialCompetitionLogosChanged(bool value)
+		=> _settings.UseOfficialCompetitionLogos = value;
 
 	[RelayCommand]
 	async Task ResetDatabase()

--- a/src/FantasyFootball.UI/_Imports.razor
+++ b/src/FantasyFootball.UI/_Imports.razor
@@ -5,5 +5,6 @@
 @using Microsoft.JSInterop
 @using MudBlazor
 @using FantasyFootball.UI
+@using FantasyFootball.UI.Components
 @using FantasyFootball.UI.Helpers
 @using FantasyFootball.UI.Layout

--- a/src/FantasyFootball.Web/Services/LocalStorageSettingsService.cs
+++ b/src/FantasyFootball.Web/Services/LocalStorageSettingsService.cs
@@ -14,6 +14,8 @@ public sealed class LocalStorageSettingsService : ISettingsService
   const string LanguageKey = "id_language";
   const string SimSpeedKey = "id_simspeed";
   const string LastCompetitionKey = "id_token";
+  const string FlagStyleKey = "id_flagstyle";
+  const string UseOfficialLogosKey = "id_useofficiallogos";
 
   readonly ISyncLocalStorageService _localStorage;
 
@@ -38,6 +40,20 @@ public sealed class LocalStorageSettingsService : ISettingsService
   {
     get => CultureInfo.GetCultureInfo(GetValueOrDefault(LanguageKey, "en"));
     set => AddOrUpdateValue(LanguageKey, value?.TwoLetterISOLanguageName ?? "en");
+  }
+
+  // New-user default is Round — the visible polish improvement over Square.
+  public FlagStyle FlagStyle
+  {
+    get => Enum.TryParse<FlagStyle>(GetValueOrDefault(FlagStyleKey, ""), out var s) ? s : FlagStyle.Round;
+    set => AddOrUpdateValue(FlagStyleKey, value.ToString());
+  }
+
+  // Off by default — generic icons ship with the repo; user drops official assets in wwwroot/competition-icons/official/ locally and flips this.
+  public bool UseOfficialCompetitionLogos
+  {
+    get => GetValueOrDefault(UseOfficialLogosKey, false);
+    set => AddOrUpdateValue(UseOfficialLogosKey, value);
   }
 
   public bool GetValueOrDefault(string key, bool defaultValue)

--- a/src/FantasyFootball.Web/wwwroot/app.css
+++ b/src/FantasyFootball.Web/wwwroot/app.css
@@ -1,0 +1,146 @@
+/* Identity: PR 2 first chunk. Body in Inter, display in Barlow Condensed, tabular numerics globally so scores like 1-0 and 11-10 align. */
+
+:root {
+  font-variant-numeric: tabular-nums;
+}
+
+body {
+  font-family: 'Inter', system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
+}
+
+/* Wordmark in the top app bar. */
+.brand-wordmark {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-family: 'Barlow Condensed', 'Inter', sans-serif;
+  font-weight: 700;
+  font-size: 1.35rem;
+  letter-spacing: 0.5px;
+  text-transform: uppercase;
+}
+
+.brand-mark {
+  flex-shrink: 0;
+  display: inline-block;
+}
+
+/* Tournament/round titles use the display face — match-card scores will get it later. */
+.display-condensed {
+  font-family: 'Barlow Condensed', 'Inter', sans-serif;
+  font-weight: 700;
+  letter-spacing: 0.3px;
+}
+
+/* Flag rendering — see FlagIcon.razor. Style picked from ISettingsService.FlagStyle. */
+.flag-icon {
+  display: inline-block;
+  vertical-align: middle;
+  flex-shrink: 0;
+  object-fit: cover;
+}
+
+.flag-square {
+  /* No clipping; the default flagcdn SVG aspect ratio. */
+  object-fit: contain;
+}
+
+.flag-round {
+  border-radius: 50%;
+}
+
+/* RoundTier — same circular clip plus an Elo-tiered border, drawn via box-shadow so it doesn't shrink the image. */
+.flag-tier-gold { box-shadow: 0 0 0 2px #C9A227; }
+.flag-tier-silver { box-shadow: 0 0 0 2px #9CA3AF; }
+.flag-tier-bronze { box-shadow: 0 0 0 2px #B8732E; }
+.flag-tier-none { box-shadow: 0 0 0 1px rgba(128, 128, 128, 0.35); }
+
+/* Scoreboard match-card row. Symmetric layout: [flag][team] — SCORE — [team][flag]. */
+.scoreboard-row {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.5rem 0.75rem;
+  border-radius: 6px;
+  min-height: 56px;
+}
+
+.scoreboard-row + .scoreboard-row {
+  margin-top: 4px;
+}
+
+.scoreboard-row:hover {
+  background: var(--mud-palette-action-hover, rgba(0, 0, 0, 0.04));
+}
+
+.scoreboard-team {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  flex: 1 1 0;
+  min-width: 0;
+}
+
+.scoreboard-team-home {
+  justify-content: flex-end;
+  text-align: right;
+}
+
+.scoreboard-team-away {
+  justify-content: flex-start;
+  text-align: left;
+}
+
+.scoreboard-team-name {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.scoreboard-score {
+  font-family: 'Barlow Condensed', 'Inter', sans-serif;
+  font-weight: 700;
+  font-size: 1.4rem;
+  letter-spacing: 0.5px;
+  min-width: 5rem;
+  text-align: center;
+  font-variant-numeric: tabular-nums;
+}
+
+.scoreboard-winner { font-weight: 600; }
+.scoreboard-loser { opacity: 0.65; }
+.scoreboard-pending { opacity: 0.65; }
+
+/* Competition-type icon stack: MudIcon underneath, img overlay on top. If img 404s, onerror hides it and the MudIcon shows through. */
+.comp-type-icon-stack {
+  display: inline-flex;
+  position: relative;
+  align-items: center;
+  justify-content: center;
+  vertical-align: middle;
+}
+
+.comp-type-icon-overlay {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+}
+
+/* Group section heading — typographic letter only (OneFootball-style). No chip, no noun. */
+.group-letter-heading {
+  font-family: 'Barlow Condensed', 'Inter', sans-serif;
+  font-weight: 700;
+  font-size: 1.5rem;
+  letter-spacing: 1px;
+  color: var(--mud-palette-primary);
+  line-height: 1;
+}
+
+/* Elo numbers tone down so they don't compete with team names. */
+.elo-muted {
+  color: var(--mud-palette-text-secondary, #9CA3AF);
+  font-variant-numeric: tabular-nums;
+  font-weight: 400;
+}

--- a/src/FantasyFootball.Web/wwwroot/favicon.svg
+++ b/src/FantasyFootball.Web/wwwroot/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="16" cy="16" r="15" fill="#00B86B"/>
+  <polygon points="16,7.5 23.2,12.8 20.5,21.2 11.5,21.2 8.8,12.8" fill="#0F1F17" stroke="#0F1F17" stroke-width="1.5" stroke-linejoin="round"/>
+</svg>

--- a/src/FantasyFootball.Web/wwwroot/index.html
+++ b/src/FantasyFootball.Web/wwwroot/index.html
@@ -7,16 +7,18 @@
     <title>Fantasy Football</title>
     <base href="/" />
     <link rel="preload" id="webassembly" />
-    <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap" rel="stylesheet" />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Barlow+Condensed:wght@600;700&display=swap" rel="stylesheet" />
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet" />
     <link href="_content/MudBlazor/MudBlazor.min.css" rel="stylesheet" />
+    <link href="app.css" rel="stylesheet" />
+    <link rel="icon" type="image/svg+xml" href="favicon.svg" />
     <link rel="icon" type="image/png" href="favicon.png" />
     <script type="importmap"></script>
 </head>
 
 <body>
     <div id="app">
-        <div style="text-align:center; padding-top:30vh; font-family:Roboto,sans-serif;">Loading…</div>
+        <div style="text-align:center; padding-top:30vh; font-family:'Inter',system-ui,sans-serif;">Loading…</div>
     </div>
 
     <div id="blazor-error-ui" style="display:none; position:fixed; bottom:0; left:0; right:0; padding:0.6rem 1.25rem; background:lightyellow; box-shadow:0 -1px 2px rgba(0,0,0,0.2); z-index:1000;">


### PR DESCRIPTION
Second of four polish PRs (see `docs/ui-polish-plan.md`). Identity-at-rest: visual brand, typography, flag treatment, scoreboard match cards, group/Elo refinements. Behavioural polish (animations, keyboard nav, undo) is PR 3.

## What ships (8 plan items, all ticked)

1. **Favicon + brand mark** — green disc + dark pentagon SVG. Same shape used inline in the top app bar wordmark, so the brand is one mark from tab icon through to header.
2. **Wordmark** — `[mark] FANTASYFOOTBALL` in Barlow Condensed bold uppercase, letter-spaced. Replaces the plain "Fantasy Football" text.
3. **Off-purple palette** — `PaletteLight` + `PaletteDark` configured with neutral surfaces and competition green (`#00B86B`) as the primary accent. Replaces MudBlazor's default purple end-to-end.
4. **Typography** — Inter for body (replaces Roboto), Barlow Condensed for display (wordmark + scoreboard scores). `font-variant-numeric: tabular-nums` on `:root` so scores like `1-0` and `11-10` align.
5. **`<FlagIcon>` component + `FlagStyle` setting** — single component (`Team` / `Code` / `Size` / `Elo`) replaces every inline `<img>`. Persisted `FlagStyle` (`Square` / `Round` / `RoundTier`) with Settings picker and live preview spanning the four Elo tiers. RoundTier draws gold/silver/bronze borders via `box-shadow` so the image doesn't shrink.
6. **Scoreboard match cards** — `[name][flag] SCORE [flag][name]`, winner bolded, loser at `0.65` opacity, score in Barlow Condensed display weight. ~56px row, subtle hover, tabular numerics.
7. **Group letter heading** — OneFootball-style: just the letter (`A` / `B` / `…`) in Barlow Condensed green. No chip, no noun — single signal.
8. **Elo tone-down** — Teams + TeamDetail render Elo in `text-secondary` with regular weight, so team name remains the primary signal.

## Deferred (deliberate)

- **`GameRowDetail` setting** (`Minimal` / `Probabilities` / `EloAndProbabilities`) is moved to PR 3. Computed pre-game win probabilities are sim-insight more than identity-at-rest.

## Plan notes captured (no code yet, queued for PR 3)

Three small plan additions for items Stephan raised mid-session, plus two from kicker.de reference shots. All carry "PR 3" tags in the doc:

- Delete competitions from the list, not the detail page (per-row trash + confirm).
- Day-grouping dividers in the games panel when `PlayedOn.Date` varies.
- Unify Settings speed UI with the detail picker (replace slider with same 4-preset picker).
- `GameListMode` (`OnePerRound` / `AllOfStage`) so users can scroll an entire stage without round-by-round clicking.
- Round-picker date ranges (`Achtelfinale (10.03. - 18.03.)`).
- ET / penalty sub-score below main result on KO scoreboard rows.

## Tests

- Build: clean.
- Suite: 36 pass / 6 fail. The 6 are the pre-existing greedy-3rd-place tournament-sim tests via the SQLite roundtrip path (issue #12-adjacent). PR 2 touched zero Core / sim code; no regression.
- New PR 2 tests: none. UI polish at this level isn't unit-testable in the current setup (no UI test harness).

## Test plan

- [ ] Brand mark identical in browser tab favicon and top app bar wordmark.
- [ ] Settings: FlagStyle radio picker with preview; switching applies across the app (back to /competitions, /teams, …) without reload.
- [ ] `/competitions/{id}`: game rows render as scoreboard cards; winner bolded, loser dimmed; score uses Barlow Condensed; group letters as standalone bold green headings.
- [ ] `/teams`: Elo column reads dimmer than team names.
- [ ] `/teams/{id}`: Rank stays prominent, Elo muted on the same line.
- [ ] No purple anywhere — primary accent is green throughout.

## Reference

- Plan: `docs/ui-polish-plan.md § PR 2`.