### PR TITLE
UI polish PR 3: Sim feel

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -50,6 +50,36 @@ dotnet workload install maui
 - XAML formatting governed by Settings.XamlStyler
 - Follow .editorconfig rules
 
+## Iteration loop — keep the dev server running
+
+While iterating on UI work, **launch the Blazor web host yourself** in the
+background (`dotnet run --project src/FantasyFootball.Web`, then open
+`https://localhost:7140`) so the user can visually inspect progress and give
+feedback at regular intervals. Don't wait to be asked. After a meaningful
+chunk lands, point the user at what to look at on the running site.
+
+Only ask the user to launch from Visual Studio when interactive debugging
+(breakpoints, step-through) is genuinely needed — pure visual inspection
+should happen on the server you're already running.
+
+### Verification checklist on each run
+
+Every time a fresh build is up, give the user a concrete checklist of what
+to look at — they shouldn't have to guess. Cover:
+
+- **What to check** (the change you just made — pages, components, flows
+  to open and the steps to reproduce the behaviour).
+- **What to test** (interactions, edge cases, keyboard / hover / click
+  paths, mobile layout if relevant).
+- **What to verify or sign off on** (correctness criteria — "this should
+  look like X", "Y should now work", "Z should no longer happen").
+- **What feedback you'd specifically like** (open questions, judgment
+  calls — copy choices, animation timing, layout density).
+
+Format it as a short bulleted list with the URL/path for each item, not a
+wall of prose. Keep it scannable — the user is opening the browser, not
+reading a manual.
+
 ## Out of scope
 
 **Accessibility (a11y) is not a priority at this stage.** Do not invest effort

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -53,14 +53,32 @@ dotnet workload install maui
 ## Iteration loop — keep the dev server running
 
 While iterating on UI work, **launch the Blazor web host yourself** in the
-background (`dotnet run --project src/FantasyFootball.Web`, then open
-`https://localhost:7140`) so the user can visually inspect progress and give
-feedback at regular intervals. Don't wait to be asked. After a meaningful
-chunk lands, point the user at what to look at on the running site.
+background and keep it running. The user can visually inspect progress and
+give feedback without being asked. Don't wait to be asked. After a
+meaningful chunk lands, point the user at what to look at on the running
+site at `https://localhost:7140`.
+
+**Use `dotnet watch`, not `dotnet run`.** Plain `dotnet run` requires a
+manual kill + restart for each change *and* a browser hard-refresh (Blazor
+WASM caches the runtime / DLLs in the tab; plain F5 won't pick up C#
+changes). `dotnet watch` auto-rebuilds on file changes and tells the open
+browser tab to reload itself.
+
+```bash
+dotnet watch --project src/FantasyFootball.Web run --launch-profile https --no-hot-reload
+```
+
+`--no-hot-reload` is intentional: WASM hot-reload is flaky and can
+silently fail to apply C# changes. With it disabled, every file change
+does a full rebuild + browser reload — slower but always correct.
+
+If `dotnet watch` exits with code 127 in the background task notifications,
+that's the harness reporting the process was killed (e.g. by Stop-Process
+when freeing port 7140) — it's not a build failure.
 
 Only ask the user to launch from Visual Studio when interactive debugging
 (breakpoints, step-through) is genuinely needed — pure visual inspection
-should happen on the server you're already running.
+should happen on the watch server you're already running.
 
 ### Verification checklist on each run
 

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -80,6 +80,12 @@ Format it as a short bulleted list with the URL/path for each item, not a
 wall of prose. Keep it scannable — the user is opening the browser, not
 reading a manual.
 
+**Frame it as a diff since the last launch.** The user has already looked
+at everything else. List only what's new or changed since the previous
+running build — skip features that landed in earlier rounds and are
+already signed off. If the previous run was many commits ago, summarise
+the commits being verified at the top so the user knows the scope.
+
 ## Out of scope
 
 **Accessibility (a11y) is not a priority at this stage.** Do not invest effort

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -65,12 +65,15 @@ changes). `dotnet watch` auto-rebuilds on file changes and tells the open
 browser tab to reload itself.
 
 ```bash
-dotnet watch --project src/FantasyFootball.Web run --launch-profile https --no-hot-reload
+dotnet watch --project src/FantasyFootball.Web run --launch-profile https
 ```
 
-`--no-hot-reload` is intentional: WASM hot-reload is flaky and can
-silently fail to apply C# changes. With it disabled, every file change
-does a full rebuild + browser reload — slower but always correct.
+Do **not** pass `--no-hot-reload` — that disables the browser-refresh
+signal as a side effect, so the open tab stays on the old bundle even
+after the rebuild completes. Default behaviour auto-rebuilds AND tells
+the open tab to reload itself. C# hot-reload itself is flaky for WASM,
+but the page reload still picks up changes correctly because the
+rebuilt DLLs are downloaded fresh by the page on reload.
 
 If `dotnet watch` exits with code 127 in the background task notifications,
 that's the harness reporting the process was killed (e.g. by Stop-Process

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -65,15 +65,28 @@ changes). `dotnet watch` auto-rebuilds on file changes and tells the open
 browser tab to reload itself.
 
 ```bash
-dotnet watch --project src/FantasyFootball.Web run --launch-profile https
+DOTNET_WATCH_RESTART_ON_RUDE_EDIT=true \
+  dotnet watch --project src/FantasyFootball.Web run --launch-profile https --non-interactive
 ```
 
-Do **not** pass `--no-hot-reload` — that disables the browser-refresh
-signal as a side effect, so the open tab stays on the old bundle even
-after the rebuild completes. Default behaviour auto-rebuilds AND tells
-the open tab to reload itself. C# hot-reload itself is flaky for WASM,
-but the page reload still picks up changes correctly because the
-rebuilt DLLs are downloaded fresh by the page on reload.
+Three flags / env vars worth understanding:
+
+- **No `--no-hot-reload`** — that disables the browser-refresh signal as
+  a side effect, leaving the open tab on the old bundle.
+- **`--non-interactive`** — without this, "rude edits" (e.g. changing
+  the type of a field) cause `dotnet watch` to prompt
+  `Restart? Yes/No/Always/Never` on stdin. The background process can't
+  receive that input and the watch hangs — the old WASM bundle keeps
+  being served while new code is uncompiled. Symptom: file changes
+  silently don't appear in the browser.
+- **`DOTNET_WATCH_RESTART_ON_RUDE_EDIT=true`** — answers the rude-edit
+  prompt as "Always restart" so the same trap doesn't reopen if
+  `--non-interactive` ever stops being respected.
+
+If you see file changes not landing in the browser despite a successful
+rebuild log, suspect the rude-edit prompt — kill all `dotnet` processes
+(`Get-Process dotnet | Stop-Process -Force`) and relaunch with the env
+var + flag above.
 
 If `dotnet watch` exits with code 127 in the background task notifications,
 that's the harness reporting the process was killed (e.g. by Stop-Process

--- a/docs/ideas.md
+++ b/docs/ideas.md
@@ -41,6 +41,28 @@ Unsorted feature/UX ideas that aren't yet committed to a PR plan. Promote to
   entity with proper relationships. Probably a follow-up to whatever
   surface lands first.
 
+## Confederation + governing-body logos in pickers
+
+- **Confederation logos** (UEFA, CONMEBOL, AFC, CAF, CONCACAF, OFC, plus
+  FIFA as the global parent) shown in the team picker and next to
+  confederation-scoped filters / dropdowns.
+- **FIFA WC + UEFA Euros marks** next to the competition-type picker on
+  `/competitions` (and on the start-new dialog), so the visual identity of
+  the tournament is immediately recognisable.
+- Asset source: user has the sortitoutsi.net FM24 graphics pack locally —
+  `logos/confeds/normal/{1..7}.png` (7 PNGs) and selected entries from
+  `logos/comps/normal/` (5975 PNGs total; need to pick out WC + Euros IDs
+  via `config.xml`).
+- **Caveats**:
+  - FM IDs are numeric, not ISO/UEFA-style codes. Need a small hand-
+    maintained mapping table: `Confederation` enum → file ID, comp-type
+    enum → file ID.
+  - Licensing — sortitoutsi.net assets are community-aggregated, often cut
+    from real broadcast/marketing material. Public GitHub Pages deploy
+    means thinking about redistribution risk before bundling. Possible
+    mitigations: serve from a separate static origin, or replace with
+    permissively-licensed equivalents (Wikipedia SVGs, simpleicons.org).
+
 ## Manual competition setup — drawing-ceremony UX
 
 Applies to the *manual* setup mode only (Classic / Random unchanged):

--- a/docs/ideas.md
+++ b/docs/ideas.md
@@ -1,0 +1,39 @@
+# Idea pile
+
+Unsorted feature/UX ideas that aren't yet committed to a PR plan. Promote to
+`ui-polish-plan.md` (or a dedicated planning doc) when an idea graduates to
+"we're doing this next".
+
+## Simulation model
+
+- **Pluggable simulation models.** Today's sim is one Elo-based model with
+  fixed parameters. Offer alternatives:
+  - **Elo (current)** — baseline.
+  - **Elo + outliers** — modified Elo with heavier tails (more upsets / blowouts).
+  - **Tweakable parameters** — expose math knobs (Elo K-factor, goal-distribution
+    variance, home-field advantage, draw bias) for an "Advanced" mode.
+- UX shape: a `SimulationModel` setting (radio + per-model param panel) for
+  power users. Default stays Elo with current params.
+
+## Settings as overlay (not a separate page)
+
+- Replace `/settings` page with a modal / dropdown / slide-over overlay
+  triggered from the app bar.
+- The page underneath stays visible → user sees the effect of a setting
+  (flag style, game-row detail, sim speed) directly on the current page
+  without navigating away and back.
+- Mirrors how OneFootball / Sofascore handle preferences.
+
+## Manual competition setup — drawing-ceremony UX
+
+Applies to the *manual* setup mode only (Classic / Random unchanged):
+
+- **Drag-and-drop** team entries between group slots.
+- **Double-tap** an empty slot to type with autocomplete (existing team
+  search).
+- **Pot-based animated draw**: emulate the official ceremony — teams sit in
+  pots, click "draw" to animate one team at a time landing in the next
+  legal group slot. Subtle confetti/ball-bounce; respects standard draw
+  constraints (no two teams from same confederation in one group, etc.).
+- Natural extension of the existing manual setup; differentiates the app
+  vs "just pick teams from a dropdown".

--- a/docs/ideas.md
+++ b/docs/ideas.md
@@ -24,6 +24,23 @@ Unsorted feature/UX ideas that aren't yet committed to a PR plan. Promote to
   without navigating away and back.
 - Mirrors how OneFootball / Sofascore handle preferences.
 
+## Venue / location surface
+
+- **Show venue on game cards** (e.g. where the kickoff time sits, or next to it).
+  Configurable visibility so users who want a clean row can hide it.
+- **A richer location surface** somewhere in the app — stadium, city,
+  capacity, previous games played here in this competition, the home team
+  if it's a club ground / national stadium, anything else venue-flavoured.
+  Open question on shape:
+  - Popover/drawer when clicking the venue chip on a game card?
+  - Dedicated "Venues" tab on the competition page?
+  - Venue page reachable from each game's details popover (see
+    `ui-polish-plan.md § Click-for-game-details`)?
+- Data work first: venue is currently a `Game.Location` string (or
+  similar). For previous-games / capacity / coords we'd need a Venue
+  entity with proper relationships. Probably a follow-up to whatever
+  surface lands first.
+
 ## Manual competition setup — drawing-ceremony UX
 
 Applies to the *manual* setup mode only (Classic / Random unchanged):

--- a/docs/ui-polish-plan.md
+++ b/docs/ui-polish-plan.md
@@ -409,7 +409,7 @@ Done:
 
 Still open (next session):
 
-- [ ] Keyboard navigation (full mapping; help overlay; About reference).
+- [x] Keyboard navigation (full mapping; help overlay; About reference).
 - [ ] Undo stack (in-memory, JSON-snapshot-per-action, capped at 50).
 - [ ] Just-finished game highlight (game row + standings rows pulse).
 - [ ] Score reveal animation.

--- a/docs/ui-polish-plan.md
+++ b/docs/ui-polish-plan.md
@@ -410,7 +410,7 @@ Done:
 Still open (next session):
 
 - [x] Keyboard navigation (full mapping; help overlay; About reference).
-- [ ] Undo stack (in-memory, JSON-snapshot-per-action, capped at 50).
+- [x] Undo stack (in-memory, JSON-snapshot-per-action, capped at 50).
 - [ ] Just-finished game highlight (game row + standings rows pulse).
 - [ ] Score reveal animation.
 - [ ] Standings row reorder via FLIP.

--- a/docs/ui-polish-plan.md
+++ b/docs/ui-polish-plan.md
@@ -410,7 +410,8 @@ Done:
 Still open (next session):
 
 - [x] Keyboard navigation (full mapping; help overlay; About reference).
-- [x] Undo stack (in-memory, JSON-snapshot-per-action, capped at 50).
+- [x] Undo stack (in-memory, per-game snapshot, capped at 50; UI attaches the
+  Undo button to the row of the just-simmed game).
 - [ ] Just-finished game highlight (game row + standings rows pulse).
 - [ ] Score reveal animation.
 - [ ] Standings row reorder via FLIP.

--- a/docs/ui-polish-plan.md
+++ b/docs/ui-polish-plan.md
@@ -375,25 +375,58 @@ around third-place resolve, corrupt-blob quarantine on load.
 
 ### PR 3 — Sim feel
 
-- Speed control (Slow / Normal / Fast / Instant) on competition page.
-- **Unify Settings speed UI with the detail picker** — replace the
-  0–500 ms slider with the same 4-preset picker (decision noted under
-  Functionality § Speed control).
-- **Delete competitions from the list, not the detail page** — move the
-  trash icon off `/competitions/{id}` to per-row delete on `/competitions`
-  with a confirm dialog.
-- **Day-grouping dividers in the games panel** when `PlayedOn.Date`
-  varies (`Mon 25 Jun` subtle separator).
-- Keyboard navigation (full mapping; help overlay; About reference).
-- Undo stack (in-memory, JSON-snapshot-per-action, capped at 50).
-- Just-finished game highlight (game row + standings rows pulse).
-- Score reveal animation.
-- Standings row reorder via FLIP.
-- Standings qualifier highlight (left-edge bar).
-- Optional `Qual %` column in group stage (Monte Carlo).
-- Click-for-game-details popover / drawer.
-- Replay button on `Competition.IsFinished`.
-- Confetti burst on finish.
+**Status**: in flight on branch `feature/ui-polish-3-sim-feel`. Five
+chunks committed locally (not pushed yet). Pick up the remaining items
+in a fresh session; merge PR 3 once a meaningful slice is complete.
+
+Local commits on this branch (latest first):
+
+| SHA | Chunk |
+|---|---|
+| `e450e07` | Standings: qualification-zone left-edge bar + group-letter spacing |
+| `db91c3e` | Group letter + kickoff time on scoreboard rows |
+| `7fae924` | Day-grouping dividers in the games panel |
+| `bbe6df0` | Unify Settings speed UI with detail picker |
+| `1095c86` | Move competition delete from detail page to per-row list action |
+
+Done:
+
+- [x] Speed control (Slow / Normal / Fast / Instant) on competition page.
+  (Already shipped in PR 1; left here for plan completeness.)
+- [x] **Unify Settings speed UI with the detail picker** — replace the
+  0–500 ms slider with the same 4-preset picker.
+- [x] **Delete competitions from the list, not the detail page** — move
+  the trash icon off `/competitions/{id}` to per-row delete on
+  `/competitions` with a confirm dialog.
+- [x] **Day-grouping dividers in the games panel** when `PlayedOn.Date`
+  varies (`ddd d MMM` subtle separator).
+- [x] **Group letter + kickoff time on scoreboard rows** (vertical tag
+  on the leading side of each match-card row; letter blank for KO games
+  whose teams span groups, kickoff time always shown).
+- [x] **Standings qualifier highlight** (left-edge bar) — slim 3px
+  muted-green / muted-red column inset from row edges; resolves
+  ThirdPlace combination eligibility once the group stage finishes.
+
+Still open (next session):
+
+- [ ] Keyboard navigation (full mapping; help overlay; About reference).
+- [ ] Undo stack (in-memory, JSON-snapshot-per-action, capped at 50).
+- [ ] Just-finished game highlight (game row + standings rows pulse).
+- [ ] Score reveal animation.
+- [ ] Standings row reorder via FLIP.
+- [ ] Optional `Qual %` column in group stage (Monte Carlo).
+- [ ] Click-for-game-details popover / drawer.
+- [ ] Replay button on `Competition.IsFinished`.
+- [ ] Confetti burst on finish.
+
+Open visual / correctness questions deferred from this session:
+
+- Group H standings sometimes show GD/Pts combos that contradict the
+  sort (e.g. Spain GD +7, Pts 4, sitting above teams with higher GD).
+  Tie-break logic or `Standings.CreateFrom` ordering is suspect — file
+  a separate bug rather than rolling into PR 3.
+- Per-row delete confirmation dialog text wording: revisit once the
+  About page mentions the action.
 
 ### PR 4 — KO bracket
 

--- a/docs/ui-polish-plan.md
+++ b/docs/ui-polish-plan.md
@@ -412,7 +412,8 @@ Still open (next session):
 - [x] Keyboard navigation (full mapping; help overlay; About reference).
 - [x] Undo stack (in-memory, per-game snapshot, capped at 50; UI attaches the
   Undo button to the row of the just-simmed game).
-- [ ] Just-finished game highlight (game row + standings rows pulse).
+- [x] Just-finished game highlight (game row pulse on single-game sim and redo;
+  standings-row pulse deferred to a follow-up).
 - [ ] Score reveal animation.
 - [ ] Standings row reorder via FLIP.
 - [ ] Optional `Qual %` column in group stage (Monte Carlo).

--- a/src/FantasyFootball.Core/Data/CompetitionSimulator.cs
+++ b/src/FantasyFootball.Core/Data/CompetitionSimulator.cs
@@ -84,7 +84,14 @@ public class CompetitionSimulator(Competition competition, IRepository repo, int
 		Log.Debug("--------------------------------------");
 	}
 
-	public async Task SimulateGame(Game game)
+	/// <summary>
+	/// Simulates a single game. When called from a multi-game loop (Round / Stage / Tournament)
+	/// the caller leaves <paramref name="delayAfter"/> as true so the GameDelay pacing applies
+	/// between games. For a one-off user click on Sim Game / Redo there is no "next game" to
+	/// pace against — the delay would just block the busy spinner from clearing — so the VM
+	/// passes false.
+	/// </summary>
+	public async Task SimulateGame(Game game, bool delayAfter = true)
 	{
 		if (!game.IsReadyToStart)
 		{
@@ -106,7 +113,7 @@ public class CompetitionSimulator(Competition competition, IRepository repo, int
 		else
 		{
 			MessageBus.Send(new GameFinishedMessage(game));
-			await Task.Delay(GameDelay);
+			if (delayAfter) { await Task.Delay(GameDelay); }
 		}
 
 		// Persistence is the caller's responsibility — saving per game escalates to a full

--- a/src/FantasyFootball.Core/Models/Game.cs
+++ b/src/FantasyFootball.Core/Models/Game.cs
@@ -4,7 +4,7 @@ using MathNet.Numerics.Distributions;
 namespace FantasyFootball.Models;
 
 /// <summary>
-/// TODO There is no good way to create a Game from a string, or create a Game with a result already set, or clear an existing result
+/// TODO There is no good way to create a Game from a string, or create a Game with a result already set
 /// </summary>
 [Table(nameof(Game))]
 [JsonPolymorphic(TypeDiscriminatorPropertyName = "$kind")]
@@ -113,6 +113,15 @@ public class Game : NamedUniqueId
 		AwayScore = awayGoals;
 		Ending = end;
 		State = GameState.FINISHED;
+	}
+
+	/// <summary> Inverse of <see cref="Simulate"/> for the undo flow: returns the game to its pre-sim, scheduled state. </summary>
+	public void ClearResult()
+	{
+		HomeScore = 0;
+		AwayScore = 0;
+		Ending = GameEnd.NORMAL;
+		State = GameState.SCHEDULED;
 	}
 
 	public override string ToString() => $"{PlayedOn,-5:g}, {HomeTeam?.ShortName,-2}-{AwayTeam?.ShortName,2} {Result}";

--- a/src/FantasyFootball.Core/Models/GroupQualifier.cs
+++ b/src/FantasyFootball.Core/Models/GroupQualifier.cs
@@ -3,9 +3,6 @@
 [Table(nameof(GroupQualifier))]
 public class GroupQualifier : Qualifier
 {
-	// used to cache the result, i.e. once the team is determined, store it here and return it in Get()
-	Team? _qualified;
-
 	public int GroupId { get; init; }
 	public int FinalPlacement { get; init; }
 
@@ -14,10 +11,14 @@ public class GroupQualifier : Qualifier
 
 	public Group? Group => Competition?.Groups[GroupId];
 
-	// TODO Remove static reference to EuroRoundAdvancer
+	// Recomputes each call. Caching the resolved team led to stale KO bracket display after an
+	// undo on a group-stage game, because the cache had no invalidation hook. The recompute is
+	// cheap (one GetStandings pass over a 4-team group, or a single ResolveThirdPlaceQualifier
+	// call once the stage finishes) and the IsFinished guards inside ensure null is returned
+	// whenever the source state isn't ready.
 	public override Team? Get()
 	{
-		return _qualified ??= GetQualifier();
+		return GetQualifier();
 
 		Team? GetQualifier() => FinalPlacement switch
 		{

--- a/src/FantasyFootball.Core/Services/CompetitionSnapshot.cs
+++ b/src/FantasyFootball.Core/Services/CompetitionSnapshot.cs
@@ -1,0 +1,24 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using FantasyFootball.Models;
+
+namespace FantasyFootball.Services;
+
+/// <summary>
+/// Shared JSON snapshot helpers for the Competition aggregate.
+/// Used by LocalStorageRepository (persistence) and the undo stack (in-memory rewind).
+/// Both must use identical options so a string captured by one path round-trips through the other.
+/// </summary>
+public static class CompetitionSnapshot
+{
+	// STJ freezes options on first use; a single shared instance is the documented best practice.
+	public static readonly JsonSerializerOptions JsonOptions = new()
+	{
+		TypeInfoResolver = new IgnoreAttributeTypeInfoResolver(),
+		ReferenceHandler = ReferenceHandler.Preserve,
+	};
+
+	public static string Serialize(Competition competition) => JsonSerializer.Serialize(competition, JsonOptions);
+
+	public static Competition? Deserialize(string json) => JsonSerializer.Deserialize<Competition>(json, JsonOptions);
+}

--- a/src/FantasyFootball.Core/Services/CompetitionSnapshot.cs
+++ b/src/FantasyFootball.Core/Services/CompetitionSnapshot.cs
@@ -1,13 +1,11 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
-using FantasyFootball.Models;
 
 namespace FantasyFootball.Services;
 
 /// <summary>
-/// Shared JSON snapshot helpers for the Competition aggregate.
-/// Used by LocalStorageRepository (persistence) and the undo stack (in-memory rewind).
-/// Both must use identical options so a string captured by one path round-trips through the other.
+/// Shared JSON serializer options for the Competition aggregate.
+/// Used by the LocalStorage repository (persistence) and the test suite (round-trip checks).
 /// </summary>
 public static class CompetitionSnapshot
 {
@@ -17,8 +15,4 @@ public static class CompetitionSnapshot
 		TypeInfoResolver = new IgnoreAttributeTypeInfoResolver(),
 		ReferenceHandler = ReferenceHandler.Preserve,
 	};
-
-	public static string Serialize(Competition competition) => JsonSerializer.Serialize(competition, JsonOptions);
-
-	public static Competition? Deserialize(string json) => JsonSerializer.Deserialize<Competition>(json, JsonOptions);
 }

--- a/src/FantasyFootball.Core/Services/CompetitionSnapshot.cs
+++ b/src/FantasyFootball.Core/Services/CompetitionSnapshot.cs
@@ -10,9 +10,18 @@ namespace FantasyFootball.Services;
 public static class CompetitionSnapshot
 {
 	// STJ freezes options on first use; a single shared instance is the documented best practice.
-	public static readonly JsonSerializerOptions JsonOptions = new()
+	// MakeReadOnly() turns accidental late mutation into a clear InvalidOperationException instead of
+	// silently affecting every other caller of these shared options.
+	public static readonly JsonSerializerOptions JsonOptions = CreateJsonOptions();
+
+	static JsonSerializerOptions CreateJsonOptions()
 	{
-		TypeInfoResolver = new IgnoreAttributeTypeInfoResolver(),
-		ReferenceHandler = ReferenceHandler.Preserve,
-	};
+		var options = new JsonSerializerOptions
+		{
+			TypeInfoResolver = new IgnoreAttributeTypeInfoResolver(),
+			ReferenceHandler = ReferenceHandler.Preserve,
+		};
+		options.MakeReadOnly();
+		return options;
+	}
 }

--- a/src/FantasyFootball.Core/Services/IgnoreAttributeTypeInfoResolver.cs
+++ b/src/FantasyFootball.Core/Services/IgnoreAttributeTypeInfoResolver.cs
@@ -4,10 +4,11 @@ using System.Text.Json.Serialization.Metadata;
 using FantasyFootball.Models;
 using SQLite;
 
-namespace FantasyFootball.Web.Services;
+namespace FantasyFootball.Services;
 
 /// <summary>
-/// JSON type-info resolver that strips properties we don't want persisted to LocalStorage.
+/// JSON type-info resolver that strips properties we don't want persisted to LocalStorage
+/// or captured in in-memory Competition snapshots (e.g. undo).
 ///
 /// Two filter rules:
 ///

--- a/src/FantasyFootball.Tests/CompetitionDetailViewModelTests.cs
+++ b/src/FantasyFootball.Tests/CompetitionDetailViewModelTests.cs
@@ -1,0 +1,131 @@
+using System.Globalization;
+using FantasyFootball.Repositories;
+using FantasyFootball.Services;
+using FantasyFootball.UI.ViewModels;
+
+namespace FantasyFootball.Tests;
+
+/// <summary>
+/// VM coverage for the undo / redo flow on the competition detail page. The cases pin the contract
+/// the page binding relies on: per-game undo stack, ClearResult on pop, big-scope sims wipe the stack,
+/// cap eviction, and Redo replaces in place.
+/// </summary>
+public class CompetitionDetailViewModelTests : BaseTest
+{
+	readonly CompetitionDetailViewModel _vm;
+
+	public CompetitionDetailViewModelTests(ITestOutputHelper output) : base(output)
+	{
+		var competition = InitCompetition(CompetitionType.WM, 2022);
+		_vm = new CompetitionDetailViewModel(Repo, new TestSettingsService(), DataService);
+		_vm.Load(competition.Id);
+		// All assertions run against _vm.Competition.* — the SQLite round-trip in InitCompetition can
+		// give the test fixture a different Competition instance than the one Load() ends up holding.
+		_vm.Competition.Should().NotBeNull();
+	}
+
+	[Fact]
+	public async Task SimulateGame_ThenUndo_RevertsResultAndPopsStack()
+	{
+		var game = _vm.Competition!.CurrentGame!;
+
+		await _vm.SimulateGame();
+
+		game.IsFinished.Should().BeTrue();
+		_vm.CanUndo.Should().BeTrue();
+		_vm.UndoTargetGame.Should().BeSameAs(game);
+
+		_vm.Undo();
+
+		game.IsFinished.Should().BeFalse("undo should reset the game to SCHEDULED");
+		_vm.CanUndo.Should().BeFalse();
+		_vm.UndoTargetGame.Should().BeNull();
+	}
+
+	[Fact]
+	public async Task Undo_AfterTwoSims_PopsMostRecentFirst()
+	{
+		var firstGame = _vm.Competition!.CurrentGame!;
+		await _vm.SimulateGame();
+		var secondGame = _vm.Competition.CurrentGame!;
+		secondGame.Should().NotBeSameAs(firstGame, "after the first sim, CurrentGame must advance to the next unfinished game");
+		await _vm.SimulateGame();
+
+		_vm.UndoTargetGame.Should().BeSameAs(secondGame);
+
+		_vm.Undo();
+		_vm.UndoTargetGame.Should().BeSameAs(firstGame, "stack is LIFO; first undo reveals the older entry");
+		secondGame.IsFinished.Should().BeFalse();
+		firstGame.IsFinished.Should().BeTrue();
+
+		_vm.Undo();
+		_vm.CanUndo.Should().BeFalse();
+		firstGame.IsFinished.Should().BeFalse();
+	}
+
+	[Fact]
+	public async Task SimulateRound_ClearsAnyPriorSingleGameUndoEntries()
+	{
+		await _vm.SimulateGame();
+		_vm.CanUndo.Should().BeTrue();
+
+		await _vm.SimulateRound();
+
+		_vm.CanUndo.Should().BeFalse("big-scope sims wipe the per-game undo stack");
+		_vm.UndoTargetGame.Should().BeNull();
+	}
+
+	[Fact]
+	public async Task PushUndoEntry_CapsAtFifty_KeepingTheNewestEntries()
+	{
+		var firstSimmedGame = _vm.Competition!.CurrentGame!;
+		for (var i = 0; i < 51; i++) { await _vm.SimulateGame(); }
+
+		// After 50 pops the stack must be empty — the 51st-from-top entry (the very first sim) was evicted.
+		for (var i = 0; i < 50; i++)
+		{
+			_vm.CanUndo.Should().BeTrue($"expected at least {50 - i} undo entries remaining");
+			_vm.Undo();
+		}
+
+		_vm.CanUndo.Should().BeFalse("stack capped at 50 — the oldest entry was evicted");
+		firstSimmedGame.IsFinished.Should().BeTrue("the evicted entry's game should still be finished — no Undo reached it");
+	}
+
+	[Fact]
+	public async Task RedoLastGame_AfterSim_ResimsTheSameGame_AndKeepsOneStackEntry()
+	{
+		var game = _vm.Competition!.CurrentGame!;
+		await _vm.SimulateGame();
+		game.IsFinished.Should().BeTrue();
+		_vm.UndoTargetGame.Should().BeSameAs(game);
+
+		// Snapshot the score so we can confirm Redo wrote a fresh result.
+		var (firstHome, firstAway) = (game.HomeScore, game.AwayScore);
+
+		await _vm.RedoLastGame();
+
+		game.IsFinished.Should().BeTrue("redo re-sims the same game");
+		_vm.CanUndo.Should().BeTrue("redo doesn't change the stack — same one entry");
+		_vm.UndoTargetGame.Should().BeSameAs(game);
+
+		// New result may equal the old one by coincidence — IsFinished + CanUndo invariants are the contract.
+		_ = (firstHome, firstAway);
+	}
+
+	sealed class TestSettingsService : ISettingsService
+	{
+		public string LastUsedCompetition { get; set; } = "";
+		public TimeSpan SimulationSpeed { get; set; } = TimeSpan.Zero;
+		public CultureInfo LastUsedLanguage { get; set; } = CultureInfo.InvariantCulture;
+		public FlagStyle FlagStyle { get; set; } = FlagStyle.Square;
+		public bool UseOfficialCompetitionLogos { get; set; }
+
+		public bool GetValueOrDefault(string key, bool defaultValue) => defaultValue;
+		public string GetValueOrDefault(string key, string defaultValue) => defaultValue;
+		public double GetValueOrDefault(string key, double defaultValue) => defaultValue;
+		public void AddOrUpdateValue(string key, bool value) { }
+		public void AddOrUpdateValue(string key, string value) { }
+		public void AddOrUpdateValue(string key, double value) { }
+	}
+}

--- a/src/FantasyFootball.Tests/FantasyFootball.Tests.csproj
+++ b/src/FantasyFootball.Tests/FantasyFootball.Tests.csproj
@@ -38,6 +38,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\FantasyFootball.Core\FantasyFootball.Core.csproj" />
+    <ProjectReference Include="..\FantasyFootball.UI\FantasyFootball.UI.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/FantasyFootball.Tests/GameTests.cs
+++ b/src/FantasyFootball.Tests/GameTests.cs
@@ -1,0 +1,43 @@
+using FantasyFootball.Repositories;
+
+namespace FantasyFootball.Tests;
+
+/// <summary>
+/// Coverage for <see cref="Game"/>'s state transitions, in particular the
+/// <see cref="Game.ClearResult"/> inverse used by the undo flow.
+/// </summary>
+public class GameTests : BaseTest
+{
+	public GameTests(ITestOutputHelper output) : base(output) { }
+
+	[Fact]
+	public void ClearResult_AfterSimulate_ResetsToScheduledWithZeroScores()
+	{
+		var competition = InitCompetition(CompetitionType.WM, 2022);
+		var game = competition.CurrentGame!;
+		game.Simulate();
+		game.IsFinished.Should().BeTrue("setup: a freshly-simmed game should be finished");
+
+		game.ClearResult();
+
+		game.IsFinished.Should().BeFalse();
+		game.State.Should().Be(GameState.SCHEDULED);
+		game.HomeScore.Should().Be(0);
+		game.AwayScore.Should().Be(0);
+		game.Ending.Should().Be(GameEnd.NORMAL);
+	}
+
+	[Fact]
+	public void Simulate_AfterClearResult_ProducesFinishedResultAgain()
+	{
+		var competition = InitCompetition(CompetitionType.WM, 2022);
+		var game = competition.CurrentGame!;
+		game.Simulate();
+		game.ClearResult();
+		game.IsReadyToStart.Should().BeTrue("cleared game with real teams should be ready to sim again");
+
+		game.Simulate();
+
+		game.IsFinished.Should().BeTrue();
+	}
+}

--- a/src/FantasyFootball.Tests/GlobalUsings.cs
+++ b/src/FantasyFootball.Tests/GlobalUsings.cs
@@ -12,6 +12,7 @@ global using FantasyFootball.Data;
 global using FantasyFootball.Data.CompetitionFactories;
 global using FantasyFootball.Data.Formats;
 global using FantasyFootball.Models;
+global using FantasyFootball.Services;
 
 global using Serilog;
 global using Serilog.Events;

--- a/src/FantasyFootball.Tests/LocalStorageSerializationTests.cs
+++ b/src/FantasyFootball.Tests/LocalStorageSerializationTests.cs
@@ -1,9 +1,5 @@
 using System.IO;
-using System.Reflection;
 using System.Text.Json;
-using System.Text.Json.Serialization;
-using System.Text.Json.Serialization.Metadata;
-using SQLite;
 
 namespace FantasyFootball.Tests;
 
@@ -15,12 +11,7 @@ namespace FantasyFootball.Tests;
 /// </summary>
 public class LocalStorageSerializationTests(ITestOutputHelper output) : BaseTest(output)
 {
-	static JsonSerializerOptions BuildOptions() => new()
-	{
-		// Same resolver the Web host uses.
-		TypeInfoResolver = new TestIgnoreResolver(),
-		ReferenceHandler = ReferenceHandler.Preserve,
-	};
+	static JsonSerializerOptions BuildOptions() => CompetitionSnapshot.JsonOptions;
 
 	[Fact]
 	public void CreatedCompetition_FromFactory_RoundTrips()
@@ -141,42 +132,4 @@ public class LocalStorageSerializationTests(ITestOutputHelper output) : BaseTest
 		act.Should().NotThrow();
 	}
 
-	/// <summary>
-	/// Local copy of the Web host's IgnoreAttributeTypeInfoResolver. The Tests
-	/// project does not reference Web, so the resolver can't be shared yet —
-	/// it's <c>public sealed</c>, so InternalsVisibleTo doesn't help either.
-	/// Real fix: relocate the resolver into a shared project (Core or a new
-	/// FantasyFootball.Serialization helper) so both Web and Tests reference
-	/// the same type. Tracked as a follow-up issue.
-	///
-	/// **MAINTENANCE OBLIGATION**: keep this in sync with
-	/// <c>src/FantasyFootball.Web/Services/IgnoreAttributeTypeInfoResolver.cs</c>.
-	/// Any new entry in <c>BackPointerCollections</c> there must be mirrored
-	/// here, or the round-trip tests will silently lose coverage.
-	/// </summary>
-	sealed class TestIgnoreResolver : DefaultJsonTypeInfoResolver
-	{
-		static readonly HashSet<(Type DeclaringType, string PropertyName)> BackPointerCollections =
-		[
-			(typeof(Confederation), nameof(Confederation.Countries)),
-			(typeof(Country), nameof(Country.Clubs)),
-		];
-
-		public override JsonTypeInfo GetTypeInfo(Type type, JsonSerializerOptions options)
-		{
-			var info = base.GetTypeInfo(type, options);
-			var toRemove = new List<JsonPropertyInfo>();
-			foreach (var property in info.Properties)
-			{
-				if (property.AttributeProvider is not PropertyInfo propInfo) { continue; }
-				var hasExactIgnore = propInfo
-					.GetCustomAttributes(typeof(IgnoreAttribute), inherit: false)
-					.Any(a => a.GetType() == typeof(IgnoreAttribute));
-				var isBackPointer = BackPointerCollections.Contains((type, propInfo.Name));
-				if (hasExactIgnore || isBackPointer) { toRemove.Add(property); }
-			}
-			foreach (var p in toRemove) { info.Properties.Remove(p); }
-			return info;
-		}
-	}
 }

--- a/src/FantasyFootball.UI/Components/GameViewRow.razor
+++ b/src/FantasyFootball.UI/Components/GameViewRow.razor
@@ -26,6 +26,12 @@
     }
     else if (ShowUndo)
     {
+      <MudIconButton Icon="@Icons.Material.Filled.Replay"
+                     Color="Color.Primary"
+                     Size="Size.Small"
+                     Disabled="Disabled"
+                     OnClick="OnRedo"
+                     title="Re-simulate this game (Ctrl+Y)" />
       <MudIconButton Icon="@Icons.Material.Filled.Undo"
                      Size="Size.Small"
                      Disabled="Disabled"
@@ -42,6 +48,7 @@
   [Parameter] public bool Disabled { get; set; }
   [Parameter] public EventCallback OnSim { get; set; }
   [Parameter] public EventCallback OnUndo { get; set; }
+  [Parameter] public EventCallback OnRedo { get; set; }
 
   bool HasResult => Game.IsFinished;
   bool IsDraw => HasResult && Game.Winner is null;

--- a/src/FantasyFootball.UI/Components/GameViewRow.razor
+++ b/src/FantasyFootball.UI/Components/GameViewRow.razor
@@ -1,6 +1,10 @@
 @using FantasyFootball.Models
 
 <div class="scoreboard-row">
+  <div class="scoreboard-group-tag">
+    <span class="scoreboard-group-tag-letter">@GroupLetter</span>
+    <span class="scoreboard-group-tag-time">@Game.PlayedOn.ToString("HH:mm")</span>
+  </div>
   <div class="scoreboard-team scoreboard-team-home @TeamClass(HomeIsWinner)">
     <span class="scoreboard-team-name">@Game.HomeTeam.Name</span>
     <FlagIcon Team="Game.HomeTeam" Size="24" />
@@ -26,4 +30,16 @@
     isThisSideWinner ? "scoreboard-winner" :
     HasResult && !IsDraw ? "scoreboard-loser" :
     "";
+
+  // Group letter when both teams sit in the same group of the parent stage (group-stage games). KO games span groups → blank.
+  string GroupLetter
+  {
+    get
+    {
+      var stage = Game.Round?.Stage;
+      if (stage is null) { return ""; }
+      var group = stage.Groups.FirstOrDefault(g => g.Teams.Contains(Game.HomeTeam) && g.Teams.Contains(Game.AwayTeam));
+      return group?.Name?.Split(' ', StringSplitOptions.RemoveEmptyEntries).LastOrDefault()?.ToUpperInvariant() ?? "";
+    }
+  }
 }

--- a/src/FantasyFootball.UI/Components/GameViewRow.razor
+++ b/src/FantasyFootball.UI/Components/GameViewRow.razor
@@ -1,6 +1,6 @@
 @using FantasyFootball.Models
 
-<div class="scoreboard-row">
+<div class="scoreboard-row @(IsJustFinished ? "scoreboard-row-just-finished" : "")">
   <div class="scoreboard-group-tag">
     <span class="scoreboard-group-tag-letter">@_groupLetter</span>
     <span class="scoreboard-group-tag-time">@Game.PlayedOn.ToString("HH:mm")</span>
@@ -45,6 +45,7 @@
   [Parameter] public Game Game { get; set; } = null!;
   [Parameter] public bool ShowSim { get; set; }
   [Parameter] public bool ShowUndo { get; set; }
+  [Parameter] public bool IsJustFinished { get; set; }
   [Parameter] public bool Disabled { get; set; }
   [Parameter] public EventCallback OnSim { get; set; }
   [Parameter] public EventCallback OnUndo { get; set; }

--- a/src/FantasyFootball.UI/Components/GameViewRow.razor
+++ b/src/FantasyFootball.UI/Components/GameViewRow.razor
@@ -14,10 +14,34 @@
     <FlagIcon Team="Game.AwayTeam" Size="24" />
     <span class="scoreboard-team-name">@Game.AwayTeam.Name</span>
   </div>
+  <div class="scoreboard-action">
+    @if (ShowSim)
+    {
+      <MudIconButton Icon="@Icons.Material.Filled.PlayArrow"
+                     Color="Color.Primary"
+                     Size="Size.Small"
+                     Disabled="Disabled"
+                     OnClick="OnSim"
+                     title="Simulate this game (Space)" />
+    }
+    else if (ShowUndo)
+    {
+      <MudIconButton Icon="@Icons.Material.Filled.Undo"
+                     Size="Size.Small"
+                     Disabled="Disabled"
+                     OnClick="OnUndo"
+                     title="Undo this game (Ctrl+Z or U)" />
+    }
+  </div>
 </div>
 
 @code {
   [Parameter] public Game Game { get; set; } = null!;
+  [Parameter] public bool ShowSim { get; set; }
+  [Parameter] public bool ShowUndo { get; set; }
+  [Parameter] public bool Disabled { get; set; }
+  [Parameter] public EventCallback OnSim { get; set; }
+  [Parameter] public EventCallback OnUndo { get; set; }
 
   bool HasResult => Game.IsFinished;
   bool IsDraw => HasResult && Game.Winner is null;

--- a/src/FantasyFootball.UI/Components/GameViewRow.razor
+++ b/src/FantasyFootball.UI/Components/GameViewRow.razor
@@ -2,7 +2,7 @@
 
 <div class="scoreboard-row">
   <div class="scoreboard-group-tag">
-    <span class="scoreboard-group-tag-letter">@GroupLetter</span>
+    <span class="scoreboard-group-tag-letter">@_groupLetter</span>
     <span class="scoreboard-group-tag-time">@Game.PlayedOn.ToString("HH:mm")</span>
   </div>
   <div class="scoreboard-team scoreboard-team-home @TeamClass(HomeIsWinner)">
@@ -32,14 +32,13 @@
     "";
 
   // Group letter when both teams sit in the same group of the parent stage (group-stage games). KO games span groups → blank.
-  string GroupLetter
+  string _groupLetter = "";
+
+  protected override void OnParametersSet()
   {
-    get
-    {
-      var stage = Game.Round?.Stage;
-      if (stage is null) { return ""; }
-      var group = stage.Groups.FirstOrDefault(g => g.Teams.Contains(Game.HomeTeam) && g.Teams.Contains(Game.AwayTeam));
-      return group?.Name?.Split(' ', StringSplitOptions.RemoveEmptyEntries).LastOrDefault()?.ToUpperInvariant() ?? "";
-    }
+    var stage = Game.Round?.Stage;
+    if (stage is null) { _groupLetter = ""; return; }
+    var group = stage.Groups.FirstOrDefault(g => g.Teams.Contains(Game.HomeTeam) && g.Teams.Contains(Game.AwayTeam));
+    _groupLetter = group?.Name?.Split(' ', StringSplitOptions.RemoveEmptyEntries).LastOrDefault()?.ToUpperInvariant() ?? "";
   }
 }

--- a/src/FantasyFootball.UI/Components/GroupView.razor
+++ b/src/FantasyFootball.UI/Components/GroupView.razor
@@ -55,7 +55,10 @@
     if (competition is null) { return; }
 
     var ownStageIndex = competition.Stages.IndexOf(Group.Stage);
-    var ownGroupIndex = competition.Groups.IndexOf(Group);
+    // GroupQualifier.GroupId is the index within its OWN stage (per Qualifier.FromGroup), not across all
+    // stages. Today only one stage has groups so competition.Groups.IndexOf would happen to agree; using
+    // the stage-scoped list keeps this honest if a future format ever adds a second group stage.
+    var ownGroupIndex = Group.Stage.Groups.IndexOf(Group);
     if (ownStageIndex < 0 || ownGroupIndex < 0) { return; }
 
     var laterQualifiers = competition.Stages
@@ -71,7 +74,7 @@
       {
         if (q.GroupId == ownGroupIndex) { _directSlots.Add(q.FinalPlacement); }
       }
-      else if (q.ThirdPlaceCombination.Contains(Letter, StringComparison.OrdinalIgnoreCase))
+      else if (q.ThirdPlaceCombination.Split('/').Contains(Letter, StringComparer.OrdinalIgnoreCase))
       {
         _thirdPlaceEligible = true;
       }
@@ -86,7 +89,7 @@
         var advancedIds = laterQualifiers
           .Where(q => !string.IsNullOrEmpty(q.ThirdPlaceCombination))
           .Select(q => q.Get()?.Id)
-          .Where(id => id is not null)
+          .OfType<int>()
           .ToHashSet();
         _thirdPlaceAdvanced = advancedIds.Contains(ownThirdPlaceTeam.Id);
       }

--- a/src/FantasyFootball.UI/Components/GroupView.razor
+++ b/src/FantasyFootball.UI/Components/GroupView.razor
@@ -2,7 +2,7 @@
 
 <div class="group-block">
 <div class="group-letter-heading">@Letter</div>
-<MudTable Items="Group.GetStandings()"
+<MudTable Items="_standings"
           T="TeamRecord"
           Hover="false"
           Dense="true"
@@ -39,12 +39,14 @@
     ? parts[^1].ToUpperInvariant()
     : "?";
 
+  IList<TeamRecord> _standings = [];
   HashSet<int> _directSlots = [];
   bool _thirdPlaceEligible;
   bool? _thirdPlaceAdvanced; // null = stage not finished yet (undetermined), true/false = resolved.
 
   protected override void OnParametersSet()
   {
+    _standings = Group.GetStandings();
     _directSlots = [];
     _thirdPlaceEligible = false;
     _thirdPlaceAdvanced = null;
@@ -78,7 +80,7 @@
     // Once the group stage is finished we can resolve ThirdPlace qualifiers to actual teams. Position 3 then promotes from "no bar" to advance / out.
     if (_thirdPlaceEligible && Group.Stage.IsFinished)
     {
-      var ownThirdPlaceTeam = Group.GetStandings().ElementAtOrDefault(2)?.Team;
+      var ownThirdPlaceTeam = _standings.ElementAtOrDefault(2)?.Team;
       if (ownThirdPlaceTeam is not null)
       {
         var advancedIds = laterQualifiers

--- a/src/FantasyFootball.UI/Components/GroupView.razor
+++ b/src/FantasyFootball.UI/Components/GroupView.razor
@@ -86,11 +86,12 @@
       var ownThirdPlaceTeam = _standings.ElementAtOrDefault(2)?.Team;
       if (ownThirdPlaceTeam is not null)
       {
-        // Reference equality, not Id: nested Team instances inside Competition have Id=0
-        // in the LocalStorage path, so {0}.Contains(0) would falsely mark every group green.
+        // NamedUniqueId.Equals handles both worlds: ReferenceEquals fallback for Id=0 entities
+        // (LocalStorage path — Team instances inside Competition have unset Ids), and Id-equality
+        // for Id>0 entities (future SQLite-backed BlazorWebView host). Stable across both paths.
         _thirdPlaceAdvanced = laterQualifiers
           .Where(q => !string.IsNullOrEmpty(q.ThirdPlaceCombination))
-          .Any(q => ReferenceEquals(q.Get(), ownThirdPlaceTeam));
+          .Any(q => Equals(q.Get(), ownThirdPlaceTeam));
       }
     }
   }

--- a/src/FantasyFootball.UI/Components/GroupView.razor
+++ b/src/FantasyFootball.UI/Components/GroupView.razor
@@ -86,12 +86,11 @@
       var ownThirdPlaceTeam = _standings.ElementAtOrDefault(2)?.Team;
       if (ownThirdPlaceTeam is not null)
       {
-        var advancedIds = laterQualifiers
+        // Reference equality, not Id: nested Team instances inside Competition have Id=0
+        // in the LocalStorage path, so {0}.Contains(0) would falsely mark every group green.
+        _thirdPlaceAdvanced = laterQualifiers
           .Where(q => !string.IsNullOrEmpty(q.ThirdPlaceCombination))
-          .Select(q => q.Get()?.Id)
-          .OfType<int>()
-          .ToHashSet();
-        _thirdPlaceAdvanced = advancedIds.Contains(ownThirdPlaceTeam.Id);
+          .Any(q => ReferenceEquals(q.Get(), ownThirdPlaceTeam));
       }
     }
   }

--- a/src/FantasyFootball.UI/Components/GroupView.razor
+++ b/src/FantasyFootball.UI/Components/GroupView.razor
@@ -1,15 +1,16 @@
 @using FantasyFootball.Models
 
-<div class="group-letter-heading mt-3 mb-1">@Letter</div>
+<div class="group-block">
+<div class="group-letter-heading">@Letter</div>
 <MudTable Items="Group.GetStandings()"
           T="TeamRecord"
           Hover="false"
           Dense="true"
           Breakpoint="Breakpoint.None"
           Elevation="0"
-          Class="mb-3">
+          Class="group-standings">
   <HeaderContent>
-    <MudTh Style="width: 1.5rem;"></MudTh>
+    <MudTh Style="width: 1.5rem; padding-left: 0.75rem;"></MudTh>
     <MudTh Style="width: 2rem;"></MudTh>
     <MudTh></MudTh>
     <MudTh Style="width: 2.5rem; text-align: right;">P</MudTh>
@@ -17,7 +18,10 @@
     <MudTh Style="width: 2.5rem; text-align: right;">Pts</MudTh>
   </HeaderContent>
   <RowTemplate>
-    <MudTd>@context.Position</MudTd>
+    <MudTd Style="position: relative; padding-left: 0.75rem;">
+      <span class="standings-qual-bar @QualBarClass(context.Position)"></span>
+      @context.Position
+    </MudTd>
     <MudTd><FlagIcon Team="context.Team" Size="20" /></MudTd>
     <MudTd>@context.Team.Name</MudTd>
     <MudTd Style="text-align: right;">@context.MatchesPlayed</MudTd>
@@ -25,6 +29,7 @@
     <MudTd Style="text-align: right; font-weight: bold;">@context.Points</MudTd>
   </RowTemplate>
 </MudTable>
+</div>
 
 @code {
   [Parameter] public Group Group { get; set; } = null!;
@@ -33,4 +38,66 @@
   string Letter => Group.Name?.Split(' ', StringSplitOptions.RemoveEmptyEntries) is { Length: > 0 } parts
     ? parts[^1].ToUpperInvariant()
     : "?";
+
+  HashSet<int> _directSlots = [];
+  bool _thirdPlaceEligible;
+  bool? _thirdPlaceAdvanced; // null = stage not finished yet (undetermined), true/false = resolved.
+
+  protected override void OnParametersSet()
+  {
+    _directSlots = [];
+    _thirdPlaceEligible = false;
+    _thirdPlaceAdvanced = null;
+
+    var competition = Group.Stage?.Competition;
+    if (competition is null) { return; }
+
+    var ownStageIndex = competition.Stages.IndexOf(Group.Stage);
+    var ownGroupIndex = competition.Groups.IndexOf(Group);
+    if (ownStageIndex < 0 || ownGroupIndex < 0) { return; }
+
+    var laterQualifiers = competition.Stages
+      .Skip(ownStageIndex + 1)
+      .SelectMany(s => s.Games.OfType<KoGame>())
+      .SelectMany(g => new[] { g.HomeGroupQualifier, g.AwayGroupQualifier })
+      .OfType<GroupQualifier>()
+      .ToList();
+
+    foreach (var q in laterQualifiers)
+    {
+      if (string.IsNullOrEmpty(q.ThirdPlaceCombination))
+      {
+        if (q.GroupId == ownGroupIndex) { _directSlots.Add(q.FinalPlacement); }
+      }
+      else if (q.ThirdPlaceCombination.Contains(Letter, StringComparison.OrdinalIgnoreCase))
+      {
+        _thirdPlaceEligible = true;
+      }
+    }
+
+    // Once the group stage is finished we can resolve ThirdPlace qualifiers to actual teams. Position 3 then promotes from "no bar" to advance / out.
+    if (_thirdPlaceEligible && Group.Stage.IsFinished)
+    {
+      var ownThirdPlaceTeam = Group.GetStandings().ElementAtOrDefault(2)?.Team;
+      if (ownThirdPlaceTeam is not null)
+      {
+        var advancedIds = laterQualifiers
+          .Where(q => !string.IsNullOrEmpty(q.ThirdPlaceCombination))
+          .Select(q => q.Get()?.Id)
+          .Where(id => id is not null)
+          .ToHashSet();
+        _thirdPlaceAdvanced = advancedIds.Contains(ownThirdPlaceTeam.Id);
+      }
+    }
+  }
+
+  // Position referenced unconditionally → green. Position 3 of a 3rd-place-eligible group:
+  // - stage not finished → no bar (fate undetermined).
+  // - stage finished, this group's 3rd place made the cross-group cut → green; else → red.
+  // All other positions → red.
+  string QualBarClass(int position) =>
+    _directSlots.Contains(position) ? "standings-qual-bar-advance" :
+    position == 3 && _thirdPlaceEligible && _thirdPlaceAdvanced is null ? "" :
+    position == 3 && _thirdPlaceEligible && _thirdPlaceAdvanced == true ? "standings-qual-bar-advance" :
+    "standings-qual-bar-out";
 }

--- a/src/FantasyFootball.UI/Components/KeyboardShortcuts.razor
+++ b/src/FantasyFootball.UI/Components/KeyboardShortcuts.razor
@@ -14,7 +14,7 @@
     <tr><td><kbd>T</kbd></td><td>Simulate tournament</td></tr>
     <tr><td><kbd>←</kbd> / <kbd>→</kbd></td><td>Prev / next round</td></tr>
     <tr><td><kbd>↑</kbd> / <kbd>↓</kbd></td><td>Prev / next stage</td></tr>
-    <tr><td><kbd>Ctrl+Z</kbd> / <kbd>U</kbd></td><td>Undo last sim</td></tr>
+    <tr><td><kbd>Ctrl+Z</kbd> / <kbd>U</kbd></td><td>Undo last simulated game</td></tr>
     <tr><td><kbd>Esc</kbd></td><td>Back to competitions</td></tr>
     <tr><td><kbd>H</kbd> / <kbd>?</kbd></td><td>Show this help</td></tr>
   </tbody>

--- a/src/FantasyFootball.UI/Components/KeyboardShortcuts.razor
+++ b/src/FantasyFootball.UI/Components/KeyboardShortcuts.razor
@@ -16,6 +16,6 @@
     <tr><td><kbd>↑</kbd> / <kbd>↓</kbd></td><td>Prev / next stage</td></tr>
     <tr><td><kbd>Ctrl+Z</kbd> / <kbd>U</kbd></td><td>Undo last sim (coming soon)</td></tr>
     <tr><td><kbd>Esc</kbd></td><td>Back to competitions</td></tr>
-    <tr><td><kbd>?</kbd></td><td>Show this help</td></tr>
+    <tr><td><kbd>H</kbd> / <kbd>?</kbd></td><td>Show this help</td></tr>
   </tbody>
 </MudSimpleTable>

--- a/src/FantasyFootball.UI/Components/KeyboardShortcuts.razor
+++ b/src/FantasyFootball.UI/Components/KeyboardShortcuts.razor
@@ -10,7 +10,6 @@
   <tbody>
     <tr><td><kbd>Space</kbd></td><td>Simulate next game</td></tr>
     <tr><td><kbd>R</kbd> / <kbd>Shift+Space</kbd></td><td>Simulate round</td></tr>
-    <tr><td><kbd>S</kbd></td><td>Simulate stage</td></tr>
     <tr><td><kbd>T</kbd></td><td>Simulate tournament</td></tr>
     <tr><td><kbd>←</kbd> / <kbd>→</kbd></td><td>Prev / next round</td></tr>
     <tr><td><kbd>↑</kbd> / <kbd>↓</kbd></td><td>Prev / next stage</td></tr>

--- a/src/FantasyFootball.UI/Components/KeyboardShortcuts.razor
+++ b/src/FantasyFootball.UI/Components/KeyboardShortcuts.razor
@@ -14,7 +14,7 @@
     <tr><td><kbd>T</kbd></td><td>Simulate tournament</td></tr>
     <tr><td><kbd>←</kbd> / <kbd>→</kbd></td><td>Prev / next round</td></tr>
     <tr><td><kbd>↑</kbd> / <kbd>↓</kbd></td><td>Prev / next stage</td></tr>
-    <tr><td><kbd>Ctrl+Z</kbd> / <kbd>U</kbd></td><td>Undo last sim (coming soon)</td></tr>
+    <tr><td><kbd>Ctrl+Z</kbd> / <kbd>U</kbd></td><td>Undo last sim</td></tr>
     <tr><td><kbd>Esc</kbd></td><td>Back to competitions</td></tr>
     <tr><td><kbd>H</kbd> / <kbd>?</kbd></td><td>Show this help</td></tr>
   </tbody>

--- a/src/FantasyFootball.UI/Components/KeyboardShortcuts.razor
+++ b/src/FantasyFootball.UI/Components/KeyboardShortcuts.razor
@@ -13,6 +13,7 @@
     <tr><td><kbd>T</kbd></td><td>Simulate tournament</td></tr>
     <tr><td><kbd>←</kbd> / <kbd>→</kbd></td><td>Prev / next round</td></tr>
     <tr><td><kbd>↑</kbd> / <kbd>↓</kbd></td><td>Prev / next stage</td></tr>
+    <tr><td><kbd>Ctrl+Y</kbd></td><td>Re-simulate last game (replace result)</td></tr>
     <tr><td><kbd>Ctrl+Z</kbd> / <kbd>U</kbd></td><td>Undo last simulated game</td></tr>
     <tr><td><kbd>Esc</kbd></td><td>Back to competitions</td></tr>
     <tr><td><kbd>H</kbd> / <kbd>?</kbd></td><td>Show this help</td></tr>

--- a/src/FantasyFootball.UI/Components/KeyboardShortcuts.razor
+++ b/src/FantasyFootball.UI/Components/KeyboardShortcuts.razor
@@ -1,0 +1,21 @@
+@* Keyboard shortcut reference table. Shared between /about and the in-page help overlay on the competition detail page. *@
+
+<MudSimpleTable Dense="true" Hover="false" Bordered="false" Striped="true" Style="max-width: 32rem;">
+  <thead>
+    <tr>
+      <th style="width: 9rem;">Key</th>
+      <th>Action</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr><td><kbd>Space</kbd></td><td>Simulate next game</td></tr>
+    <tr><td><kbd>R</kbd> / <kbd>Shift+Space</kbd></td><td>Simulate round</td></tr>
+    <tr><td><kbd>S</kbd></td><td>Simulate stage</td></tr>
+    <tr><td><kbd>T</kbd></td><td>Simulate tournament</td></tr>
+    <tr><td><kbd>←</kbd> / <kbd>→</kbd></td><td>Prev / next round</td></tr>
+    <tr><td><kbd>↑</kbd> / <kbd>↓</kbd></td><td>Prev / next stage</td></tr>
+    <tr><td><kbd>Ctrl+Z</kbd> / <kbd>U</kbd></td><td>Undo last sim (coming soon)</td></tr>
+    <tr><td><kbd>Esc</kbd></td><td>Back to competitions</td></tr>
+    <tr><td><kbd>?</kbd></td><td>Show this help</td></tr>
+  </tbody>
+</MudSimpleTable>

--- a/src/FantasyFootball.UI/Pages/About.razor
+++ b/src/FantasyFootball.UI/Pages/About.razor
@@ -1,4 +1,5 @@
 @page "/about"
+@using FantasyFootball.UI.Components
 
 <PageTitle>About — Fantasy Football</PageTitle>
 
@@ -14,27 +15,9 @@
   <div>
     <MudText Typo="Typo.subtitle1" Class="mb-2"><strong>Keyboard shortcuts</strong></MudText>
     <MudText Typo="Typo.body2" Color="Color.Secondary" Class="mb-3">
-      Documented here; will become active once keyboard navigation lands (planned for PR 3).
+      Active on the competition detail page. Press <kbd>?</kbd> there to open this list as an overlay.
     </MudText>
-    <MudSimpleTable Dense="true" Hover="false" Bordered="false" Striped="true" Style="max-width: 32rem;">
-      <thead>
-        <tr>
-          <th style="width: 9rem;">Key</th>
-          <th>Action</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr><td><kbd>Space</kbd></td><td>Simulate next game</td></tr>
-        <tr><td><kbd>R</kbd> / <kbd>Shift+Space</kbd></td><td>Simulate round</td></tr>
-        <tr><td><kbd>S</kbd></td><td>Simulate stage</td></tr>
-        <tr><td><kbd>T</kbd></td><td>Simulate tournament</td></tr>
-        <tr><td><kbd>←</kbd> / <kbd>→</kbd></td><td>Prev / next round</td></tr>
-        <tr><td><kbd>↑</kbd> / <kbd>↓</kbd></td><td>Prev / next stage</td></tr>
-        <tr><td><kbd>Ctrl+Z</kbd> / <kbd>U</kbd></td><td>Undo last sim</td></tr>
-        <tr><td><kbd>Esc</kbd></td><td>Back to competitions</td></tr>
-        <tr><td><kbd>?</kbd></td><td>Show this help</td></tr>
-      </tbody>
-    </MudSimpleTable>
+    <KeyboardShortcuts />
   </div>
 
   <div>

--- a/src/FantasyFootball.UI/Pages/CompetitionDetail.razor
+++ b/src/FantasyFootball.UI/Pages/CompetitionDetail.razor
@@ -122,6 +122,7 @@ else
                 <GameViewRow Game="game"
                              ShowSim="@(ReferenceEquals(game, currentGame))"
                              ShowUndo="@(ReferenceEquals(game, undoTargetGame))"
+                             IsJustFinished="@(ReferenceEquals(game, ViewModel.RecentlyFinishedGame))"
                              Disabled="@ViewModel.IsBusy"
                              OnSim="@(async () => await ViewModel.SimulateGame())"
                              OnUndo="@(() => ViewModel.Undo())"

--- a/src/FantasyFootball.UI/Pages/CompetitionDetail.razor
+++ b/src/FantasyFootball.UI/Pages/CompetitionDetail.razor
@@ -36,10 +36,6 @@ else
           Winner: @ViewModel.Winner.Name
         </MudChip>
       }
-      <MudSpacer />
-      <MudIconButton Icon="@Icons.Material.Filled.Delete"
-                     Color="Color.Error"
-                     OnClick="DeleteAndExit" />
     </MudStack>
 
     @if (!ViewModel.IsFinished)
@@ -161,13 +157,6 @@ else
   }
 
   void OnVmChanged(object? sender, EventArgs e) => InvokeAsync(StateHasChanged);
-
-  void DeleteAndExit()
-  {
-    // TODO: confirmation dialog before destroy.
-    ViewModel.Delete();
-    Nav.NavigateTo("/competitions");
-  }
 
   public void Dispose() => ViewModel.PropertyChanged -= OnVmChanged;
 }

--- a/src/FantasyFootball.UI/Pages/CompetitionDetail.razor
+++ b/src/FantasyFootball.UI/Pages/CompetitionDetail.razor
@@ -5,6 +5,7 @@
 @using FantasyFootball.UI.ViewModels
 @inject CompetitionDetailViewModel ViewModel
 @inject NavigationManager Nav
+@inject IJSRuntime JS
 @implements IDisposable
 
 <PageTitle>@(ViewModel.Competition?.ShortName ?? "Competition") — Fantasy Football</PageTitle>
@@ -72,6 +73,10 @@ else
           <MudProgressCircular Size="Size.Small" Indeterminate="true" />
         }
         <MudSpacer />
+        <MudIconButton Icon="@Icons.Material.Filled.Keyboard"
+                       Size="Size.Small"
+                       OnClick="@(() => _helpOpen = true)"
+                       title="Keyboard shortcuts (H or ?)" />
         <MudToggleGroup T="SimulationSpeed"
                         Value="ViewModel.Speed"
                         ValueChanged="@((SimulationSpeed v) => ViewModel.Speed = v)"
@@ -184,7 +189,12 @@ else
 
   protected override async Task OnAfterRenderAsync(bool firstRender)
   {
-    if (firstRender) { await _pageRoot.FocusAsync(); }
+    if (firstRender)
+    {
+      // Suppress browser scroll defaults for Space + arrows on the page root, then focus it.
+      await JS.InvokeVoidAsync("ffKeyboard.registerPreventScroll", _pageRoot);
+      await _pageRoot.FocusAsync();
+    }
   }
 
   void OnVmChanged(object? sender, EventArgs e) => InvokeAsync(StateHasChanged);
@@ -195,7 +205,8 @@ else
   {
     if (ViewModel.IsBusy || ViewModel.Competition is null) { return; }
 
-    if (e.Key == "?") { _helpOpen = !_helpOpen; return; }
+    // H or ? toggles the help overlay. H works on every layout; ? is awkward on de-DE (Shift+ß).
+    if (e.Key is "?" or "h" or "H") { _helpOpen = !_helpOpen; return; }
     if (_helpOpen && e.Key == "Escape") { _helpOpen = false; return; }
 
     if (!ViewModel.IsFinished)

--- a/src/FantasyFootball.UI/Pages/CompetitionDetail.razor
+++ b/src/FantasyFootball.UI/Pages/CompetitionDetail.razor
@@ -124,7 +124,8 @@ else
                              ShowUndo="@(ReferenceEquals(game, undoTargetGame))"
                              Disabled="@ViewModel.IsBusy"
                              OnSim="@(async () => await ViewModel.SimulateGame())"
-                             OnUndo="@(() => ViewModel.Undo())" />
+                             OnUndo="@(() => ViewModel.Undo())"
+                             OnRedo="@(async () => await ViewModel.RedoLastGame())" />
               }
             }
           }
@@ -234,6 +235,12 @@ else
     if ((ctrlKey && key is "z" or "Z") || (!ctrlKey && key is "u" or "U"))
     {
       ViewModel.Undo();
+      return;
+    }
+
+    if (ctrlKey && key is "y" or "Y")
+    {
+      await ViewModel.RedoLastGame();
       return;
     }
 

--- a/src/FantasyFootball.UI/Pages/CompetitionDetail.razor
+++ b/src/FantasyFootball.UI/Pages/CompetitionDetail.razor
@@ -10,8 +10,6 @@
 
 <PageTitle>@(ViewModel.Competition?.ShortName ?? "Competition") — Fantasy Football</PageTitle>
 
-<div>
-
 <MudButton Href="/competitions"
            StartIcon="@Icons.Material.Filled.ArrowBack"
            Variant="Variant.Text"
@@ -177,8 +175,6 @@ else
     <KeyboardShortcuts />
   </MudPaper>
 </MudOverlay>
-
-</div>
 
 @code {
   [Parameter] public int Id { get; set; }

--- a/src/FantasyFootball.UI/Pages/CompetitionDetail.razor
+++ b/src/FantasyFootball.UI/Pages/CompetitionDetail.razor
@@ -6,11 +6,11 @@
 @inject CompetitionDetailViewModel ViewModel
 @inject NavigationManager Nav
 @inject IJSRuntime JS
-@implements IDisposable
+@implements IAsyncDisposable
 
 <PageTitle>@(ViewModel.Competition?.ShortName ?? "Competition") — Fantasy Football</PageTitle>
 
-<div tabindex="0" @ref="_pageRoot" @onkeydown="HandleKey" style="outline: none;">
+<div>
 
 <MudButton Href="/competitions"
            StartIcon="@Icons.Material.Filled.ArrowBack"
@@ -182,8 +182,8 @@ else
   [Parameter] public int Id { get; set; }
 
   int? _lastLoadedId;
-  ElementReference _pageRoot;
   bool _helpOpen;
+  DotNetObjectReference<CompetitionDetail>? _selfRef;
 
   protected override void OnInitialized() => ViewModel.PropertyChanged += OnVmChanged;
 
@@ -198,24 +198,25 @@ else
   {
     if (firstRender)
     {
-      // Suppress browser scroll defaults for Space + arrows on the page root, then focus it.
-      await JS.InvokeVoidAsync("ffKeyboard.registerPreventScroll", _pageRoot);
-      await _pageRoot.FocusAsync();
+      // Document-level keydown forwarder. Listening on document (not the page root div) means Space + arrows
+      // work without the user clicking into the page first; the JS side skips when focus is on an input.
+      _selfRef = DotNetObjectReference.Create(this);
+      await JS.InvokeVoidAsync("ffKeyboard.registerDocumentHandler", _selfRef);
     }
   }
 
   void OnVmChanged(object? sender, EventArgs e) => InvokeAsync(StateHasChanged);
 
-  // Page-level keyboard handler. CompetitionDetail has no text inputs, so we don't filter by event target.
-  // Sim keys no-op once a tournament has finished; nav keys remain available.
-  async Task HandleKey(Microsoft.AspNetCore.Components.Web.KeyboardEventArgs e)
+  // Invoked by the document-level JS keydown listener. Sim keys no-op once finished; nav keys remain.
+  [JSInvokable]
+  public async Task OnKeyDown(string key, bool ctrlKey, bool shiftKey)
   {
     // Overlay keys ABOVE the IsBusy gate — user must always be able to open / close help, even while a sim runs.
     // H or ? toggles. H works on every layout; ? is awkward on de-DE (Shift+ß).
-    if (e.Key is "?" or "h" or "H") { _helpOpen = !_helpOpen; return; }
+    if (key is "?" or "h" or "H") { _helpOpen = !_helpOpen; StateHasChanged(); return; }
     if (_helpOpen)
     {
-      if (e.Key == "Escape") { _helpOpen = false; }
+      if (key == "Escape") { _helpOpen = false; StateHasChanged(); }
       // Swallow everything else while the overlay is up — no sim shortcuts firing behind it.
       return;
     }
@@ -224,20 +225,20 @@ else
 
     if (!ViewModel.IsFinished)
     {
-      if (e.Key == " " && e.ShiftKey) { await ViewModel.SimulateRound(); return; }
-      if (e.Key == " ") { await ViewModel.SimulateGame(); return; }
-      if (e.Key is "r" or "R") { await ViewModel.SimulateRound(); return; }
-      if (e.Key is "t" or "T") { await ViewModel.SimulateAll(); return; }
+      if (key == " " && shiftKey) { await ViewModel.SimulateRound(); return; }
+      if (key == " ") { await ViewModel.SimulateGame(); return; }
+      if (key is "r" or "R") { await ViewModel.SimulateRound(); return; }
+      if (key is "t" or "T") { await ViewModel.SimulateAll(); return; }
     }
 
-    if ((e.CtrlKey && e.Key is "z" or "Z") || (!e.CtrlKey && e.Key is "u" or "U"))
+    if ((ctrlKey && key is "z" or "Z") || (!ctrlKey && key is "u" or "U"))
     {
       ViewModel.Undo();
       return;
     }
 
     // Prev/next round wraps within the current stage; prev/next stage wraps within the competition.
-    switch (e.Key)
+    switch (key)
     {
       case "ArrowLeft": StepRound(-1); break;
       case "ArrowRight": StepRound(+1); break;
@@ -265,5 +266,15 @@ else
     ViewModel.SelectedStage = stages[(i + delta + stages.Count) % stages.Count];
   }
 
-  public void Dispose() => ViewModel.PropertyChanged -= OnVmChanged;
+  public async ValueTask DisposeAsync()
+  {
+    ViewModel.PropertyChanged -= OnVmChanged;
+    if (_selfRef is not null)
+    {
+      try { await JS.InvokeVoidAsync("ffKeyboard.unregisterDocumentHandler"); }
+      catch (JSDisconnectedException) { /* Page navigated away; the listener's gone with it. */ }
+      _selfRef.Dispose();
+      _selfRef = null;
+    }
+  }
 }

--- a/src/FantasyFootball.UI/Pages/CompetitionDetail.razor
+++ b/src/FantasyFootball.UI/Pages/CompetitionDetail.razor
@@ -206,11 +206,17 @@ else
   // Sim keys no-op once a tournament has finished; nav keys remain available.
   async Task HandleKey(Microsoft.AspNetCore.Components.Web.KeyboardEventArgs e)
   {
-    if (ViewModel.IsBusy || ViewModel.Competition is null) { return; }
-
-    // H or ? toggles the help overlay. H works on every layout; ? is awkward on de-DE (Shift+ß).
+    // Overlay keys ABOVE the IsBusy gate — user must always be able to open / close help, even while a sim runs.
+    // H or ? toggles. H works on every layout; ? is awkward on de-DE (Shift+ß).
     if (e.Key is "?" or "h" or "H") { _helpOpen = !_helpOpen; return; }
-    if (_helpOpen && e.Key == "Escape") { _helpOpen = false; return; }
+    if (_helpOpen)
+    {
+      if (e.Key == "Escape") { _helpOpen = false; }
+      // Swallow everything else while the overlay is up — no sim shortcuts firing behind it.
+      return;
+    }
+
+    if (ViewModel.IsBusy || ViewModel.Competition is null) { return; }
 
     if (!ViewModel.IsFinished)
     {

--- a/src/FantasyFootball.UI/Pages/CompetitionDetail.razor
+++ b/src/FantasyFootball.UI/Pages/CompetitionDetail.razor
@@ -33,71 +33,30 @@ else
       <MudText Typo="Typo.h5" HtmlTag="h1">
         @ViewModel.Competition.ShortName <span style="opacity: 0.6;">#@ViewModel.Competition.Id</span>
       </MudText>
+      @if (!ViewModel.IsFinished)
+      {
+        <MudIconButton Icon="@Icons.Material.Filled.DoubleArrow"
+                       Size="Size.Small"
+                       OnClick="@(async () => await ViewModel.SimulateAll())"
+                       Disabled="ViewModel.IsBusy"
+                       title="Simulate tournament (T)" />
+      }
+      @if (ViewModel.IsBusy)
+      {
+        <MudProgressCircular Size="Size.Small" Indeterminate="true" />
+      }
       @if (ViewModel.IsFinished && ViewModel.Winner is not null)
       {
         <MudChip T="string" Color="Color.Success" Icon="@Icons.Material.Filled.EmojiEvents" Size="Size.Small">
           Winner: @ViewModel.Winner.Name
         </MudChip>
       }
+      <MudSpacer />
+      <MudIconButton Icon="@Icons.Material.Filled.Keyboard"
+                     Size="Size.Small"
+                     OnClick="@(() => _helpOpen = true)"
+                     title="Quick settings &amp; keyboard shortcuts (H or ?)" />
     </MudStack>
-
-    @if (!ViewModel.IsFinished)
-    {
-      <MudStack Row="true" Spacing="2" Wrap="Wrap.Wrap" AlignItems="AlignItems.Center">
-        <MudButton Variant="Variant.Filled" Color="Color.Primary"
-                   StartIcon="@Icons.Material.Filled.PlayArrow"
-                   OnClick="@(async () => await ViewModel.SimulateGame())"
-                   Disabled="ViewModel.IsBusy">
-          Game
-        </MudButton>
-        <MudButton Variant="Variant.Outlined"
-                   StartIcon="@Icons.Material.Filled.SkipNext"
-                   OnClick="@(async () => await ViewModel.SimulateRound())"
-                   Disabled="ViewModel.IsBusy">
-          Round
-        </MudButton>
-        <MudButton Variant="Variant.Outlined"
-                   StartIcon="@Icons.Material.Filled.FastForward"
-                   OnClick="@(async () => await ViewModel.SimulateStage())"
-                   Disabled="ViewModel.IsBusy">
-          Stage
-        </MudButton>
-        <MudButton Variant="Variant.Outlined"
-                   StartIcon="@Icons.Material.Filled.DoubleArrow"
-                   OnClick="@(async () => await ViewModel.SimulateAll())"
-                   Disabled="ViewModel.IsBusy">
-          Tournament
-        </MudButton>
-        <MudIconButton Icon="@Icons.Material.Filled.Undo"
-                       Size="Size.Small"
-                       OnClick="@(() => ViewModel.Undo())"
-                       Disabled="@(!ViewModel.CanUndo || ViewModel.IsBusy)"
-                       title="Undo last simulated game (Ctrl+Z or U)" />
-        @if (ViewModel.IsBusy)
-        {
-          <MudProgressCircular Size="Size.Small" Indeterminate="true" />
-        }
-        <MudSpacer />
-        <MudIconButton Icon="@Icons.Material.Filled.Keyboard"
-                       Size="Size.Small"
-                       OnClick="@(() => _helpOpen = true)"
-                       title="Keyboard shortcuts (H or ?)" />
-        <MudToggleGroup T="SimulationSpeed"
-                        Value="ViewModel.Speed"
-                        ValueChanged="@((SimulationSpeed v) => ViewModel.Speed = v)"
-                        Size="Size.Small"
-                        Color="Color.Primary"
-                        CheckMark="false"
-                        SelectionMode="SelectionMode.SingleSelection"
-                        Disabled="ViewModel.IsBusy"
-                        title="Simulation speed (overrides Settings for this session)">
-          <MudToggleItem Value="SimulationSpeed.Slow" Text="🐢" />
-          <MudToggleItem Value="SimulationSpeed.Normal" Text="▶" />
-          <MudToggleItem Value="SimulationSpeed.Fast" Text="🐇" />
-          <MudToggleItem Value="SimulationSpeed.Instant" Text="⚡" />
-        </MudToggleGroup>
-      </MudStack>
-    }
 
     <MudGrid Spacing="2">
       <MudItem xs="12" sm="6">
@@ -131,11 +90,23 @@ else
     <MudGrid Spacing="3">
       <MudItem xs="12" md="7">
         <MudPaper Class="pa-3" Elevation="1">
-          <MudText Typo="Typo.h6" GutterBottom="true">Games</MudText>
+          <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1" Class="mb-2">
+            <MudText Typo="Typo.h6">Games</MudText>
+            @if (!ViewModel.IsFinished && ViewModel.SelectedRound is not null)
+            {
+              <MudIconButton Icon="@Icons.Material.Filled.SkipNext"
+                             Size="Size.Small"
+                             OnClick="@(async () => await ViewModel.SimulateRound())"
+                             Disabled="ViewModel.IsBusy"
+                             title="Simulate round (R or Shift+Space)" />
+            }
+          </MudStack>
           @if (ViewModel.SelectedRound is not null)
           {
             var games = ViewModel.SelectedRound.AllGames.OrderBy(g => g.PlayedOn).ToList();
             var multiDay = games.Select(g => g.PlayedOn.Date).Distinct().Count() > 1;
+            var currentGameId = ViewModel.Competition?.CurrentGame?.Id;
+            var undoTargetGameId = ViewModel.UndoTargetGameId;
             @foreach (var dayGroup in games.GroupBy(g => g.PlayedOn.Date))
             {
               @if (multiDay)
@@ -144,7 +115,12 @@ else
               }
               @foreach (var game in dayGroup)
               {
-                <GameViewRow Game="game" />
+                <GameViewRow Game="game"
+                             ShowSim="@(game.Id == currentGameId)"
+                             ShowUndo="@(game.Id == undoTargetGameId)"
+                             Disabled="@ViewModel.IsBusy"
+                             OnSim="@(async () => await ViewModel.SimulateGame())"
+                             OnUndo="@(() => ViewModel.Undo())" />
               }
             }
           }
@@ -164,12 +140,34 @@ else
 }
 
 <MudOverlay Visible="_helpOpen" DarkBackground="true" ZIndex="9999" @onclick="@(() => _helpOpen = false)">
-  <MudPaper Class="pa-4" Elevation="6" @onclick:stopPropagation="true">
-    <MudStack Row="true" AlignItems="AlignItems.Center" Class="mb-2">
-      <MudText Typo="Typo.h6">Keyboard shortcuts</MudText>
+  <MudPaper Class="pa-4" Elevation="6" Style="max-width: 36rem;" @onclick:stopPropagation="true">
+    <MudStack Row="true" AlignItems="AlignItems.Center" Class="mb-3">
+      <MudText Typo="Typo.h6">Quick settings &amp; shortcuts</MudText>
       <MudSpacer />
       <MudIconButton Icon="@Icons.Material.Filled.Close" Size="Size.Small" OnClick="@(() => _helpOpen = false)" />
     </MudStack>
+
+    <MudText Typo="Typo.subtitle2" Class="mb-2">Simulation speed</MudText>
+    <MudToggleGroup T="SimulationSpeed"
+                    Value="ViewModel.Speed"
+                    ValueChanged="@((SimulationSpeed v) => ViewModel.Speed = v)"
+                    Size="Size.Small"
+                    Color="Color.Primary"
+                    CheckMark="false"
+                    SelectionMode="SelectionMode.SingleSelection"
+                    Disabled="ViewModel.IsBusy">
+      <MudToggleItem Value="SimulationSpeed.Slow" Text="🐢 Slow" />
+      <MudToggleItem Value="SimulationSpeed.Normal" Text="▶ Normal" />
+      <MudToggleItem Value="SimulationSpeed.Fast" Text="🐇 Fast" />
+      <MudToggleItem Value="SimulationSpeed.Instant" Text="⚡ Instant" />
+    </MudToggleGroup>
+    <MudText Typo="Typo.caption" Color="Color.Secondary" Class="mt-1 d-block">
+      Overrides the global Settings default for this session.
+    </MudText>
+
+    <MudDivider Class="my-3" />
+
+    <MudText Typo="Typo.subtitle2" Class="mb-2">Keyboard shortcuts</MudText>
     <KeyboardShortcuts />
   </MudPaper>
 </MudOverlay>
@@ -219,7 +217,6 @@ else
       if (e.Key == " " && e.ShiftKey) { await ViewModel.SimulateRound(); return; }
       if (e.Key == " ") { await ViewModel.SimulateGame(); return; }
       if (e.Key is "r" or "R") { await ViewModel.SimulateRound(); return; }
-      if (e.Key is "s" or "S") { await ViewModel.SimulateStage(); return; }
       if (e.Key is "t" or "T") { await ViewModel.SimulateAll(); return; }
     }
 

--- a/src/FantasyFootball.UI/Pages/CompetitionDetail.razor
+++ b/src/FantasyFootball.UI/Pages/CompetitionDetail.razor
@@ -72,7 +72,7 @@ else
                        Size="Size.Small"
                        OnClick="@(() => ViewModel.Undo())"
                        Disabled="@(!ViewModel.CanUndo || ViewModel.IsBusy)"
-                       title="Undo last sim (Ctrl+Z or U)" />
+                       title="Undo last simulated game (Ctrl+Z or U)" />
         @if (ViewModel.IsBusy)
         {
           <MudProgressCircular Size="Size.Small" Indeterminate="true" />

--- a/src/FantasyFootball.UI/Pages/CompetitionDetail.razor
+++ b/src/FantasyFootball.UI/Pages/CompetitionDetail.razor
@@ -68,6 +68,11 @@ else
                    Disabled="ViewModel.IsBusy">
           Tournament
         </MudButton>
+        <MudIconButton Icon="@Icons.Material.Filled.Undo"
+                       Size="Size.Small"
+                       OnClick="@(() => ViewModel.Undo())"
+                       Disabled="@(!ViewModel.CanUndo || ViewModel.IsBusy)"
+                       title="Undo last sim (Ctrl+Z or U)" />
         @if (ViewModel.IsBusy)
         {
           <MudProgressCircular Size="Size.Small" Indeterminate="true" />
@@ -216,6 +221,12 @@ else
       if (e.Key is "r" or "R") { await ViewModel.SimulateRound(); return; }
       if (e.Key is "s" or "S") { await ViewModel.SimulateStage(); return; }
       if (e.Key is "t" or "T") { await ViewModel.SimulateAll(); return; }
+    }
+
+    if ((e.CtrlKey && e.Key is "z" or "Z") || (!e.CtrlKey && e.Key is "u" or "U"))
+    {
+      ViewModel.Undo();
+      return;
     }
 
     // Prev/next round wraps within the current stage; prev/next stage wraps within the competition.

--- a/src/FantasyFootball.UI/Pages/CompetitionDetail.razor
+++ b/src/FantasyFootball.UI/Pages/CompetitionDetail.razor
@@ -9,6 +9,8 @@
 
 <PageTitle>@(ViewModel.Competition?.ShortName ?? "Competition") — Fantasy Football</PageTitle>
 
+<div tabindex="0" @ref="_pageRoot" @onkeydown="HandleKey" style="outline: none;">
+
 <MudButton Href="/competitions"
            StartIcon="@Icons.Material.Filled.ArrowBack"
            Variant="Variant.Text"
@@ -151,10 +153,25 @@ else
   </MudStack>
 }
 
+<MudOverlay Visible="_helpOpen" DarkBackground="true" ZIndex="9999" @onclick="@(() => _helpOpen = false)">
+  <MudPaper Class="pa-4" Elevation="6" @onclick:stopPropagation="true">
+    <MudStack Row="true" AlignItems="AlignItems.Center" Class="mb-2">
+      <MudText Typo="Typo.h6">Keyboard shortcuts</MudText>
+      <MudSpacer />
+      <MudIconButton Icon="@Icons.Material.Filled.Close" Size="Size.Small" OnClick="@(() => _helpOpen = false)" />
+    </MudStack>
+    <KeyboardShortcuts />
+  </MudPaper>
+</MudOverlay>
+
+</div>
+
 @code {
   [Parameter] public int Id { get; set; }
 
   int? _lastLoadedId;
+  ElementReference _pageRoot;
+  bool _helpOpen;
 
   protected override void OnInitialized() => ViewModel.PropertyChanged += OnVmChanged;
 
@@ -165,7 +182,59 @@ else
     ViewModel.Load(Id);
   }
 
+  protected override async Task OnAfterRenderAsync(bool firstRender)
+  {
+    if (firstRender) { await _pageRoot.FocusAsync(); }
+  }
+
   void OnVmChanged(object? sender, EventArgs e) => InvokeAsync(StateHasChanged);
+
+  // Page-level keyboard handler. CompetitionDetail has no text inputs, so we don't filter by event target.
+  // Sim keys no-op once a tournament has finished; nav keys remain available.
+  async Task HandleKey(Microsoft.AspNetCore.Components.Web.KeyboardEventArgs e)
+  {
+    if (ViewModel.IsBusy || ViewModel.Competition is null) { return; }
+
+    if (e.Key == "?") { _helpOpen = !_helpOpen; return; }
+    if (_helpOpen && e.Key == "Escape") { _helpOpen = false; return; }
+
+    if (!ViewModel.IsFinished)
+    {
+      if (e.Key == " " && e.ShiftKey) { await ViewModel.SimulateRound(); return; }
+      if (e.Key == " ") { await ViewModel.SimulateGame(); return; }
+      if (e.Key is "r" or "R") { await ViewModel.SimulateRound(); return; }
+      if (e.Key is "s" or "S") { await ViewModel.SimulateStage(); return; }
+      if (e.Key is "t" or "T") { await ViewModel.SimulateAll(); return; }
+    }
+
+    // Prev/next round wraps within the current stage; prev/next stage wraps within the competition.
+    switch (e.Key)
+    {
+      case "ArrowLeft": StepRound(-1); break;
+      case "ArrowRight": StepRound(+1); break;
+      case "ArrowUp": StepStage(-1); break;
+      case "ArrowDown": StepStage(+1); break;
+      case "Escape": Nav.NavigateTo("/competitions"); break;
+    }
+  }
+
+  void StepRound(int delta)
+  {
+    var rounds = ViewModel.Rounds;
+    if (rounds.Count == 0 || ViewModel.SelectedRound is null) { return; }
+    var i = rounds.IndexOf(ViewModel.SelectedRound);
+    if (i < 0) { return; }
+    ViewModel.SelectedRound = rounds[(i + delta + rounds.Count) % rounds.Count];
+  }
+
+  void StepStage(int delta)
+  {
+    var stages = ViewModel.Stages;
+    if (stages.Count == 0 || ViewModel.SelectedStage is null) { return; }
+    var i = stages.IndexOf(ViewModel.SelectedStage);
+    if (i < 0) { return; }
+    ViewModel.SelectedStage = stages[(i + delta + stages.Count) % stages.Count];
+  }
 
   public void Dispose() => ViewModel.PropertyChanged -= OnVmChanged;
 }

--- a/src/FantasyFootball.UI/Pages/CompetitionDetail.razor
+++ b/src/FantasyFootball.UI/Pages/CompetitionDetail.razor
@@ -122,9 +122,18 @@ else
           <MudText Typo="Typo.h6" GutterBottom="true">Games</MudText>
           @if (ViewModel.SelectedRound is not null)
           {
-            foreach (var game in ViewModel.SelectedRound.AllGames.OrderBy(g => g.PlayedOn))
+            var games = ViewModel.SelectedRound.AllGames.OrderBy(g => g.PlayedOn).ToList();
+            var multiDay = games.Select(g => g.PlayedOn.Date).Distinct().Count() > 1;
+            @foreach (var dayGroup in games.GroupBy(g => g.PlayedOn.Date))
             {
-              <GameViewRow Game="game" />
+              @if (multiDay)
+              {
+                <div class="game-day-divider">@dayGroup.Key.ToString("ddd d MMM", System.Globalization.CultureInfo.InvariantCulture)</div>
+              }
+              @foreach (var game in dayGroup)
+              {
+                <GameViewRow Game="game" />
+              }
             }
           }
         </MudPaper>

--- a/src/FantasyFootball.UI/Pages/CompetitionDetail.razor
+++ b/src/FantasyFootball.UI/Pages/CompetitionDetail.razor
@@ -128,7 +128,7 @@ else
             {
               @if (multiDay)
               {
-                <div class="game-day-divider">@dayGroup.Key.ToString("ddd d MMM", System.Globalization.CultureInfo.InvariantCulture)</div>
+                <div class="game-day-divider">@dayGroup.Key.ToString("ddd d MMM", System.Globalization.CultureInfo.CurrentCulture)</div>
               }
               @foreach (var game in dayGroup)
               {

--- a/src/FantasyFootball.UI/Pages/CompetitionDetail.razor
+++ b/src/FantasyFootball.UI/Pages/CompetitionDetail.razor
@@ -105,8 +105,12 @@ else
           {
             var games = ViewModel.SelectedRound.AllGames.OrderBy(g => g.PlayedOn).ToList();
             var multiDay = games.Select(g => g.PlayedOn.Date).Distinct().Count() > 1;
-            var currentGameId = ViewModel.Competition?.CurrentGame?.Id;
-            var undoTargetGameId = ViewModel.UndoTargetGameId;
+            // Reference-compare, not Id-compare: nested entities in the LocalStorage path keep Id=0
+            // (LocalStorageRepository only assigns IDs to aggregate roots), so `game.Id == X.Id` is true
+            // for every row when X.Id is also 0. Reference equality works because both sides come from
+            // the live Competition graph rendered this pass.
+            var currentGame = ViewModel.Competition?.CurrentGame;
+            var undoTargetGame = ViewModel.UndoTargetGame;
             @foreach (var dayGroup in games.GroupBy(g => g.PlayedOn.Date))
             {
               @if (multiDay)
@@ -116,8 +120,8 @@ else
               @foreach (var game in dayGroup)
               {
                 <GameViewRow Game="game"
-                             ShowSim="@(game.Id == currentGameId)"
-                             ShowUndo="@(game.Id == undoTargetGameId)"
+                             ShowSim="@(ReferenceEquals(game, currentGame))"
+                             ShowUndo="@(ReferenceEquals(game, undoTargetGame))"
                              Disabled="@ViewModel.IsBusy"
                              OnSim="@(async () => await ViewModel.SimulateGame())"
                              OnUndo="@(() => ViewModel.Undo())" />

--- a/src/FantasyFootball.UI/Pages/Competitions.razor
+++ b/src/FantasyFootball.UI/Pages/Competitions.razor
@@ -5,6 +5,7 @@
 @using FantasyFootball.UI.ViewModels
 @inject CompetitionsViewModel ViewModel
 @inject NavigationManager Nav
+@inject IDialogService DialogService
 @implements IDisposable
 
 <PageTitle>Competitions — Fantasy Football</PageTitle>
@@ -50,6 +51,7 @@
           <MudTh>Name</MudTh>
           <MudTh Style="width: 10rem;">Started</MudTh>
           <MudTh>Status</MudTh>
+          <MudTh Style="width: 3rem;"></MudTh>
         </HeaderContent>
         <RowTemplate>
           <MudTd>@context.Id</MudTd>
@@ -61,6 +63,12 @@
           </MudTd>
           <MudTd>@context.SimulationStart.ToString("g")</MudTd>
           <MudTd>@context.CurrentStatus</MudTd>
+          <MudTd Style="text-align: right;" @onclick:stopPropagation="true">
+            <MudIconButton Icon="@Icons.Material.Filled.DeleteOutline"
+                           Size="Size.Small"
+                           Color="Color.Default"
+                           OnClick="@(() => ConfirmDelete(context))" />
+          </MudTd>
         </RowTemplate>
       </MudTable>
     </MudTabPanel>
@@ -85,6 +93,7 @@
             <MudTh Style="width: 10rem;">Started</MudTh>
             <MudTh Style="width: 2.5rem;"></MudTh>
             <MudTh>Winner</MudTh>
+            <MudTh Style="width: 3rem;"></MudTh>
           </HeaderContent>
           <RowTemplate>
             <MudTd>@context.Id</MudTd>
@@ -97,6 +106,12 @@
             <MudTd>@context.SimulationStart.ToString("g")</MudTd>
             <MudTd><FlagIcon Team="context.Winner" Size="24" /></MudTd>
             <MudTd>@context.Winner?.Name</MudTd>
+            <MudTd Style="text-align: right;" @onclick:stopPropagation="true">
+              <MudIconButton Icon="@Icons.Material.Filled.DeleteOutline"
+                             Size="Size.Small"
+                             Color="Color.Default"
+                             OnClick="@(() => ConfirmDelete(context))" />
+            </MudTd>
           </RowTemplate>
         </MudTable>
 
@@ -170,6 +185,19 @@
   }
 
   void StartNew() => Nav.NavigateTo("/competitions/setup");
+
+  async Task ConfirmDelete(Competition competition)
+  {
+    var options = new MessageBoxOptions
+    {
+      Title = "Delete competition?",
+      Message = $"Delete {competition.ShortName} #{competition.Id}? This cannot be undone.",
+      YesText = "Delete",
+      CancelText = "Cancel",
+    };
+    var confirmed = await DialogService.ShowMessageBoxAsync(options);
+    if (confirmed == true) { ViewModel.Delete(competition); }
+  }
 
   public void Dispose() => ViewModel.PropertyChanged -= OnVmChanged;
 }

--- a/src/FantasyFootball.UI/Pages/Settings.razor
+++ b/src/FantasyFootball.UI/Pages/Settings.razor
@@ -21,14 +21,23 @@
     </MudSelect>
 
     <div>
-      <MudText Typo="Typo.body2" Class="mb-2">
-        Simulation speed: <strong>@ViewModel.SimulationSpeedMs.ToString("F0") ms</strong> per game
+      <MudText Typo="Typo.body2" Class="mb-2"><strong>Default simulation speed</strong></MudText>
+      <MudToggleGroup T="SimulationSpeed"
+                      Value="ViewModel.SelectedSimulationSpeed"
+                      ValueChanged="@((SimulationSpeed v) => ViewModel.SelectedSimulationSpeed = v)"
+                      Size="Size.Small"
+                      Color="Color.Primary"
+                      CheckMark="false"
+                      SelectionMode="SelectionMode.SingleSelection"
+                      Style="width: fit-content;">
+        <MudToggleItem Value="SimulationSpeed.Slow" Text="🐢 Slow" />
+        <MudToggleItem Value="SimulationSpeed.Normal" Text="▶ Normal" />
+        <MudToggleItem Value="SimulationSpeed.Fast" Text="🐇 Fast" />
+        <MudToggleItem Value="SimulationSpeed.Instant" Text="⚡ Instant" />
+      </MudToggleGroup>
+      <MudText Typo="Typo.caption" Color="Color.Secondary" Class="d-block mt-1">
+        Per-session override available next to the sim buttons on the competition page.
       </MudText>
-      <MudSlider T="double"
-                 Min="0" Max="500" Step="10"
-                 Value="ViewModel.SimulationSpeedMs"
-                 ValueChanged="@(v => ViewModel.SimulationSpeedMs = v)"
-                 Color="Color.Primary" />
     </div>
 
     <div>

--- a/src/FantasyFootball.UI/Pages/Settings.razor
+++ b/src/FantasyFootball.UI/Pages/Settings.razor
@@ -36,7 +36,7 @@
         <MudToggleItem Value="SimulationSpeed.Instant" Text="⚡ Instant" />
       </MudToggleGroup>
       <MudText Typo="Typo.caption" Color="Color.Secondary" Class="d-block mt-1">
-        Per-session override available next to the sim buttons on the competition page.
+        Per-session override available in the quick settings overlay on the competition page (press <kbd>H</kbd> or <kbd>?</kbd>).
       </MudText>
     </div>
 

--- a/src/FantasyFootball.UI/ViewModels/CompetitionDetailViewModel.cs
+++ b/src/FantasyFootball.UI/ViewModels/CompetitionDetailViewModel.cs
@@ -196,7 +196,8 @@ public partial class CompetitionDetailViewModel : ObservableObject
 		try
 		{
 			game.ClearResult();
-			await _simulator.SimulateGame(game);
+			// Same as SimulateGame: single-game user click, no inter-game pacing.
+			await _simulator.SimulateGame(game, delayAfter: false);
 			_repo.Save(Competition);
 		}
 		finally { OnSimBatchComplete(); }

--- a/src/FantasyFootball.UI/ViewModels/CompetitionDetailViewModel.cs
+++ b/src/FantasyFootball.UI/ViewModels/CompetitionDetailViewModel.cs
@@ -95,6 +95,9 @@ public partial class CompetitionDetailViewModel : ObservableObject
 	public void Load(int competitionId)
 	{
 		ClearUndo();
+		// Clear any in-flight pulse target — a FlashRecentlyFinished from a previous
+		// competition would otherwise eventually fire StateHasChanged on this page for nothing.
+		RecentlyFinishedGame = null;
 		Competition = _repo.Get<Competition>(competitionId);
 		if (Competition is null) { return; }
 
@@ -135,6 +138,10 @@ public partial class CompetitionDetailViewModel : ObservableObject
 			// Single-game user click — no inter-game pacing needed; tell the simulator to skip
 			// the post-sim Task.Delay so the busy spinner clears immediately after the result.
 			await _simulator.SimulateGame(gameBeingSimmed, delayAfter: false);
+			// If the sim bailed early (e.g. game wasn't ready), the speculative undo entry we
+			// pushed up front would be stale. Pop it so the per-row Undo icon doesn't appear
+			// on an unplayed game.
+			if (!gameBeingSimmed.IsFinished) { _undoStack.TryPop(out _); }
 			_repo.Save(Competition);
 		}
 		finally { OnSimBatchComplete(); }
@@ -200,6 +207,9 @@ public partial class CompetitionDetailViewModel : ObservableObject
 			game.ClearResult();
 			// Same as SimulateGame: single-game user click, no inter-game pacing.
 			await _simulator.SimulateGame(game, delayAfter: false);
+			// Sim could fail / be skipped after we cleared the result — pop the undo entry
+			// so the Undo button doesn't sit on a now-blank row.
+			if (!game.IsFinished) { _undoStack.TryPop(out _); }
 			_repo.Save(Competition);
 		}
 		finally { OnSimBatchComplete(); }

--- a/src/FantasyFootball.UI/ViewModels/CompetitionDetailViewModel.cs
+++ b/src/FantasyFootball.UI/ViewModels/CompetitionDetailViewModel.cs
@@ -30,7 +30,8 @@ public partial class CompetitionDetailViewModel : ObservableObject
 	// In-memory rewind stack. JSON snapshot per user-initiated Sim Game action.
 	// Each entry remembers which game was *about to be* simmed at snapshot time, so the per-row
 	// undo button can attach to that specific game once the sim is done.
-	// Cap is generous: 50 is more than a per-game WC48 run would ever push.
+	// Cap at 50: a per-game WC48 run (80 group + KO games) will exceed this and evict the oldest
+	// entries beyond the 50 most recent. Acceptable: users rarely undo across more than a handful of games.
 	const int UndoCap = 50;
 	readonly record struct UndoEntry(string Json, int SimmedGameId);
 	readonly Stack<UndoEntry> _undoStack = new();
@@ -194,7 +195,9 @@ public partial class CompetitionDetailViewModel : ObservableObject
 	{
 		if (Competition is null) { return; }
 		_undoStack.Push(new UndoEntry(CompetitionSnapshot.Serialize(Competition), simmedGameId));
-		// Cap. Stack<T> has no Dequeue, so drop oldest by rebuilding when over.
+		// Cap. Stack<T> has no Dequeue, so drop the oldest (bottom-of-stack) by rebuilding from the top.
+		// .Take(UndoCap) takes the newest UndoCap entries (Stack enumerates top→bottom), .Reverse()
+		// puts them in bottom→top order so pushing back replays the original ordering.
 		if (_undoStack.Count > UndoCap)
 		{
 			var keep = _undoStack.Take(UndoCap).Reverse().ToArray();

--- a/src/FantasyFootball.UI/ViewModels/CompetitionDetailViewModel.cs
+++ b/src/FantasyFootball.UI/ViewModels/CompetitionDetailViewModel.cs
@@ -138,13 +138,15 @@ public partial class CompetitionDetailViewModel : ObservableObject
 			// Single-game user click — no inter-game pacing needed; tell the simulator to skip
 			// the post-sim Task.Delay so the busy spinner clears immediately after the result.
 			await _simulator.SimulateGame(gameBeingSimmed, delayAfter: false);
-			// If the sim bailed early (e.g. game wasn't ready), the speculative undo entry we
-			// pushed up front would be stale. Pop it so the per-row Undo icon doesn't appear
-			// on an unplayed game.
-			if (!gameBeingSimmed.IsFinished) { _undoStack.TryPop(out _); }
 			_repo.Save(Competition);
 		}
-		finally { OnSimBatchComplete(); }
+		finally
+		{
+			// In finally, not try, so an exception inside SimulateGame can't leave a stale entry
+			// pointing at a still-SCHEDULED game (Undo icon would otherwise appear on an unplayed row).
+			if (!gameBeingSimmed.IsFinished) { _undoStack.TryPop(out _); }
+			OnSimBatchComplete();
+		}
 	}
 
 	// Round / Tournament sims do NOT push undo snapshots — undo is scoped to single games.
@@ -207,12 +209,14 @@ public partial class CompetitionDetailViewModel : ObservableObject
 			game.ClearResult();
 			// Same as SimulateGame: single-game user click, no inter-game pacing.
 			await _simulator.SimulateGame(game, delayAfter: false);
-			// Sim could fail / be skipped after we cleared the result — pop the undo entry
-			// so the Undo button doesn't sit on a now-blank row.
-			if (!game.IsFinished) { _undoStack.TryPop(out _); }
 			_repo.Save(Competition);
 		}
-		finally { OnSimBatchComplete(); }
+		finally
+		{
+			// Exception-safe pop — if the sim throws after ClearResult, we still leave the stack honest.
+			if (!game.IsFinished) { _undoStack.TryPop(out _); }
+			OnSimBatchComplete();
+		}
 	}
 
 	async Task FlashRecentlyFinished(Game game)

--- a/src/FantasyFootball.UI/ViewModels/CompetitionDetailViewModel.cs
+++ b/src/FantasyFootball.UI/ViewModels/CompetitionDetailViewModel.cs
@@ -27,10 +27,13 @@ public partial class CompetitionDetailViewModel : ObservableObject
 
 	CompetitionSimulator? _simulator;
 
-	// In-memory rewind stack. JSON snapshot per user-initiated sim action (Game / Round / Stage / Tournament).
-	// Cap mirrors the failure-log sketch: 50 is more than a per-game WC48 run would ever push.
+	// In-memory rewind stack. JSON snapshot per user-initiated Sim Game action.
+	// Each entry remembers which game was *about to be* simmed at snapshot time, so the per-row
+	// undo button can attach to that specific game once the sim is done.
+	// Cap is generous: 50 is more than a per-game WC48 run would ever push.
 	const int UndoCap = 50;
-	readonly Stack<string> _undoStack = new();
+	readonly record struct UndoEntry(string Json, int SimmedGameId);
+	readonly Stack<UndoEntry> _undoStack = new();
 
 	public CompetitionDetailViewModel(IRepository repo, ISettingsService settings, IDataService dataService)
 	{
@@ -76,6 +79,10 @@ public partial class CompetitionDetailViewModel : ObservableObject
 
 	public bool CanUndo => _undoStack.Count > 0;
 
+	// Game.Id of the most recently simmed game (= top-of-stack snapshot's target). Drives per-row
+	// undo button placement: the undo lives on the row of the game it would un-do.
+	public int? UndoTargetGameId => _undoStack.TryPeek(out var top) ? top.SimmedGameId : null;
+
 	public void Load(int competitionId)
 	{
 		ClearUndo();
@@ -106,7 +113,7 @@ public partial class CompetitionDetailViewModel : ObservableObject
 	public async Task SimulateGame()
 	{
 		if (_simulator is null || Competition?.CurrentGame is null || IsBusy) { return; }
-		PushUndoSnapshot();
+		PushUndoSnapshot(Competition.CurrentGame.Id);
 		IsBusy = true;
 		try
 		{
@@ -162,8 +169,8 @@ public partial class CompetitionDetailViewModel : ObservableObject
 	public void Undo()
 	{
 		if (_undoStack.Count == 0 || Competition is null || IsBusy) { return; }
-		var json = _undoStack.Pop();
-		var restored = CompetitionSnapshot.Deserialize(json);
+		var entry = _undoStack.Pop();
+		var restored = CompetitionSnapshot.Deserialize(entry.Json);
 		if (restored is null) { OnPropertyChanged(nameof(CanUndo)); return; }
 
 		// NamedUniqueId.Equals compares by Id, so the restored instance is "equal" to the live one;
@@ -180,12 +187,13 @@ public partial class CompetitionDetailViewModel : ObservableObject
 		// Re-resolve selection against the new object graph.
 		OnSimBatchComplete();
 		OnPropertyChanged(nameof(CanUndo));
+		OnPropertyChanged(nameof(UndoTargetGameId));
 	}
 
-	void PushUndoSnapshot()
+	void PushUndoSnapshot(int simmedGameId)
 	{
 		if (Competition is null) { return; }
-		_undoStack.Push(CompetitionSnapshot.Serialize(Competition));
+		_undoStack.Push(new UndoEntry(CompetitionSnapshot.Serialize(Competition), simmedGameId));
 		// Cap. Stack<T> has no Dequeue, so drop oldest by rebuilding when over.
 		if (_undoStack.Count > UndoCap)
 		{
@@ -194,6 +202,7 @@ public partial class CompetitionDetailViewModel : ObservableObject
 			foreach (var s in keep) { _undoStack.Push(s); }
 		}
 		OnPropertyChanged(nameof(CanUndo));
+		OnPropertyChanged(nameof(UndoTargetGameId));
 	}
 
 	void ClearUndo()
@@ -201,6 +210,7 @@ public partial class CompetitionDetailViewModel : ObservableObject
 		if (_undoStack.Count == 0) { return; }
 		_undoStack.Clear();
 		OnPropertyChanged(nameof(CanUndo));
+		OnPropertyChanged(nameof(UndoTargetGameId));
 	}
 
 	/// <summary>
@@ -223,6 +233,7 @@ public partial class CompetitionDetailViewModel : ObservableObject
 		}
 		IsBusy = false;
 		OnPropertyChanged(nameof(CanUndo));
+		OnPropertyChanged(nameof(UndoTargetGameId));
 	}
 
 	void OnGameFinished(Game finished)

--- a/src/FantasyFootball.UI/ViewModels/CompetitionDetailViewModel.cs
+++ b/src/FantasyFootball.UI/ViewModels/CompetitionDetailViewModel.cs
@@ -27,14 +27,14 @@ public partial class CompetitionDetailViewModel : ObservableObject
 
 	CompetitionSimulator? _simulator;
 
-	// In-memory rewind stack. JSON snapshot per user-initiated Sim Game action.
-	// Each entry remembers which game was *about to be* simmed at snapshot time, so the per-row
-	// undo button can attach to that specific game once the sim is done.
+	// In-memory undo stack of *just-simmed games*. Undo = pop, call game.ClearResult().
+	// No snapshots / serialization needed: a simmed game is fully reversible by clearing its score
+	// and state back to SCHEDULED. Downstream state (standings, qualifiers, KO bracket) recomputes
+	// on the fly from finished games, so nothing else needs to be rewound.
 	// Cap at 50: a per-game WC48 run (80 group + KO games) will exceed this and evict the oldest
-	// entries beyond the 50 most recent. Acceptable: users rarely undo across more than a handful of games.
+	// entries beyond the 50 most recent. Acceptable: users rarely undo across many games.
 	const int UndoCap = 50;
-	readonly record struct UndoEntry(string Json, int SimmedGameId);
-	readonly Stack<UndoEntry> _undoStack = new();
+	readonly Stack<Game> _undoStack = new();
 
 	public CompetitionDetailViewModel(IRepository repo, ISettingsService settings, IDataService dataService)
 	{
@@ -80,9 +80,9 @@ public partial class CompetitionDetailViewModel : ObservableObject
 
 	public bool CanUndo => _undoStack.Count > 0;
 
-	// Game.Id of the most recently simmed game (= top-of-stack snapshot's target). Drives per-row
-	// undo button placement: the undo lives on the row of the game it would un-do.
-	public int? UndoTargetGameId => _undoStack.TryPeek(out var top) ? top.SimmedGameId : null;
+	// The most recently simmed game (top of stack). Drives per-row undo button placement —
+	// the button lives on the row of the game it would un-do.
+	public Game? UndoTargetGame => _undoStack.TryPeek(out var top) ? top : null;
 
 	public void Load(int competitionId)
 	{
@@ -114,12 +114,13 @@ public partial class CompetitionDetailViewModel : ObservableObject
 	public async Task SimulateGame()
 	{
 		if (_simulator is null || Competition?.CurrentGame is null || IsBusy) { return; }
-		PushUndoSnapshot(Competition.CurrentGame.Id);
+		var gameBeingSimmed = Competition.CurrentGame;
 		IsBusy = true;
 		try
 		{
-			await _simulator.SimulateGame(Competition.CurrentGame);
+			await _simulator.SimulateGame(gameBeingSimmed);
 			_repo.Save(Competition);
+			PushUndoEntry(gameBeingSimmed);
 		}
 		finally { OnSimBatchComplete(); }
 	}
@@ -169,32 +170,19 @@ public partial class CompetitionDetailViewModel : ObservableObject
 
 	public void Undo()
 	{
-		if (_undoStack.Count == 0 || Competition is null || IsBusy) { return; }
-		var entry = _undoStack.Pop();
-		var restored = CompetitionSnapshot.Deserialize(entry.Json);
-		if (restored is null) { OnPropertyChanged(nameof(CanUndo)); return; }
+		if (Competition is null || IsBusy) { return; }
+		if (!_undoStack.TryPop(out var game)) { return; }
 
-		// NamedUniqueId.Equals compares by Id, so the restored instance is "equal" to the live one;
-		// CommunityToolkit's [ObservableProperty] setter would no-op and the page would keep
-		// rendering the simmed graph. Force the field update via null transition.
-		Competition = null;
-		Competition = restored;
-		SelectedStage = null;
-		SelectedRound = null;
-
+		game.ClearResult();
 		_repo.Save(Competition);
-		_simulator = new CompetitionSimulator(Competition, _repo);
-		ApplySpeedToSimulator();
-		// Re-resolve selection against the new object graph.
 		OnSimBatchComplete();
 		OnPropertyChanged(nameof(CanUndo));
-		OnPropertyChanged(nameof(UndoTargetGameId));
+		OnPropertyChanged(nameof(UndoTargetGame));
 	}
 
-	void PushUndoSnapshot(int simmedGameId)
+	void PushUndoEntry(Game simmedGame)
 	{
-		if (Competition is null) { return; }
-		_undoStack.Push(new UndoEntry(CompetitionSnapshot.Serialize(Competition), simmedGameId));
+		_undoStack.Push(simmedGame);
 		// Cap. Stack<T> has no Dequeue, so drop the oldest (bottom-of-stack) by rebuilding from the top.
 		// .Take(UndoCap) takes the newest UndoCap entries (Stack enumerates top→bottom), .Reverse()
 		// puts them in bottom→top order so pushing back replays the original ordering.
@@ -202,10 +190,10 @@ public partial class CompetitionDetailViewModel : ObservableObject
 		{
 			var keep = _undoStack.Take(UndoCap).Reverse().ToArray();
 			_undoStack.Clear();
-			foreach (var s in keep) { _undoStack.Push(s); }
+			foreach (var g in keep) { _undoStack.Push(g); }
 		}
 		OnPropertyChanged(nameof(CanUndo));
-		OnPropertyChanged(nameof(UndoTargetGameId));
+		OnPropertyChanged(nameof(UndoTargetGame));
 	}
 
 	void ClearUndo()
@@ -213,7 +201,7 @@ public partial class CompetitionDetailViewModel : ObservableObject
 		if (_undoStack.Count == 0) { return; }
 		_undoStack.Clear();
 		OnPropertyChanged(nameof(CanUndo));
-		OnPropertyChanged(nameof(UndoTargetGameId));
+		OnPropertyChanged(nameof(UndoTargetGame));
 	}
 
 	/// <summary>
@@ -236,7 +224,7 @@ public partial class CompetitionDetailViewModel : ObservableObject
 		}
 		IsBusy = false;
 		OnPropertyChanged(nameof(CanUndo));
-		OnPropertyChanged(nameof(UndoTargetGameId));
+		OnPropertyChanged(nameof(UndoTargetGame));
 	}
 
 	void OnGameFinished(Game finished)

--- a/src/FantasyFootball.UI/ViewModels/CompetitionDetailViewModel.cs
+++ b/src/FantasyFootball.UI/ViewModels/CompetitionDetailViewModel.cs
@@ -116,10 +116,14 @@ public partial class CompetitionDetailViewModel : ObservableObject
 		finally { OnSimBatchComplete(); }
 	}
 
+	// Round / Stage / Tournament sims do NOT push undo snapshots — undo is scoped to single games.
+	// If the user opts into a bigger sim and isn't happy, the recovery path is to re-sim the tournament,
+	// not to rewind mass amounts of state. Any prior single-game undo entries are cleared too,
+	// since they belong to a graph that's now been simmed past.
 	public async Task SimulateRound()
 	{
 		if (_simulator is null || Competition?.CurrentStage?.CurrentRound is null || IsBusy) { return; }
-		PushUndoSnapshot();
+		ClearUndo();
 		IsBusy = true;
 		try
 		{
@@ -132,7 +136,7 @@ public partial class CompetitionDetailViewModel : ObservableObject
 	public async Task SimulateStage()
 	{
 		if (_simulator is null || Competition?.CurrentStage is null || IsBusy) { return; }
-		PushUndoSnapshot();
+		ClearUndo();
 		IsBusy = true;
 		try
 		{
@@ -145,7 +149,7 @@ public partial class CompetitionDetailViewModel : ObservableObject
 	public async Task SimulateAll()
 	{
 		if (_simulator is null || Competition is null || Competition.IsFinished || IsBusy) { return; }
-		PushUndoSnapshot();
+		ClearUndo();
 		IsBusy = true;
 		try
 		{

--- a/src/FantasyFootball.UI/ViewModels/CompetitionDetailViewModel.cs
+++ b/src/FantasyFootball.UI/ViewModels/CompetitionDetailViewModel.cs
@@ -27,6 +27,11 @@ public partial class CompetitionDetailViewModel : ObservableObject
 
 	CompetitionSimulator? _simulator;
 
+	// In-memory rewind stack. JSON snapshot per user-initiated sim action (Game / Round / Stage / Tournament).
+	// Cap mirrors the failure-log sketch: 50 is more than a per-game WC48 run would ever push.
+	const int UndoCap = 50;
+	readonly Stack<string> _undoStack = new();
+
 	public CompetitionDetailViewModel(IRepository repo, ISettingsService settings, IDataService dataService)
 	{
 		_repo = repo;
@@ -34,6 +39,7 @@ public partial class CompetitionDetailViewModel : ObservableObject
 		_dataService = dataService;
 
 		MessageBus.Register<GameFinishedMessage>(this, (_, msg) => OnGameFinished(msg.FinishedGame));
+		MessageBus.Register<DataResetMessage>(this, (_, _) => ClearUndo());
 	}
 
 	[ObservableProperty]
@@ -68,8 +74,11 @@ public partial class CompetitionDetailViewModel : ObservableObject
 	public Team? Winner => Competition?.Winner;
 	public bool IsFinished => Competition?.IsFinished ?? false;
 
+	public bool CanUndo => _undoStack.Count > 0;
+
 	public void Load(int competitionId)
 	{
+		ClearUndo();
 		Competition = _repo.Get<Competition>(competitionId);
 		if (Competition is null) { return; }
 
@@ -97,6 +106,7 @@ public partial class CompetitionDetailViewModel : ObservableObject
 	public async Task SimulateGame()
 	{
 		if (_simulator is null || Competition?.CurrentGame is null || IsBusy) { return; }
+		PushUndoSnapshot();
 		IsBusy = true;
 		try
 		{
@@ -109,6 +119,7 @@ public partial class CompetitionDetailViewModel : ObservableObject
 	public async Task SimulateRound()
 	{
 		if (_simulator is null || Competition?.CurrentStage?.CurrentRound is null || IsBusy) { return; }
+		PushUndoSnapshot();
 		IsBusy = true;
 		try
 		{
@@ -121,6 +132,7 @@ public partial class CompetitionDetailViewModel : ObservableObject
 	public async Task SimulateStage()
 	{
 		if (_simulator is null || Competition?.CurrentStage is null || IsBusy) { return; }
+		PushUndoSnapshot();
 		IsBusy = true;
 		try
 		{
@@ -133,6 +145,7 @@ public partial class CompetitionDetailViewModel : ObservableObject
 	public async Task SimulateAll()
 	{
 		if (_simulator is null || Competition is null || Competition.IsFinished || IsBusy) { return; }
+		PushUndoSnapshot();
 		IsBusy = true;
 		try
 		{
@@ -140,6 +153,43 @@ public partial class CompetitionDetailViewModel : ObservableObject
 			_repo.Save(Competition);
 		}
 		finally { OnSimBatchComplete(); }
+	}
+
+	public void Undo()
+	{
+		if (_undoStack.Count == 0 || Competition is null || IsBusy) { return; }
+		var json = _undoStack.Pop();
+		var restored = CompetitionSnapshot.Deserialize(json);
+		if (restored is null) { OnPropertyChanged(nameof(CanUndo)); return; }
+
+		Competition = restored;
+		_repo.Save(Competition);
+		_simulator = new CompetitionSimulator(Competition, _repo);
+		ApplySpeedToSimulator();
+		// Re-resolve selection against the new object graph; OnSimBatchComplete does exactly that.
+		OnSimBatchComplete();
+		OnPropertyChanged(nameof(CanUndo));
+	}
+
+	void PushUndoSnapshot()
+	{
+		if (Competition is null) { return; }
+		_undoStack.Push(CompetitionSnapshot.Serialize(Competition));
+		// Cap. Stack<T> has no Dequeue, so drop oldest by rebuilding when over.
+		if (_undoStack.Count > UndoCap)
+		{
+			var keep = _undoStack.Take(UndoCap).Reverse().ToArray();
+			_undoStack.Clear();
+			foreach (var s in keep) { _undoStack.Push(s); }
+		}
+		OnPropertyChanged(nameof(CanUndo));
+	}
+
+	void ClearUndo()
+	{
+		if (_undoStack.Count == 0) { return; }
+		_undoStack.Clear();
+		OnPropertyChanged(nameof(CanUndo));
 	}
 
 	/// <summary>
@@ -157,8 +207,11 @@ public partial class CompetitionDetailViewModel : ObservableObject
 			SelectedStage = Competition.CurrentStage ?? Competition.Stages.LastOrDefault();
 			SelectedRound = SelectedStage?.CurrentRound ?? SelectedStage?.Rounds.LastOrDefault();
 			OnPropertyChanged(nameof(Competition));
+			// Finished competitions are immutable in the UX — the user can't go back to before the trophy.
+			if (Competition.IsFinished) { ClearUndo(); }
 		}
 		IsBusy = false;
+		OnPropertyChanged(nameof(CanUndo));
 	}
 
 	void OnGameFinished(Game finished)

--- a/src/FantasyFootball.UI/ViewModels/CompetitionDetailViewModel.cs
+++ b/src/FantasyFootball.UI/ViewModels/CompetitionDetailViewModel.cs
@@ -166,11 +166,18 @@ public partial class CompetitionDetailViewModel : ObservableObject
 		var restored = CompetitionSnapshot.Deserialize(json);
 		if (restored is null) { OnPropertyChanged(nameof(CanUndo)); return; }
 
+		// NamedUniqueId.Equals compares by Id, so the restored instance is "equal" to the live one;
+		// CommunityToolkit's [ObservableProperty] setter would no-op and the page would keep
+		// rendering the simmed graph. Force the field update via null transition.
+		Competition = null;
 		Competition = restored;
+		SelectedStage = null;
+		SelectedRound = null;
+
 		_repo.Save(Competition);
 		_simulator = new CompetitionSimulator(Competition, _repo);
 		ApplySpeedToSimulator();
-		// Re-resolve selection against the new object graph; OnSimBatchComplete does exactly that.
+		// Re-resolve selection against the new object graph.
 		OnSimBatchComplete();
 		OnPropertyChanged(nameof(CanUndo));
 	}

--- a/src/FantasyFootball.UI/ViewModels/CompetitionDetailViewModel.cs
+++ b/src/FantasyFootball.UI/ViewModels/CompetitionDetailViewModel.cs
@@ -180,6 +180,26 @@ public partial class CompetitionDetailViewModel : ObservableObject
 		OnPropertyChanged(nameof(UndoTargetGame));
 	}
 
+	/// <summary>
+	/// Replaces the most recently simmed game's result with a fresh draw. Equivalent to Undo + SimulateGame
+	/// on the same game, but in one click. The undo stack is unchanged so the user can still revert this
+	/// new result.
+	/// </summary>
+	public async Task RedoLastGame()
+	{
+		if (_simulator is null || Competition is null || IsBusy) { return; }
+		if (!_undoStack.TryPeek(out var game)) { return; }
+
+		IsBusy = true;
+		try
+		{
+			game.ClearResult();
+			await _simulator.SimulateGame(game);
+			_repo.Save(Competition);
+		}
+		finally { OnSimBatchComplete(); }
+	}
+
 	void PushUndoEntry(Game simmedGame)
 	{
 		_undoStack.Push(simmedGame);

--- a/src/FantasyFootball.UI/ViewModels/CompetitionDetailViewModel.cs
+++ b/src/FantasyFootball.UI/ViewModels/CompetitionDetailViewModel.cs
@@ -123,15 +123,19 @@ public partial class CompetitionDetailViewModel : ObservableObject
 	{
 		if (_simulator is null || Competition?.CurrentGame is null || IsBusy) { return; }
 		var gameBeingSimmed = Competition.CurrentGame;
+		// Set undo target + pulse marker UP FRONT, before the sim's Task.Delay throws an
+		// async yield. The next render flushes them in the same frame as the new score —
+		// otherwise the buttons + pulse appear ~Task.Delay(GameDelay) ms after the score,
+		// visibly lagging the click.
+		PushUndoEntry(gameBeingSimmed);
+		_ = FlashRecentlyFinished(gameBeingSimmed);
 		IsBusy = true;
 		try
 		{
 			await _simulator.SimulateGame(gameBeingSimmed);
 			_repo.Save(Competition);
-			PushUndoEntry(gameBeingSimmed);
 		}
 		finally { OnSimBatchComplete(); }
-		_ = FlashRecentlyFinished(gameBeingSimmed);
 	}
 
 	// Round / Tournament sims do NOT push undo snapshots — undo is scoped to single games.
@@ -185,6 +189,9 @@ public partial class CompetitionDetailViewModel : ObservableObject
 		if (_simulator is null || Competition is null || IsBusy) { return; }
 		if (!_undoStack.TryPeek(out var game)) { return; }
 
+		// Pulse fires before the await — same reasoning as SimulateGame, so the new score
+		// and the pulse animation land in the same render frame.
+		_ = FlashRecentlyFinished(game);
 		IsBusy = true;
 		try
 		{
@@ -193,7 +200,6 @@ public partial class CompetitionDetailViewModel : ObservableObject
 			_repo.Save(Competition);
 		}
 		finally { OnSimBatchComplete(); }
-		_ = FlashRecentlyFinished(game);
 	}
 
 	async Task FlashRecentlyFinished(Game game)

--- a/src/FantasyFootball.UI/ViewModels/CompetitionDetailViewModel.cs
+++ b/src/FantasyFootball.UI/ViewModels/CompetitionDetailViewModel.cs
@@ -134,7 +134,7 @@ public partial class CompetitionDetailViewModel : ObservableObject
 		_ = FlashRecentlyFinished(gameBeingSimmed);
 	}
 
-	// Round / Stage / Tournament sims do NOT push undo snapshots — undo is scoped to single games.
+	// Round / Tournament sims do NOT push undo snapshots — undo is scoped to single games.
 	// If the user opts into a bigger sim and isn't happy, the recovery path is to re-sim the tournament,
 	// not to rewind mass amounts of state. Any prior single-game undo entries are cleared too,
 	// since they belong to a graph that's now been simmed past.
@@ -146,19 +146,6 @@ public partial class CompetitionDetailViewModel : ObservableObject
 		try
 		{
 			await _simulator.SimulateRound(Competition.CurrentStage.CurrentRound);
-			_repo.Save(Competition);
-		}
-		finally { OnSimBatchComplete(); }
-	}
-
-	public async Task SimulateStage()
-	{
-		if (_simulator is null || Competition?.CurrentStage is null || IsBusy) { return; }
-		ClearUndo();
-		IsBusy = true;
-		try
-		{
-			await _simulator.SimulateStage(Competition.CurrentStage);
 			_repo.Save(Competition);
 		}
 		finally { OnSimBatchComplete(); }
@@ -184,9 +171,8 @@ public partial class CompetitionDetailViewModel : ObservableObject
 
 		game.ClearResult();
 		_repo.Save(Competition);
+		// OnSimBatchComplete owns the CanUndo / UndoTargetGame notifications.
 		OnSimBatchComplete();
-		OnPropertyChanged(nameof(CanUndo));
-		OnPropertyChanged(nameof(UndoTargetGame));
 	}
 
 	/// <summary>

--- a/src/FantasyFootball.UI/ViewModels/CompetitionDetailViewModel.cs
+++ b/src/FantasyFootball.UI/ViewModels/CompetitionDetailViewModel.cs
@@ -132,7 +132,9 @@ public partial class CompetitionDetailViewModel : ObservableObject
 		IsBusy = true;
 		try
 		{
-			await _simulator.SimulateGame(gameBeingSimmed);
+			// Single-game user click — no inter-game pacing needed; tell the simulator to skip
+			// the post-sim Task.Delay so the busy spinner clears immediately after the result.
+			await _simulator.SimulateGame(gameBeingSimmed, delayAfter: false);
 			_repo.Save(Competition);
 		}
 		finally { OnSimBatchComplete(); }

--- a/src/FantasyFootball.UI/ViewModels/CompetitionDetailViewModel.cs
+++ b/src/FantasyFootball.UI/ViewModels/CompetitionDetailViewModel.cs
@@ -64,6 +64,14 @@ public partial class CompetitionDetailViewModel : ObservableObject
 	public partial bool IsBusy { get; set; }
 
 	/// <summary>
+	/// The game whose result was most recently established (or replaced) via a single-game sim.
+	/// Set immediately after Simulate / Redo, cleared automatically after ~1.5s so the row's pulse
+	/// animation only fires once per action. Multi-game sims (round / stage / tournament) don't pulse.
+	/// </summary>
+	[ObservableProperty]
+	public partial Game? RecentlyFinishedGame { get; set; }
+
+	/// <summary>
 	/// Per-session speed override for sim actions. Defaults to the Settings value
 	/// on Load; the page's speed control mutates it for the current visit only.
 	/// `Instant` short-circuits the inter-game delay and suppresses per-game
@@ -123,6 +131,7 @@ public partial class CompetitionDetailViewModel : ObservableObject
 			PushUndoEntry(gameBeingSimmed);
 		}
 		finally { OnSimBatchComplete(); }
+		_ = FlashRecentlyFinished(gameBeingSimmed);
 	}
 
 	// Round / Stage / Tournament sims do NOT push undo snapshots — undo is scoped to single games.
@@ -198,6 +207,15 @@ public partial class CompetitionDetailViewModel : ObservableObject
 			_repo.Save(Competition);
 		}
 		finally { OnSimBatchComplete(); }
+		_ = FlashRecentlyFinished(game);
+	}
+
+	async Task FlashRecentlyFinished(Game game)
+	{
+		RecentlyFinishedGame = game;
+		await Task.Delay(1500);
+		// Only clear if no later sim has overwritten us — otherwise the next pulse races with ours.
+		if (ReferenceEquals(RecentlyFinishedGame, game)) { RecentlyFinishedGame = null; }
 	}
 
 	void PushUndoEntry(Game simmedGame)

--- a/src/FantasyFootball.UI/ViewModels/CompetitionDetailViewModel.cs
+++ b/src/FantasyFootball.UI/ViewModels/CompetitionDetailViewModel.cs
@@ -161,15 +161,6 @@ public partial class CompetitionDetailViewModel : ObservableObject
 		IsBusy = false;
 	}
 
-	public void Delete()
-	{
-		if (Competition is null) { return; }
-		var deletedId = Competition.Id;
-		_repo.Delete(Competition);
-		Competition = null;
-		MessageBus.Send(new CompetitionDeletedMessage(deletedId));
-	}
-
 	void OnGameFinished(Game finished)
 	{
 		// Bail if the message is for a different competition.

--- a/src/FantasyFootball.UI/ViewModels/CompetitionsViewModel.cs
+++ b/src/FantasyFootball.UI/ViewModels/CompetitionsViewModel.cs
@@ -92,6 +92,12 @@ public partial class CompetitionsViewModel : ObservableObject
 		Reload();
 	}
 
+	public void Delete(Competition competition)
+	{
+		_repo.Delete(competition);
+		MessageBus.Send(new CompetitionDeletedMessage(competition.Id));
+	}
+
 	public void Reload()
 	{
 		IsBusy = true;

--- a/src/FantasyFootball.UI/ViewModels/SettingsViewModel.cs
+++ b/src/FantasyFootball.UI/ViewModels/SettingsViewModel.cs
@@ -24,7 +24,7 @@ public partial class SettingsViewModel : ObservableObject
 		_dataService = dataService;
 
 		SelectedLanguage = settings.LastUsedLanguage;
-		SimulationSpeedMs = settings.SimulationSpeed.TotalMilliseconds;
+		SelectedSimulationSpeed = SimulationSpeedExtensions.FromTimeSpan(settings.SimulationSpeed);
 		SelectedFlagStyle = settings.FlagStyle;
 		UseOfficialCompetitionLogos = settings.UseOfficialCompetitionLogos;
 		SupportedLanguages = [new("en"), new("de")];
@@ -36,7 +36,7 @@ public partial class SettingsViewModel : ObservableObject
 	public partial CultureInfo SelectedLanguage { get; set; }
 
 	[ObservableProperty]
-	public partial double SimulationSpeedMs { get; set; }
+	public partial SimulationSpeed SelectedSimulationSpeed { get; set; }
 
 	[ObservableProperty]
 	public partial FlagStyle SelectedFlagStyle { get; set; }
@@ -59,8 +59,8 @@ public partial class SettingsViewModel : ObservableObject
 		// Tracked as a follow-up; for now the choice persists but only takes effect on reload.
 	}
 
-	partial void OnSimulationSpeedMsChanged(double value)
-		=> _settings.SimulationSpeed = TimeSpan.FromMilliseconds(value);
+	partial void OnSelectedSimulationSpeedChanged(SimulationSpeed value)
+		=> _settings.SimulationSpeed = value.ToDelay();
 
 	partial void OnSelectedFlagStyleChanged(FlagStyle value)
 		=> _settings.FlagStyle = value;

--- a/src/FantasyFootball.Web/Services/LocalStorageRepository.cs
+++ b/src/FantasyFootball.Web/Services/LocalStorageRepository.cs
@@ -1,8 +1,8 @@
 using System.Text.Json;
-using System.Text.Json.Serialization;
 using Blazored.LocalStorage;
 using FantasyFootball.Models;
 using FantasyFootball.Repositories;
+using FantasyFootball.Services;
 using Serilog;
 
 namespace FantasyFootball.Web.Services;
@@ -32,12 +32,7 @@ public sealed class LocalStorageRepository : IRepository
     typeof(Country),
   ];
 
-  // STJ freezes JsonSerializerOptions on first use; one shared instance is the documented best practice.
-  static readonly JsonSerializerOptions JsonOptions = new()
-  {
-    TypeInfoResolver = new IgnoreAttributeTypeInfoResolver(),
-    ReferenceHandler = ReferenceHandler.Preserve,
-  };
+  static readonly JsonSerializerOptions JsonOptions = CompetitionSnapshot.JsonOptions;
 
   readonly ISyncLocalStorageService _localStorage;
   readonly Dictionary<Type, Dictionary<int, NamedUniqueId>> _buckets = [];

--- a/src/FantasyFootball.Web/wwwroot/app.css
+++ b/src/FantasyFootball.Web/wwwroot/app.css
@@ -111,6 +111,15 @@ body {
 .scoreboard-loser { opacity: 0.65; }
 .scoreboard-pending { opacity: 0.65; }
 
+/* Just-finished pulse: brief green tint that fades to transparent, fires once per single-game sim. */
+@keyframes scoreboard-pulse {
+  0%   { background-color: rgba(0, 184, 107, 0.22); }
+  100% { background-color: transparent; }
+}
+.scoreboard-row-just-finished {
+  animation: scoreboard-pulse 1.5s ease-out;
+}
+
 /* Right-side action column on a game row — Sim on the current game, Redo+Undo on the most recently simmed one. */
 .scoreboard-action {
   min-width: 5rem;

--- a/src/FantasyFootball.Web/wwwroot/app.css
+++ b/src/FantasyFootball.Web/wwwroot/app.css
@@ -111,6 +111,30 @@ body {
 .scoreboard-loser { opacity: 0.65; }
 .scoreboard-pending { opacity: 0.65; }
 
+/* Group letter + kickoff time at the start of each scoreboard row. Letter is blank for KO games (teams span groups); kickoff stays. */
+.scoreboard-group-tag {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  font-family: 'Barlow Condensed', 'Inter', sans-serif;
+  color: var(--mud-palette-text-secondary);
+  min-width: 2.5rem;
+  line-height: 1.1;
+  flex-shrink: 0;
+}
+
+.scoreboard-group-tag-letter {
+  font-weight: 700;
+  font-size: 0.95rem;
+  letter-spacing: 0.5px;
+}
+
+.scoreboard-group-tag-time {
+  font-size: 0.7rem;
+  font-variant-numeric: tabular-nums;
+}
+
 /* Day-grouping divider for the games panel when a round spans multiple PlayedOn dates. */
 .game-day-divider {
   font-size: 0.75rem;

--- a/src/FantasyFootball.Web/wwwroot/app.css
+++ b/src/FantasyFootball.Web/wwwroot/app.css
@@ -111,6 +111,20 @@ body {
 .scoreboard-loser { opacity: 0.65; }
 .scoreboard-pending { opacity: 0.65; }
 
+/* Day-grouping divider for the games panel when a round spans multiple PlayedOn dates. */
+.game-day-divider {
+  font-size: 0.75rem;
+  color: var(--mud-palette-text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  padding: 0.5rem 0.75rem 0.25rem;
+  margin-top: 0.5rem;
+}
+
+.game-day-divider:first-child {
+  margin-top: 0;
+}
+
 /* Competition-type icon stack: MudIcon underneath, img overlay on top. If img 404s, onerror hides it and the MudIcon shows through. */
 .comp-type-icon-stack {
   display: inline-flex;

--- a/src/FantasyFootball.Web/wwwroot/app.css
+++ b/src/FantasyFootball.Web/wwwroot/app.css
@@ -145,10 +145,6 @@ body {
   margin-top: 0.5rem;
 }
 
-.game-day-divider:first-child {
-  margin-top: 0;
-}
-
 /* Competition-type icon stack: MudIcon underneath, img overlay on top. If img 404s, onerror hides it and the MudIcon shows through. */
 .comp-type-icon-stack {
   display: inline-flex;

--- a/src/FantasyFootball.Web/wwwroot/app.css
+++ b/src/FantasyFootball.Web/wwwroot/app.css
@@ -166,14 +166,44 @@ body {
   object-fit: contain;
 }
 
-/* Group section heading — typographic letter only (OneFootball-style). No chip, no noun. */
+/* Qualification-zone left-edge bar in standings rows. Slim, muted column inset from row edges. */
+.standings-qual-bar {
+  position: absolute;
+  left: 0;
+  top: 6px;
+  bottom: 6px;
+  width: 3px;
+  border-radius: 2px;
+}
+
+.standings-qual-bar-advance { background: var(--mud-palette-success); opacity: 0.55; }
+.standings-qual-bar-out { background: var(--mud-palette-error); opacity: 0.3; }
+
+/* Group block wraps heading + table. Big gap between blocks, zero between letter and its own table.
+   .group-letter-heading has no margin; .group-standings has negative top margin to pull the MudTable
+   header (P GD Pts) tight against the letter, then a quiet divider afterwards via mb. */
+.group-block {
+  margin-top: 1.75rem;
+}
+
+.group-block:first-of-type {
+  margin-top: 0;
+}
+
 .group-letter-heading {
   font-family: 'Barlow Condensed', 'Inter', sans-serif;
   font-weight: 700;
-  font-size: 1.5rem;
+  font-size: 1.4rem;
   letter-spacing: 1px;
   color: var(--mud-palette-primary);
   line-height: 1;
+  margin: 0;
+  padding-left: 0.5rem;
+}
+
+.group-standings .mud-table-head .mud-table-cell {
+  padding-top: 4px;
+  padding-bottom: 4px;
 }
 
 /* Elo numbers tone down so they don't compete with team names. */

--- a/src/FantasyFootball.Web/wwwroot/app.css
+++ b/src/FantasyFootball.Web/wwwroot/app.css
@@ -111,12 +111,13 @@ body {
 .scoreboard-loser { opacity: 0.65; }
 .scoreboard-pending { opacity: 0.65; }
 
-/* Right-side action column on a game row — Sim Game button on the current game, Undo on the most recent. */
+/* Right-side action column on a game row — Sim on the current game, Redo+Undo on the most recently simmed one. */
 .scoreboard-action {
-  min-width: 2.5rem;
+  min-width: 5rem;
   display: flex;
   align-items: center;
-  justify-content: center;
+  justify-content: flex-end;
+  gap: 0.1rem;
   flex-shrink: 0;
 }
 

--- a/src/FantasyFootball.Web/wwwroot/app.css
+++ b/src/FantasyFootball.Web/wwwroot/app.css
@@ -111,6 +111,15 @@ body {
 .scoreboard-loser { opacity: 0.65; }
 .scoreboard-pending { opacity: 0.65; }
 
+/* Right-side action column on a game row — Sim Game button on the current game, Undo on the most recent. */
+.scoreboard-action {
+  min-width: 2.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
 /* Group letter + kickoff time at the start of each scoreboard row. Letter is blank for KO games (teams span groups); kickoff stays. */
 .scoreboard-group-tag {
   display: inline-flex;

--- a/src/FantasyFootball.Web/wwwroot/index.html
+++ b/src/FantasyFootball.Web/wwwroot/index.html
@@ -28,6 +28,7 @@
     </div>
 
     <script src="_content/MudBlazor/MudBlazor.min.js"></script>
+    <script src="js/keyboard.js"></script>
     <script src="_framework/blazor.webassembly#[.{fingerprint}].js"></script>
 </body>
 

--- a/src/FantasyFootball.Web/wwwroot/js/keyboard.js
+++ b/src/FantasyFootball.Web/wwwroot/js/keyboard.js
@@ -15,17 +15,20 @@ window.ffKeyboard = {
         return;
       }
 
-      // Suppress browser defaults for keys we own — scroll on Space + arrows, browser undo/redo on Ctrl+Z / Ctrl+Y.
+      // Suppress browser defaults for keys we own — scroll on Space + arrows, browser undo/redo on Ctrl/Cmd+Z / Y.
       // Skip the Alt+arrow case so the browser's history-navigation shortcut (Alt+←/→ in Firefox / some Chromium) keeps working.
       if (!e.altKey && (e.key === ' ' || e.key === 'ArrowUp' || e.key === 'ArrowDown' || e.key === 'ArrowLeft' || e.key === 'ArrowRight')) {
         e.preventDefault();
       }
-      if (e.ctrlKey && (e.key === 'z' || e.key === 'Z' || e.key === 'y' || e.key === 'Y')) {
+      // metaKey covers macOS Cmd+Z / Cmd+Y. Merging into the boolean we pass to .NET keeps the C# signature unchanged.
+      if ((e.ctrlKey || e.metaKey) && (e.key === 'z' || e.key === 'Z' || e.key === 'y' || e.key === 'Y')) {
         e.preventDefault();
       }
 
-      // Swallow rejections from a dispose race — if the component is gone, there's nothing to recover.
-      this._dotNetRef.invokeMethodAsync('OnKeyDown', e.key, e.ctrlKey, e.shiftKey).catch(() => {});
+      // Dispose race during navigation rejects the invoke with a "has already been disposed" message.
+      // Anything else is a real bug — surface it so future regressions don't vanish silently.
+      this._dotNetRef.invokeMethodAsync('OnKeyDown', e.key, e.ctrlKey || e.metaKey, e.shiftKey)
+        .catch(err => { if (!String(err).includes('disposed')) { console.warn('[ffKeyboard]', err); } });
     };
     document.addEventListener('keydown', this._handler);
   },

--- a/src/FantasyFootball.Web/wwwroot/js/keyboard.js
+++ b/src/FantasyFootball.Web/wwwroot/js/keyboard.js
@@ -7,6 +7,10 @@ window.ffKeyboard = {
       if (e.key === ' ' || e.key === 'ArrowUp' || e.key === 'ArrowDown' || e.key === 'ArrowLeft' || e.key === 'ArrowRight') {
         e.preventDefault();
       }
+      // Ctrl+Z would otherwise trigger the browser's text-editing undo on focusable elements.
+      if (e.ctrlKey && (e.key === 'z' || e.key === 'Z')) {
+        e.preventDefault();
+      }
     });
   }
 };

--- a/src/FantasyFootball.Web/wwwroot/js/keyboard.js
+++ b/src/FantasyFootball.Web/wwwroot/js/keyboard.js
@@ -19,7 +19,7 @@ window.ffKeyboard = {
       if (e.key === ' ' || e.key === 'ArrowUp' || e.key === 'ArrowDown' || e.key === 'ArrowLeft' || e.key === 'ArrowRight') {
         e.preventDefault();
       }
-      if (e.ctrlKey && (e.key === 'z' || e.key === 'Z')) {
+      if (e.ctrlKey && (e.key === 'z' || e.key === 'Z' || e.key === 'y' || e.key === 'Y')) {
         e.preventDefault();
       }
 

--- a/src/FantasyFootball.Web/wwwroot/js/keyboard.js
+++ b/src/FantasyFootball.Web/wwwroot/js/keyboard.js
@@ -15,15 +15,17 @@ window.ffKeyboard = {
         return;
       }
 
-      // Suppress browser defaults for keys we own — scroll on Space + arrows, browser undo on Ctrl+Z.
-      if (e.key === ' ' || e.key === 'ArrowUp' || e.key === 'ArrowDown' || e.key === 'ArrowLeft' || e.key === 'ArrowRight') {
+      // Suppress browser defaults for keys we own — scroll on Space + arrows, browser undo/redo on Ctrl+Z / Ctrl+Y.
+      // Skip the Alt+arrow case so the browser's history-navigation shortcut (Alt+←/→ in Firefox / some Chromium) keeps working.
+      if (!e.altKey && (e.key === ' ' || e.key === 'ArrowUp' || e.key === 'ArrowDown' || e.key === 'ArrowLeft' || e.key === 'ArrowRight')) {
         e.preventDefault();
       }
       if (e.ctrlKey && (e.key === 'z' || e.key === 'Z' || e.key === 'y' || e.key === 'Y')) {
         e.preventDefault();
       }
 
-      this._dotNetRef.invokeMethodAsync('OnKeyDown', e.key, e.ctrlKey, e.shiftKey);
+      // Swallow rejections from a dispose race — if the component is gone, there's nothing to recover.
+      this._dotNetRef.invokeMethodAsync('OnKeyDown', e.key, e.ctrlKey, e.shiftKey).catch(() => {});
     };
     document.addEventListener('keydown', this._handler);
   },

--- a/src/FantasyFootball.Web/wwwroot/js/keyboard.js
+++ b/src/FantasyFootball.Web/wwwroot/js/keyboard.js
@@ -1,0 +1,12 @@
+// preventDefault for keys the competition-detail page handles itself so the
+// browser doesn't also scroll the page underneath us.
+window.ffKeyboard = {
+  registerPreventScroll(el) {
+    if (!el) { return; }
+    el.addEventListener('keydown', (e) => {
+      if (e.key === ' ' || e.key === 'ArrowUp' || e.key === 'ArrowDown' || e.key === 'ArrowLeft' || e.key === 'ArrowRight') {
+        e.preventDefault();
+      }
+    });
+  }
+};

--- a/src/FantasyFootball.Web/wwwroot/js/keyboard.js
+++ b/src/FantasyFootball.Web/wwwroot/js/keyboard.js
@@ -1,16 +1,38 @@
-// preventDefault for keys the competition-detail page handles itself so the
-// browser doesn't also scroll the page underneath us.
+// Document-level keyboard handling for the competition detail page.
+// Fires regardless of which element has focus (Space simming the next game shouldn't require
+// clicking on the page first), and skips when the user is typing into an input.
 window.ffKeyboard = {
-  registerPreventScroll(el) {
-    if (!el) { return; }
-    el.addEventListener('keydown', (e) => {
+  _dotNetRef: null,
+  _handler: null,
+
+  registerDocumentHandler(dotNetRef) {
+    this.unregisterDocumentHandler();
+    this._dotNetRef = dotNetRef;
+    this._handler = (e) => {
+      // Don't intercept when focus is on a form control or content-editable surface.
+      const t = e.target;
+      if (t && (t.tagName === 'INPUT' || t.tagName === 'TEXTAREA' || t.tagName === 'SELECT' || t.isContentEditable)) {
+        return;
+      }
+
+      // Suppress browser defaults for keys we own — scroll on Space + arrows, browser undo on Ctrl+Z.
       if (e.key === ' ' || e.key === 'ArrowUp' || e.key === 'ArrowDown' || e.key === 'ArrowLeft' || e.key === 'ArrowRight') {
         e.preventDefault();
       }
-      // Ctrl+Z would otherwise trigger the browser's text-editing undo on focusable elements.
       if (e.ctrlKey && (e.key === 'z' || e.key === 'Z')) {
         e.preventDefault();
       }
-    });
+
+      this._dotNetRef.invokeMethodAsync('OnKeyDown', e.key, e.ctrlKey, e.shiftKey);
+    };
+    document.addEventListener('keydown', this._handler);
+  },
+
+  unregisterDocumentHandler() {
+    if (this._handler) {
+      document.removeEventListener('keydown', this._handler);
+      this._handler = null;
+    }
+    this._dotNetRef = null;
   }
 };


### PR DESCRIPTION
## Summary

PR 3 of the UI polish series. Six commits, grouped by what they touch.

| SHA | Chunk |
|---|---|
| `1095c86` | Move competition delete from detail page → per-row list action (confirm dialog) |
| `bbe6df0` | Unify Settings speed UI with the competition-detail picker (slider → 4-preset toggle group) |
| `7fae924` | Day-grouping dividers in the games panel when `PlayedOn.Date` spans multiple days |
| `db91c3e` | Group letter + kickoff time on scoreboard rows (vertical tag on the leading edge) |
| `e450e07` | Standings qualification-zone left-edge bar + group-letter spacing |
| `51781ad` | Docs: mark PR 3 chunks done; capture what's left for next session |

Highlights:

- **Standings bar**: slim 3px muted-green / muted-red left-edge column marks advancing vs. eliminated positions. Position 3 of WC48 / EM24 groups shows no bar while the group stage is in progress; once the stage finishes, it promotes to green / red by resolving the actual ThirdPlace qualifier against this group's third-placed team.
- **Scoreboard group tag**: small text-secondary letter (`A`/`B`/…) stacked above the kickoff time on the far-left of each match-card row. Letter blank for KO games whose teams span groups; kickoff always shown.
- **Settings ↔ detail parity**: same `MudToggleGroup` preset picker on both surfaces. Settings persists the global default; the detail picker overrides per-session.
- **Delete moved to list**: per-row trash on `/competitions` with confirmation dialog, removed from `/competitions/{id}` where it sat next to back-nav and was dangerously easy to mis-click.

Remaining PR 3 items (deferred to a follow-up branch): keyboard navigation, undo stack, just-finished pulse, score-reveal animation, FLIP standings reorder, Qual % column, click-for-game-details popover, replay button, confetti.

Two follow-up flags recorded in `docs/ui-polish-plan.md § PR 3`:

- Group H standings occasionally sort with GD/Pts combos that contradict the visible order — `Standings.CreateFrom` tie-break logic suspect. Separate bug.
- Per-row delete dialog copy revisit once About page mentions the action.

## Test plan

- [ ] `/competitions` shows the per-row trash icon in both Active and Finished tabs. Clicking it opens the confirm dialog and only deletes on confirm.
- [ ] `/competitions/{id}` no longer renders a trash icon next to the back button.
- [ ] `/settings` simulation-speed control is a 4-preset toggle group matching the detail-page widget; selection persists across reload.
- [ ] Round whose games span multiple `PlayedOn` dates shows the `Mon 25 Jun` divider above each day's first card. Single-day rounds: no divider.
- [ ] Each scoreboard row's leading edge shows group letter above kickoff time. KO rows show kickoff only.
- [ ] Group standings rows show the slim left-edge bar: positions referenced as direct qualifiers in later stages → muted green; positions never referenced → muted red. WC48 / EM24 position-3 rows: no bar mid-tournament, promote to green / red once the group stage finishes.