### PR TITLE
UI polish 3.5: sim feel + finish-state polish

### DIFF
--- a/src/FantasyFootball.Core/Data/CompetitionSimulator.cs
+++ b/src/FantasyFootball.Core/Data/CompetitionSimulator.cs
@@ -68,18 +68,22 @@ public class CompetitionSimulator(Competition competition, IRepository repo, int
 		Log.Debug("--------------------------------------");
 		Log.Debug($"Starting Round: {round.Name}");
 		Log.Debug("--------------------------------------");
-		Game? lastAttempted = null;
-		while (!round.IsFinished)
+		// Iterate by PlayedOn so non-Instant sims fill rows in the same order the UI displays them
+		// (CompetitionDetail orders games by PlayedOn). Round.AllGames is factory-defined order
+		// (group A first, then B, …) which interleaves with chronological kickoff times — without
+		// this snapshot, row 3 (16:00) would update *after* row 4 (15:00) once we work down each group.
+		var ordered = round.AllGames.OrderBy(g => g.PlayedOn).ToList();
+		foreach (var game in ordered)
 		{
-			var current = round.CurrentGame!;
-			// Bail if CurrentGame doesn't progress — placeholder-team KO games would otherwise spin forever (issue #12).
-			if (ReferenceEquals(current, lastAttempted))
+			if (game.IsFinished) { continue; }
+			// Skip rather than break: a placeholder-team KO game (issue #12 territory) shouldn't sim,
+			// but it also shouldn't block later games in the same round from running.
+			if (!game.IsReadyToStart)
 			{
-				Log.Warning($"Round {round.Name}: game {current} stays non-ready; bailing out of sim loop.");
-				break;
+				Log.Warning($"Round {round.Name}: game {game} is not ready; skipping.");
+				continue;
 			}
-			lastAttempted = current;
-			await SimulateGame(current);
+			await SimulateGame(game);
 		}
 		Log.Debug("--------------------------------------");
 	}

--- a/src/FantasyFootball.Core/Services/HeadToHeadLookup.cs
+++ b/src/FantasyFootball.Core/Services/HeadToHeadLookup.cs
@@ -1,0 +1,47 @@
+using FantasyFootball.Repositories;
+
+namespace FantasyFootball.Services;
+
+/// <summary>
+/// Cross-competition head-to-head tally. Walks every stored Competition's finished games once;
+/// callers should treat this as a one-shot lookup (no caching).
+/// </summary>
+public static class HeadToHeadLookup
+{
+	public readonly record struct Result(int TeamAWins, int Draws, int TeamBWins)
+	{
+		public int Total => TeamAWins + Draws + TeamBWins;
+	}
+
+	public static Result Across(IRepository repo, Team teamA, Team teamB)
+	{
+		// Cross-competition: each competition deserializes its own Team instances. ReferenceEquals
+		// (via NamedUniqueId.Equals on Id=0 entities) would never match across the graph boundary;
+		// fall back to Name, which is stable. SQLite path with Id>0 would also match Name.
+		var nameA = teamA.Name;
+		var nameB = teamB.Name;
+		var aWins = 0;
+		var bWins = 0;
+		var draws = 0;
+
+		foreach (var comp in repo.GetAll<Competition>())
+		{
+			foreach (var game in comp.GamesByDate)
+			{
+				if (!game.IsFinished) { continue; }
+
+				var home = game.HomeTeam?.Name;
+				var away = game.AwayTeam?.Name;
+				var isMatchup = (home == nameA && away == nameB) || (home == nameB && away == nameA);
+				if (!isMatchup) { continue; }
+
+				var winnerName = game.Winner?.Name;
+				if (winnerName is null) { draws++; }
+				else if (winnerName == nameA) { aWins++; }
+				else { bWins++; }
+			}
+		}
+
+		return new Result(aWins, draws, bWins);
+	}
+}

--- a/src/FantasyFootball.Core/Services/HeadToHeadLookup.cs
+++ b/src/FantasyFootball.Core/Services/HeadToHeadLookup.cs
@@ -38,7 +38,8 @@ public static class HeadToHeadLookup
 				var winnerName = game.Winner?.Name;
 				if (winnerName is null) { draws++; }
 				else if (winnerName == nameA) { aWins++; }
-				else { bWins++; }
+				else if (winnerName == nameB) { bWins++; }
+				// else: winner is neither — unreachable today (isMatchup above guarantees it), but the explicit branch keeps the intent legible if Game ever gains a separate winner-track entity.
 			}
 		}
 

--- a/src/FantasyFootball.Core/Services/MatchProbability.cs
+++ b/src/FantasyFootball.Core/Services/MatchProbability.cs
@@ -1,0 +1,41 @@
+using MathNet.Numerics.Distributions;
+
+namespace FantasyFootball.Services;
+
+/// <summary>
+/// Pre-match outcome probabilities matching <see cref="Game.Simulate"/>'s generative model:
+/// total goals ~ Poisson(2.5 + 0.001 * (Elo_home - Elo_away)); each goal independently goes
+/// home with probability 10^(diff/400) / (1 + 10^(diff/400)). By Poisson thinning the
+/// marginal home/away scores are independent Poisson with λ split by that probability.
+/// </summary>
+public static class MatchProbability
+{
+	public readonly record struct WinDrawLossResult(double Home, double Draw, double Away);
+
+	public static WinDrawLossResult WinDrawLoss(int eloHome, int eloAway)
+	{
+		var diff = eloHome - eloAway;
+		var lambdaTotal = System.Math.Max(0.5, 2.5 + 0.001 * diff);
+		var pAwayGoal = 1.0 / (1 + System.Math.Pow(10, diff / 400.0));
+		var lambdaHome = (1 - pAwayGoal) * lambdaTotal;
+		var lambdaAway = pAwayGoal * lambdaTotal;
+
+		const int MaxGoals = 10;
+		double pH = 0, pD = 0, pA = 0;
+		for (int i = 0; i <= MaxGoals; i++)
+		{
+			for (int j = 0; j <= MaxGoals; j++)
+			{
+				var p = Poisson.PMF(lambdaHome, i) * Poisson.PMF(lambdaAway, j);
+				if (i > j) { pH += p; }
+				else if (i == j) { pD += p; }
+				else { pA += p; }
+			}
+		}
+
+		// Renormalize: truncating at MaxGoals=10 loses ~1e-9 of mass at the goal counts we care about, but make it exact for callers.
+		var sum = pH + pD + pA;
+
+		return new WinDrawLossResult(pH / sum, pD / sum, pA / sum);
+	}
+}

--- a/src/FantasyFootball.Core/Services/MatchProbability.cs
+++ b/src/FantasyFootball.Core/Services/MatchProbability.cs
@@ -33,7 +33,7 @@ public static class MatchProbability
 			}
 		}
 
-		// Renormalize: truncating at MaxGoals=10 loses ~1e-9 of mass at the goal counts we care about, but make it exact for callers.
+		// Renormalize: truncating at MaxGoals=10 loses a negligible fraction of mass for near-equal Elos but rises to ~0.1% at extreme spreads (λ near 4.5); the renorm makes the H/D/A split exact regardless.
 		var sum = pH + pD + pA;
 
 		return new WinDrawLossResult(pH / sum, pD / sum, pA / sum);

--- a/src/FantasyFootball.Tests/HeadToHeadLookupTests.cs
+++ b/src/FantasyFootball.Tests/HeadToHeadLookupTests.cs
@@ -1,0 +1,143 @@
+using FantasyFootball.Repositories;
+
+namespace FantasyFootball.Tests;
+
+public class HeadToHeadLookupTests
+{
+	[Fact]
+	public void Across_NoCompetitions_ReturnsZeros()
+	{
+		var repo = new FakeRepo();
+		var teamA = new Team { Name = "A" };
+		var teamB = new Team { Name = "B" };
+
+		var result = HeadToHeadLookup.Across(repo, teamA, teamB);
+
+		result.Should().Be(new HeadToHeadLookup.Result(0, 0, 0));
+		result.Total.Should().Be(0);
+	}
+
+	[Fact]
+	public void Across_CountsWinsDrawsAndLosses_AcrossMultipleCompetitions()
+	{
+		var repo = new FakeRepo
+		{
+			Competitions =
+			{
+				// First comp: A beats B 2-1, then they draw 1-1.
+				BuildComp(("A", "B", 2, 1), ("B", "A", 1, 1)),
+				// Second comp: B beats A 2-0. Game between A and C is irrelevant — should not count.
+				BuildComp(("A", "B", 0, 2), ("A", "C", 3, 0)),
+			}
+		};
+
+		var result = HeadToHeadLookup.Across(repo, new Team { Name = "A" }, new Team { Name = "B" });
+
+		result.TeamAWins.Should().Be(1);
+		result.Draws.Should().Be(1);
+		result.TeamBWins.Should().Be(1);
+		result.Total.Should().Be(3);
+	}
+
+	[Fact]
+	public void Across_DirectionAgnostic_TeamAHomeOrAwayBothCountForTeamAWins()
+	{
+		var repo = new FakeRepo
+		{
+			Competitions =
+			{
+				BuildComp(
+					("A", "B", 1, 0),  // A wins as home
+					("B", "A", 0, 1)),  // A wins as away
+			}
+		};
+
+		var result = HeadToHeadLookup.Across(repo, new Team { Name = "A" }, new Team { Name = "B" });
+
+		result.TeamAWins.Should().Be(2);
+		result.TeamBWins.Should().Be(0);
+		result.Draws.Should().Be(0);
+	}
+
+	[Fact]
+	public void Across_IgnoresUnfinishedGames()
+	{
+		var repo = new FakeRepo
+		{
+			Competitions =
+			{
+				BuildComp(
+					("A", "B", 1, 0),  // finished
+					new ScheduledGame("A", "B")),  // not yet played
+			}
+		};
+
+		var result = HeadToHeadLookup.Across(repo, new Team { Name = "A" }, new Team { Name = "B" });
+
+		result.TeamAWins.Should().Be(1);
+		result.Total.Should().Be(1);
+	}
+
+	// Each comp builds its own fresh Team instances per name — mirrors the LocalStorage path where every deserialized
+	// Competition graph has its own Team objects (NamedUniqueId.Equals would not match them; name-based matching does).
+	static Competition BuildComp(params object[] entries)
+	{
+		var round = new Round { Name = "Round 1" };
+		var teams = new Dictionary<string, Team>(StringComparer.Ordinal);
+		Team Get(string name) => teams.TryGetValue(name, out var t) ? t : teams[name] = new Team { Name = name };
+
+		foreach (var entry in entries)
+		{
+			switch (entry)
+			{
+				case (string home, string away, int homeScore, int awayScore):
+					round.RegularGames.Add(new Game
+					{
+						HomeTeam = Get(home),
+						AwayTeam = Get(away),
+						HomeScore = homeScore,
+						AwayScore = awayScore,
+						State = GameState.FINISHED,
+						Round = round,
+					});
+					break;
+				case ScheduledGame sg:
+					round.RegularGames.Add(new Game
+					{
+						HomeTeam = Get(sg.Home),
+						AwayTeam = Get(sg.Away),
+						State = GameState.SCHEDULED,
+						Round = round,
+					});
+					break;
+				default:
+					throw new ArgumentException($"Unsupported entry type {entry.GetType()}");
+			}
+		}
+
+		var stage = new Stage { Name = "Group Stage", Rounds = [round] };
+		round.Stage = stage;
+		var comp = new Competition { Name = "test", ShortName = "T", Stages = [stage] };
+		stage.Competition = comp;
+
+		return comp;
+	}
+
+	record ScheduledGame(string Home, string Away);
+
+	sealed class FakeRepo : IRepository
+	{
+		public List<Competition> Competitions { get; init; } = [];
+
+		public List<T> GetAll<T>() where T : NamedUniqueId, new()
+			=> typeof(T) == typeof(Competition) ? Competitions.Cast<T>().ToList() : [];
+
+		public Task<List<T>> GetAllAsync<T>() where T : NamedUniqueId, new() => Task.FromResult(GetAll<T>());
+		public T? Get<T>(int id) where T : NamedUniqueId, new() => null;
+		public int Count<T>() where T : NamedUniqueId, new() => GetAll<T>().Count;
+		public void Save<T>(T item) where T : NamedUniqueId, new() { }
+		public void Delete<T>(T item) where T : NamedUniqueId, new() { }
+		public void Reset() { }
+		public void Dispose() { }
+	}
+}

--- a/src/FantasyFootball.Tests/MatchProbabilityTests.cs
+++ b/src/FantasyFootball.Tests/MatchProbabilityTests.cs
@@ -1,0 +1,32 @@
+namespace FantasyFootball.Tests;
+
+public class MatchProbabilityTests
+{
+	[Fact]
+	public void EqualElos_HomeAndAwayMirror_DrawNonTrivial()
+	{
+		var p = MatchProbability.WinDrawLoss(1500, 1500);
+
+		p.Home.Should().BeApproximately(p.Away, 1e-9);
+		p.Draw.Should().BeGreaterThan(0.15);
+		(p.Home + p.Draw + p.Away).Should().BeApproximately(1.0, 1e-9);
+	}
+
+	[Fact]
+	public void StrongHomeFavorite_HomeProbDominates()
+	{
+		var p = MatchProbability.WinDrawLoss(1900, 1300);
+
+		p.Home.Should().BeGreaterThan(0.75);
+		p.Away.Should().BeLessThan(0.10);
+	}
+
+	[Fact]
+	public void StrongAwayFavorite_AwayProbDominates()
+	{
+		var p = MatchProbability.WinDrawLoss(1300, 1900);
+
+		p.Away.Should().BeGreaterThan(0.75);
+		p.Home.Should().BeLessThan(0.10);
+	}
+}

--- a/src/FantasyFootball.UI/Components/GameViewRow.razor
+++ b/src/FantasyFootball.UI/Components/GameViewRow.razor
@@ -6,8 +6,7 @@
 
 <div class="scoreboard-row-wrapper">
 <div class="scoreboard-row @(IsJustFinished ? "scoreboard-row-just-finished" : "") @(DetailsOpen ? "scoreboard-row-open" : "")"
-     @onclick="OnDetailsToggle"
-     style="cursor: pointer;">
+     @onclick="OnDetailsToggle">
   <div class="scoreboard-group-tag">
     <span class="scoreboard-group-tag-letter">@_groupLetter</span>
     <span class="scoreboard-group-tag-time">@Game.PlayedOn.ToString("HH:mm")</span>
@@ -141,7 +140,8 @@
     _prevDetailsOpen = DetailsOpen;
   }
 
-  static string FormatPct(double p) => $"{p * 100:0}%";
+  // Floor at "<1%": "0%" reads as impossible for a heavy underdog who could still win.
+  static string FormatPct(double p) => p > 0 && p < 0.005 ? "<1%" : $"{p * 100:0}%";
 
   static string PctClass(bool isActualOutcome) => isActualOutcome ? "game-details-pct-actual" : "";
 }

--- a/src/FantasyFootball.UI/Components/GameViewRow.razor
+++ b/src/FantasyFootball.UI/Components/GameViewRow.razor
@@ -1,6 +1,13 @@
 @using FantasyFootball.Models
+@using FantasyFootball.Data
+@using FantasyFootball.Services
+@using FantasyFootball.Repositories
+@inject IRepository Repo
 
-<div class="scoreboard-row @(IsJustFinished ? "scoreboard-row-just-finished" : "")">
+<div class="scoreboard-row-wrapper">
+<div class="scoreboard-row @(IsJustFinished ? "scoreboard-row-just-finished" : "") @(DetailsOpen ? "scoreboard-row-open" : "")"
+     @onclick="OnDetailsToggle"
+     style="cursor: pointer;">
   <div class="scoreboard-group-tag">
     <span class="scoreboard-group-tag-letter">@_groupLetter</span>
     <span class="scoreboard-group-tag-time">@Game.PlayedOn.ToString("HH:mm")</span>
@@ -14,7 +21,7 @@
     <FlagIcon Team="Game.AwayTeam" Size="24" />
     <span class="scoreboard-team-name">@Game.AwayTeam.Name</span>
   </div>
-  <div class="scoreboard-action">
+  <div class="scoreboard-action" @onclick:stopPropagation="true">
     @if (ShowSim)
     {
       <MudIconButton Icon="@Icons.Material.Filled.PlayArrow"
@@ -40,6 +47,49 @@
     }
   </div>
 </div>
+<MudPopover Open="DetailsOpen"
+            AnchorOrigin="Origin.BottomCenter"
+            TransformOrigin="Origin.TopCenter"
+            Paper="true"
+            Class="game-details-popover">
+  @if (DetailsOpen)
+  {
+    @if (Game.HomeTeam.Type == TeamType.PLACEHOLDER || Game.AwayTeam.Type == TeamType.PLACEHOLDER)
+    {
+      <MudText Typo="Typo.body2">Teams not yet decided.</MudText>
+    }
+    else
+    {
+      <div class="game-details-row">
+        <span class="game-details-label">Elo</span>
+        <span class="game-details-value">@Game.HomeTeam.Elo <span class="game-details-sep">—</span> @Game.AwayTeam.Elo</span>
+      </div>
+      <div class="game-details-row">
+        <span class="game-details-label">Win / Draw / Loss</span>
+        <span class="game-details-value">
+          <span class="@PctClass(HomeIsWinner)">@FormatPct(_prob.Home)</span>
+          <span class="game-details-sep">/</span>
+          <span class="@PctClass(IsDraw)">@FormatPct(_prob.Draw)</span>
+          <span class="game-details-sep">/</span>
+          <span class="@PctClass(AwayIsWinner)">@FormatPct(_prob.Away)</span>
+        </span>
+      </div>
+      <div class="game-details-row">
+        <span class="game-details-label">H2H (all sims)</span>
+        <span class="game-details-value">
+          @if (_h2h.Total == 0) { <em>none</em> }
+          else { @($"{_h2h.TeamAWins}–{_h2h.Draws}–{_h2h.TeamBWins}") }
+        </span>
+      </div>
+      <MudDivider Class="my-2" />
+      <div class="game-details-links">
+        <MudLink Href="@($"/teams/{Game.HomeTeam.Id}")" Typo="Typo.body2">@Game.HomeTeam.Name</MudLink>
+        <MudLink Href="@($"/teams/{Game.AwayTeam.Id}")" Typo="Typo.body2">@Game.AwayTeam.Name</MudLink>
+      </div>
+    }
+  }
+</MudPopover>
+</div>
 
 @code {
   [Parameter] public Game Game { get; set; } = null!;
@@ -47,6 +97,8 @@
   [Parameter] public bool ShowUndo { get; set; }
   [Parameter] public bool IsJustFinished { get; set; }
   [Parameter] public bool Disabled { get; set; }
+  [Parameter] public bool DetailsOpen { get; set; }
+  [Parameter] public EventCallback OnDetailsToggle { get; set; }
   [Parameter] public EventCallback OnSim { get; set; }
   [Parameter] public EventCallback OnUndo { get; set; }
   [Parameter] public EventCallback OnRedo { get; set; }
@@ -66,11 +118,30 @@
   // Group letter when both teams sit in the same group of the parent stage (group-stage games). KO games span groups → blank.
   string _groupLetter = "";
 
+  bool _prevDetailsOpen;
+  MatchProbability.WinDrawLossResult _prob;
+  HeadToHeadLookup.Result _h2h;
+
   protected override void OnParametersSet()
   {
     var stage = Game.Round?.Stage;
-    if (stage is null) { _groupLetter = ""; return; }
-    var group = stage.Groups.FirstOrDefault(g => g.Teams.Contains(Game.HomeTeam) && g.Teams.Contains(Game.AwayTeam));
+    var group = stage?.Groups.FirstOrDefault(g => g.Teams.Contains(Game.HomeTeam) && g.Teams.Contains(Game.AwayTeam));
     _groupLetter = group?.Name?.Split(' ', StringSplitOptions.RemoveEmptyEntries).LastOrDefault()?.ToUpperInvariant() ?? "";
+
+    // Compute popover data only on open-transition. Recomputing every render would re-walk GetAll<Competition>()
+    // on every keypress / VM property change while a popover stays open.
+    if (DetailsOpen
+        && !_prevDetailsOpen
+        && Game.HomeTeam.Type != TeamType.PLACEHOLDER
+        && Game.AwayTeam.Type != TeamType.PLACEHOLDER)
+    {
+      _prob = MatchProbability.WinDrawLoss(Game.HomeTeam.Elo, Game.AwayTeam.Elo);
+      _h2h = HeadToHeadLookup.Across(Repo, Game.HomeTeam, Game.AwayTeam);
+    }
+    _prevDetailsOpen = DetailsOpen;
   }
+
+  static string FormatPct(double p) => $"{p * 100:0}%";
+
+  static string PctClass(bool isActualOutcome) => isActualOutcome ? "game-details-pct-actual" : "";
 }

--- a/src/FantasyFootball.UI/Pages/CompetitionDetail.razor
+++ b/src/FantasyFootball.UI/Pages/CompetitionDetail.razor
@@ -199,16 +199,11 @@ else
 
   async Task ReplayCompetition()
   {
-    // Set IsBusy + yield so the spinner flushes to the DOM before the synchronous Replay() blocks on the
-    // LocalStorage save. Without the yield the button appears unresponsive: nothing visibly happens between
-    // click and the new-page navigation. Load() on the new comp's mount resets IsBusy.
-    ViewModel.IsBusy = true;
     // Clear in-flight confetti particles from the previous finish — they'd otherwise keep falling on the
-    // new-comp page for 2-3 seconds and look like a fresh celebration.
+    // new-comp page for 2-3 seconds and look like a fresh celebration. IsBusy + spinner-flush is the VM's job.
     try { await JS.InvokeVoidAsync("ffConfetti.reset"); }
     catch (JSDisconnectedException) { /* page disposing */ }
-    await Task.Yield();
-    var replay = ViewModel.Replay();
+    var replay = await ViewModel.Replay();
     Nav.NavigateTo($"/competitions/{replay.Id}");
   }
 

--- a/src/FantasyFootball.UI/Pages/CompetitionDetail.razor
+++ b/src/FantasyFootball.UI/Pages/CompetitionDetail.razor
@@ -122,6 +122,8 @@ else
                              ShowUndo="@(ReferenceEquals(game, undoTargetGame))"
                              IsJustFinished="@(ReferenceEquals(game, ViewModel.RecentlyFinishedGame))"
                              Disabled="@ViewModel.IsBusy"
+                             DetailsOpen="@(ReferenceEquals(game, _openDetailsGame))"
+                             OnDetailsToggle="@(() => ToggleDetailsGame(game))"
                              OnSim="@(async () => await ViewModel.SimulateGame())"
                              OnUndo="@(() => ViewModel.Undo())"
                              OnRedo="@(async () => await ViewModel.RedoLastGame())" />
@@ -181,7 +183,10 @@ else
 
   int? _lastLoadedId;
   bool _helpOpen;
+  Game? _openDetailsGame;
   DotNetObjectReference<CompetitionDetail>? _selfRef;
+
+  void ToggleDetailsGame(Game game) => _openDetailsGame = ReferenceEquals(_openDetailsGame, game) ? null : game;
 
   protected override void OnInitialized() => ViewModel.PropertyChanged += OnVmChanged;
 

--- a/src/FantasyFootball.UI/Pages/CompetitionDetail.razor
+++ b/src/FantasyFootball.UI/Pages/CompetitionDetail.razor
@@ -48,6 +48,14 @@ else
         <MudChip T="string" Color="Color.Success" Icon="@Icons.Material.Filled.EmojiEvents" Size="Size.Small">
           Winner: @ViewModel.Winner.Name
         </MudChip>
+        <MudButton Variant="Variant.Outlined"
+                   Color="Color.Primary"
+                   Size="Size.Small"
+                   StartIcon="@Icons.Material.Filled.Refresh"
+                   OnClick="ReplayCompetition"
+                   Disabled="ViewModel.IsBusy">
+          Simulate again
+        </MudButton>
       }
       <MudSpacer />
       <MudIconButton Icon="@Icons.Material.Filled.Keyboard"
@@ -184,9 +192,25 @@ else
   int? _lastLoadedId;
   bool _helpOpen;
   Game? _openDetailsGame;
+  int? _confettiFiredFor;
   DotNetObjectReference<CompetitionDetail>? _selfRef;
 
   void ToggleDetailsGame(Game game) => _openDetailsGame = ReferenceEquals(_openDetailsGame, game) ? null : game;
+
+  async Task ReplayCompetition()
+  {
+    // Set IsBusy + yield so the spinner flushes to the DOM before the synchronous Replay() blocks on the
+    // LocalStorage save. Without the yield the button appears unresponsive: nothing visibly happens between
+    // click and the new-page navigation. Load() on the new comp's mount resets IsBusy.
+    ViewModel.IsBusy = true;
+    // Clear in-flight confetti particles from the previous finish — they'd otherwise keep falling on the
+    // new-comp page for 2-3 seconds and look like a fresh celebration.
+    try { await JS.InvokeVoidAsync("ffConfetti.reset"); }
+    catch (JSDisconnectedException) { /* page disposing */ }
+    await Task.Yield();
+    var replay = ViewModel.Replay();
+    Nav.NavigateTo($"/competitions/{replay.Id}");
+  }
 
   protected override void OnInitialized() => ViewModel.PropertyChanged += OnVmChanged;
 
@@ -195,6 +219,9 @@ else
     if (_lastLoadedId == Id) { return; }
     _lastLoadedId = Id;
     ViewModel.Load(Id);
+    // Loading an already-finished comp from the list: suppress confetti so the user only sees it
+    // when their own sim crosses the finish line, not when they revisit an old result.
+    _confettiFiredFor = ViewModel.IsFinished ? Id : null;
   }
 
   protected override async Task OnAfterRenderAsync(bool firstRender)
@@ -208,7 +235,16 @@ else
     }
   }
 
-  void OnVmChanged(object? sender, EventArgs e) => InvokeAsync(StateHasChanged);
+  void OnVmChanged(object? sender, EventArgs e) => InvokeAsync(async () =>
+  {
+    if (ViewModel.IsFinished && _confettiFiredFor != Id)
+    {
+      _confettiFiredFor = Id;
+      try { await JS.InvokeVoidAsync("ffConfetti.celebrate"); }
+      catch (JSDisconnectedException) { /* Page navigated away while the call was in flight. */ }
+    }
+    StateHasChanged();
+  });
 
   // Invoked by the document-level JS keydown listener. Sim keys no-op once finished; nav keys remain.
   [JSInvokable]

--- a/src/FantasyFootball.UI/ViewModels/CompetitionDetailViewModel.cs
+++ b/src/FantasyFootball.UI/ViewModels/CompetitionDetailViewModel.cs
@@ -1,6 +1,7 @@
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Messaging;
 using FantasyFootball.Data;
+using FantasyFootball.Data.CompetitionFactories;
 using FantasyFootball.Models;
 using FantasyFootball.Repositories;
 using FantasyFootball.Services;
@@ -98,6 +99,8 @@ public partial class CompetitionDetailViewModel : ObservableObject
 		// Clear any in-flight pulse target — a FlashRecentlyFinished from a previous
 		// competition would otherwise eventually fire StateHasChanged on this page for nothing.
 		RecentlyFinishedGame = null;
+		// Replay flow sets IsBusy=true before navigating; clear here so the new comp's view starts idle.
+		IsBusy = false;
 		Competition = _repo.Get<Competition>(competitionId);
 		if (Competition is null) { return; }
 
@@ -163,7 +166,8 @@ public partial class CompetitionDetailViewModel : ObservableObject
 			await _simulator.SimulateRound(Competition.CurrentStage.CurrentRound);
 			_repo.Save(Competition);
 		}
-		finally { OnSimBatchComplete(); }
+		// Keep the user on the round they just simmed — auto-advancing to the next round hides the results they wanted to see.
+		finally { OnSimBatchComplete(advanceSelection: false); }
 	}
 
 	public async Task SimulateAll()
@@ -252,19 +256,21 @@ public partial class CompetitionDetailViewModel : ObservableObject
 	}
 
 	/// <summary>
-	/// Post-sim-batch hook called from every <c>SimulateX</c> finally. Advances
-	/// Stage/Round to the current non-finished entry, re-publishes Competition
-	/// so the page rebinds, and clears <see cref="IsBusy"/>. OnGameFinished
-	/// keeps selection live in non-Quiet mode per game, but Quiet/Instant
-	/// suppresses those broadcasts — without this hook the page would still be
-	/// pinned to the round selected before the batch started.
+	/// Post-sim-batch hook called from every <c>SimulateX</c> finally. Optionally advances
+	/// Stage/Round to the current non-finished entry, re-publishes Competition so the page
+	/// rebinds, and clears <see cref="IsBusy"/>. SimulateRound passes <c>advanceSelection: false</c>
+	/// so the user stays on the round they just simmed; SimulateGame and SimulateAll let the
+	/// default advance fire (next-game flow and trophy-landing respectively).
 	/// </summary>
-	void OnSimBatchComplete()
+	void OnSimBatchComplete(bool advanceSelection = true)
 	{
 		if (Competition is not null)
 		{
-			SelectedStage = Competition.CurrentStage ?? Competition.Stages.LastOrDefault();
-			SelectedRound = SelectedStage?.CurrentRound ?? SelectedStage?.Rounds.LastOrDefault();
+			if (advanceSelection)
+			{
+				SelectedStage = Competition.CurrentStage ?? Competition.Stages.LastOrDefault();
+				SelectedRound = SelectedStage?.CurrentRound ?? SelectedStage?.Rounds.LastOrDefault();
+			}
 			OnPropertyChanged(nameof(Competition));
 			// Finished competitions are immutable in the UX — the user can't go back to before the trophy.
 			if (Competition.IsFinished) { ClearUndo(); }
@@ -274,18 +280,34 @@ public partial class CompetitionDetailViewModel : ObservableObject
 		OnPropertyChanged(nameof(UndoTargetGame));
 	}
 
+	/// <summary>
+	/// Clones the current competition's team lineup into a fresh competition with the same Type + Year
+	/// and saves it. Returns the new Id so the page can navigate to it. Uses today's Elo on each Team
+	/// instance, not a snapshot from the finished comp — issue #19 will tighten this once the per-comp
+	/// Elo snapshot lands. Group.ShallowClone strips Stage / Games / Id; the factory wires everything else fresh.
+	/// </summary>
+	public Competition Replay()
+	{
+		if (Competition is null) { throw new InvalidOperationException("No competition loaded to replay."); }
+		var year = Competition.Start?.Year ?? DateTime.Now.Year;
+		var clonedGroups = Competition.Groups.Select(g => g.ShallowClone()).ToList();
+		var factory = CompetitionFactory.For(Competition.Type, year, clonedGroups);
+		var replay = factory.Create();
+		_repo.Save(replay);
+		MessageBus.Send(new CompetitionCreatedMessage(replay));
+
+		return replay;
+	}
+
 	void OnGameFinished(Game finished)
 	{
 		// Bail if the message is for a different competition.
 		if (Competition is null || finished.Round?.Stage?.Competition is null) { return; }
 		if (finished.Round.Stage.Competition.Id != Competition.Id) { return; }
 
-		// Auto-advance Stage/Round to the next non-finished one so the games
-		// pane follows the simulation forward.
-		SelectedStage = Competition.CurrentStage ?? Competition.Stages.LastOrDefault();
-		SelectedRound = SelectedStage?.CurrentRound ?? SelectedStage?.Rounds.LastOrDefault();
-
-		// Re-publish Competition change so groupings + standings + winner re-evaluate.
+		// Re-publish Competition change so groupings + standings + winner re-evaluate. Auto-advance is left
+		// to OnSimBatchComplete: doing it per-game during a multi-game sim flipped the panel away from the
+		// round being simmed the moment its last game resolved, hiding the results the user was watching.
 		OnPropertyChanged(nameof(Competition));
 	}
 }

--- a/src/FantasyFootball.UI/ViewModels/CompetitionDetailViewModel.cs
+++ b/src/FantasyFootball.UI/ViewModels/CompetitionDetailViewModel.cs
@@ -285,18 +285,32 @@ public partial class CompetitionDetailViewModel : ObservableObject
 	/// and saves it. Returns the new Id so the page can navigate to it. Uses today's Elo on each Team
 	/// instance, not a snapshot from the finished comp — issue #19 will tighten this once the per-comp
 	/// Elo snapshot lands. Group.ShallowClone strips Stage / Games / Id; the factory wires everything else fresh.
+	/// Async so the IsBusy spinner can flush to the DOM before the synchronous LocalStorage save blocks;
+	/// IsBusy is left true on return — Load() on the new comp's mount resets it.
 	/// </summary>
-	public Competition Replay()
+	public async Task<Competition> Replay()
 	{
 		if (Competition is null) { throw new InvalidOperationException("No competition loaded to replay."); }
-		var year = Competition.Start?.Year ?? DateTime.Now.Year;
-		var clonedGroups = Competition.Groups.Select(g => g.ShallowClone()).ToList();
-		var factory = CompetitionFactory.For(Competition.Type, year, clonedGroups);
-		var replay = factory.Create();
-		_repo.Save(replay);
-		MessageBus.Send(new CompetitionCreatedMessage(replay));
+		IsBusy = true;
+		await Task.Yield();
 
-		return replay;
+		try
+		{
+			var year = Competition.Start?.Year ?? DateTime.Now.Year;
+			var clonedGroups = Competition.Groups.Select(g => g.ShallowClone()).ToList();
+			// CompetitionFactory.For raises NotImplementedException for CHAMPIONS_LEAGUE / DOMESTIC_LEAGUE and ArgumentException for unknown types; clear IsBusy on the exception path so the spinner doesn't lock the page until reload.
+			var factory = CompetitionFactory.For(Competition.Type, year, clonedGroups);
+			var replay = factory.Create();
+			_repo.Save(replay);
+			MessageBus.Send(new CompetitionCreatedMessage(replay));
+
+			return replay;
+		}
+		catch
+		{
+			IsBusy = false;
+			throw;
+		}
 	}
 
 	void OnGameFinished(Game finished)

--- a/src/FantasyFootball.Web/wwwroot/app.css
+++ b/src/FantasyFootball.Web/wwwroot/app.css
@@ -69,6 +69,11 @@ body {
   margin-top: 4px;
 }
 
+/* Whole-row click opens the details popover (see GameViewRow.razor onclick). */
+.scoreboard-row {
+  cursor: pointer;
+}
+
 .scoreboard-row:hover {
   background: var(--mud-palette-action-hover, rgba(0, 0, 0, 0.04));
 }

--- a/src/FantasyFootball.Web/wwwroot/app.css
+++ b/src/FantasyFootball.Web/wwwroot/app.css
@@ -120,6 +120,20 @@ body {
   animation: scoreboard-pulse 1.5s ease-out;
 }
 
+/* Score reveal — pop in from 140% with the brand-green tint, scale back to 100% over 450ms.
+   Paired with .scoreboard-row-just-finished on single-game sims (and redo) so both the row pulse
+   and the score animation start in the same frame. Opacity catches up faster than scale (35%)
+   so the score reads early; scale + colour settle through the rest. */
+@keyframes scoreboard-score-reveal {
+  0%   { opacity: 0; transform: scale(1.4); color: var(--mud-palette-primary); }
+  35%  { opacity: 1; transform: scale(1.2); color: var(--mud-palette-primary); }
+  100% { opacity: 1; transform: scale(1); color: inherit; }
+}
+.scoreboard-row-just-finished .scoreboard-score {
+  animation: scoreboard-score-reveal 0.45s ease-out;
+  display: inline-block; /* required for transform to apply on inline content */
+}
+
 /* Right-side action column on a game row — Sim on the current game, Redo+Undo on the most recently simmed one. */
 .scoreboard-action {
   min-width: 5rem;

--- a/src/FantasyFootball.Web/wwwroot/app.css
+++ b/src/FantasyFootball.Web/wwwroot/app.css
@@ -154,6 +154,58 @@ body {
   font-variant-numeric: tabular-nums;
 }
 
+/* Click-for-game-details popover. Anchored under the row via .scoreboard-row-wrapper (position: relative). */
+.scoreboard-row-wrapper {
+  position: relative;
+}
+
+.scoreboard-row-open {
+  background: var(--mud-palette-action-hover, rgba(0, 0, 0, 0.04));
+  box-shadow: inset 3px 0 0 var(--mud-palette-primary);
+}
+
+.game-details-popover {
+  padding: 0.75rem 1rem;
+  min-width: 18rem;
+  max-width: 22rem;
+}
+
+.game-details-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  font-size: 0.85rem;
+  padding: 0.15rem 0;
+  font-variant-numeric: tabular-nums;
+}
+
+.game-details-label {
+  color: var(--mud-palette-text-secondary);
+  font-weight: 500;
+}
+
+.game-details-value {
+  font-weight: 600;
+}
+
+.game-details-sep {
+  color: var(--mud-palette-text-secondary);
+  font-weight: 400;
+  margin: 0 0.15rem;
+}
+
+/* The percentage that matches the actual outcome (only set when Game.IsFinished). */
+.game-details-pct-actual {
+  color: var(--mud-palette-primary);
+  font-weight: 700;
+}
+
+.game-details-links {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
 /* Day-grouping divider for the games panel when a round spans multiple PlayedOn dates. */
 .game-day-divider {
   font-size: 0.75rem;

--- a/src/FantasyFootball.Web/wwwroot/index.html
+++ b/src/FantasyFootball.Web/wwwroot/index.html
@@ -29,7 +29,9 @@
 
     <script src="_content/MudBlazor/MudBlazor.min.js"></script>
     <script src="js/keyboard.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/canvas-confetti@1.9.3/dist/confetti.browser.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/canvas-confetti@1.9.3/dist/confetti.browser.min.js"
+            integrity="sha256-XAXr7WaJcRT+HM+lo4/TccjvLjuXvAS7Og3dyBT8CIE="
+            crossorigin="anonymous"></script>
     <script src="js/confetti.js"></script>
     <script src="_framework/blazor.webassembly#[.{fingerprint}].js"></script>
 </body>

--- a/src/FantasyFootball.Web/wwwroot/index.html
+++ b/src/FantasyFootball.Web/wwwroot/index.html
@@ -29,6 +29,8 @@
 
     <script src="_content/MudBlazor/MudBlazor.min.js"></script>
     <script src="js/keyboard.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/canvas-confetti@1.9.3/dist/confetti.browser.min.js"></script>
+    <script src="js/confetti.js"></script>
     <script src="_framework/blazor.webassembly#[.{fingerprint}].js"></script>
 </body>
 

--- a/src/FantasyFootball.Web/wwwroot/js/confetti.js
+++ b/src/FantasyFootball.Web/wwwroot/js/confetti.js
@@ -1,0 +1,22 @@
+// Thin JS interop wrapper around the canvas-confetti library loaded via CDN in index.html.
+// Called from CompetitionDetail when a competition's IsFinished flips true during the visit.
+window.ffConfetti = (() => {
+    function celebrate() {
+        if (typeof confetti !== 'function') { return; }
+        // Two volleys from the bottom corners — condensed version of the canvas-confetti "cannons" README example.
+        const burst = (originX) => confetti({
+            particleCount: 90,
+            spread: 70,
+            startVelocity: 45,
+            origin: { x: originX, y: 0.85 },
+            disableForReducedMotion: true,
+        });
+        burst(0.15);
+        burst(0.85);
+    }
+    function reset() {
+        if (typeof confetti !== 'function' || typeof confetti.reset !== 'function') { return; }
+        confetti.reset();
+    }
+    return { celebrate, reset };
+})();


### PR DESCRIPTION
## Summary

A grab-bag of small finish-state polish + sim-feel fixes that grew out of the post-PR-29 review. Two themed commits.

| SHA | Chunk |
|---|---|
| \`fb948ee\` | Click-for-game-details popover on scoreboard rows |
| \`5b9dbf8\` | Replay, confetti, score-reveal, sim-feel followups |

### \`fb948ee\` — click-for-game-details popover
- Tap a scoreboard row → MudPopover anchored below shows Elo / win-draw-loss probabilities (computed via the same Poisson thinning model \`Game.Simulate\` uses) / cross-competition head-to-head / per-team detail links.
- Open state hoisted to the parent so clicking row B dismisses row A's popover automatically.
- Open row gets a subtle 3px primary-color inset left border + action-hover tint.
- On finished games, the percentage matching the actual outcome is bolded + tinted brand-green.
- H2H walks every stored Competition's finished games and matches by \`Team.Name\` (cross-competition graph boundary — \`NamedUniqueId.Equals\` falls back to \`ReferenceEquals\` on Id=0 entities and won't match across the deserialize barrier).
- New \`MatchProbability\` + \`HeadToHeadLookup\` utilities in \`FantasyFootball.Core/Services/\`. \`MatchProbabilityTests\` pins three cases (equal Elos, strong home, strong away).

### \`5b9dbf8\` — five small chunks bundled
- **Replay button** on finished competitions clones the team lineup into a fresh comp via \`Group.ShallowClone\` + the same factory; today's Elo is used (issue #19 will tighten this to a per-comp snapshot later).
- **Confetti burst** on \`Competition.IsFinished\` transition during the visit (suppressed when loading an already-finished comp). \`canvas-confetti\` via CDN + thin \`js/confetti.js\` wrapper. Replay handler calls \`confetti.reset()\` so in-flight particles from the previous finish don't bleed onto the new-comp page.
- **Score reveal animation** on single-game sim + Redo: pop in at 140% scale with brand-green tint, fade + scale + colour-settle to 100% over 450ms (opacity hits full by 35%, scale/colour run full duration).
- **Sim-feel: stop flipping away from the round you just simmed.** \`OnSimBatchComplete\` now takes \`advanceSelection\` (default true); \`SimulateRound\` passes false. \`OnGameFinished\` no longer auto-advances per game (it caused the same flip during non-Instant multi-game sims). \`SimulateGame\` and \`SimulateAll\` still advance via the default — next-game flow + trophy-landing respectively.
- **Sim ordering: rows fill chronologically.** \`SimulateRound\` snapshots \`round.AllGames.OrderBy(PlayedOn).ToList()\` and iterates that. \`Round.AllGames\` is factory order (group A first, then B, …) which interleaves with chronological kickoff times in the WC factories — pre-fix, display row 3 (16:00) updated AFTER row 4 (15:00) once sim worked down each group. Skip rather than break on a non-ready KO game so the rest of the round still runs.

## Related issues

- #33 — Group standings GD/Pts ordering anomaly (not addressed in this PR, surfaced during testing).
- #34 — Performance pass (KO-phase sim feels slow due to standings panel re-walking invariants on every game-finished; filed during this work, deferred to a follow-up).

## Test plan

- [ ] Click any scoreboard row → popover shows Elo / W-D-L % / H2H (or "none" if no prior sims).
- [ ] Click another row → first popover closes, second opens. Click same row again → closes.
- [ ] On a finished game, the actual outcome percentage is bold + green.
- [ ] KO game with placeholder team → popover shows "Teams not yet decided".
- [ ] Simulate a single game (Space) — score row pulses, score itself pops in at 140% + green tint + settles.
- [ ] Simulate Round at Normal speed — rows fill in chronological (display) order, NOT factory order; selected round stays put (does not auto-advance to next round).
- [ ] Simulate Tournament — finish-line confetti fires. Re-load the finished comp from the list → no confetti.
- [ ] Click "Simulate again" → new comp opens; previous confetti particles cleared (no residual fall).
- [ ] Tests: \`MatchProbabilityTests\` 3/3, no new test regressions vs the pre-PR baseline (6 pre-existing failures around issue #12 unchanged).