### PR TITLE
UI polish PR 4: games panel redesign — hierarchical pickers + whole-stage scroll

### DIFF
--- a/src/FantasyFootball.UI/Components/GameViewRow.razor
+++ b/src/FantasyFootball.UI/Components/GameViewRow.razor
@@ -4,7 +4,7 @@
 @using FantasyFootball.Repositories
 @inject IRepository Repo
 
-<div class="scoreboard-row-wrapper">
+<div class="scoreboard-row-wrapper" id="@(ShowSim ? "current-game" : null)">
 <div class="scoreboard-row @(IsJustFinished ? "scoreboard-row-just-finished" : "") @(DetailsOpen ? "scoreboard-row-open" : "")"
      @onclick="OnDetailsToggle">
   <div class="scoreboard-group-tag">

--- a/src/FantasyFootball.UI/Components/GroupView.razor
+++ b/src/FantasyFootball.UI/Components/GroupView.razor
@@ -44,10 +44,7 @@
   bool _thirdPlaceEligible;
   bool? _thirdPlaceAdvanced; // null = stage not finished yet (undetermined), true/false = resolved.
 
-  // Cache keys for issue #34: the qualifier walk inputs are structurally invariant within a
-  // competition (Stages + KoGame qualifiers don't change after construction), so we only need
-  // to compute once per Group reference. Third-place resolution depends on Stage.IsFinished
-  // additionally, which DOES change once during the comp.
+  // Qualifier-walk cache (issue #34): inputs are invariant per Group; only recompute on Group change or Stage.IsFinished transition.
   Group? _walkedGroup;
   bool? _walkedStageFinished;
   List<GroupQualifier>? _walkedLaterQualifiers;
@@ -59,22 +56,20 @@
     var competition = Group.Stage?.Competition;
     if (competition is null) { return; }
 
-    // Static walk: depends only on the Group + its competition's KO qualifiers, which are
-    // built once at competition creation. Re-running on every game-finished render across
-    // 12 groups was ~30ms of pure waste — the killer of issue #34.
     if (!ReferenceEquals(_walkedGroup, Group))
     {
       _walkedGroup = Group;
       _walkedStageFinished = null; // also force a third-place recompute below
       _directSlots = [];
       _thirdPlaceEligible = false;
+      _thirdPlaceAdvanced = null;
+      _walkedLaterQualifiers = null;
 
       var ownStageIndex = competition.Stages.IndexOf(Group.Stage);
-      // GroupQualifier.GroupId is the index within its OWN stage (per Qualifier.FromGroup), not across all
-      // stages. Today only one stage has groups so competition.Groups.IndexOf would happen to agree;
-      // using the stage-scoped list keeps this honest if a future format ever adds a second group stage.
+      // GroupQualifier.GroupId is the index within its OWN stage (per Qualifier.FromGroup); using the stage-scoped list keeps this honest if a future format adds a second group stage.
       var ownGroupIndex = Group.Stage.Groups.IndexOf(Group);
-      if (ownStageIndex < 0 || ownGroupIndex < 0) { return; }
+      // Reset _walkedGroup so the next render retries (the ReferenceEquals guard above would otherwise permanently skip the walk).
+      if (ownStageIndex < 0 || ownGroupIndex < 0) { _walkedGroup = null; return; }
 
       _walkedLaterQualifiers = competition.Stages
         .Skip(ownStageIndex + 1)
@@ -107,8 +102,7 @@
         var ownThirdPlaceTeam = _standings.ElementAtOrDefault(2)?.Team;
         if (ownThirdPlaceTeam is not null)
         {
-          // NamedUniqueId.Equals handles ReferenceEquals fallback for Id=0 entities (LocalStorage path)
-          // and Id-equality for Id>0 entities (future SQLite-backed BlazorWebView host).
+          // NamedUniqueId.Equals: ReferenceEquals fallback for Id=0 (LocalStorage), Id-equality for Id>0 (future SQLite host).
           _thirdPlaceAdvanced = _walkedLaterQualifiers
             .Where(q => !string.IsNullOrEmpty(q.ThirdPlaceCombination))
             .Any(q => Equals(q.Get(), ownThirdPlaceTeam));

--- a/src/FantasyFootball.UI/Components/GroupView.razor
+++ b/src/FantasyFootball.UI/Components/GroupView.razor
@@ -44,54 +44,75 @@
   bool _thirdPlaceEligible;
   bool? _thirdPlaceAdvanced; // null = stage not finished yet (undetermined), true/false = resolved.
 
+  // Cache keys for issue #34: the qualifier walk inputs are structurally invariant within a
+  // competition (Stages + KoGame qualifiers don't change after construction), so we only need
+  // to compute once per Group reference. Third-place resolution depends on Stage.IsFinished
+  // additionally, which DOES change once during the comp.
+  Group? _walkedGroup;
+  bool? _walkedStageFinished;
+  List<GroupQualifier>? _walkedLaterQualifiers;
+
   protected override void OnParametersSet()
   {
     _standings = Group.GetStandings();
-    _directSlots = [];
-    _thirdPlaceEligible = false;
-    _thirdPlaceAdvanced = null;
 
     var competition = Group.Stage?.Competition;
     if (competition is null) { return; }
 
-    var ownStageIndex = competition.Stages.IndexOf(Group.Stage);
-    // GroupQualifier.GroupId is the index within its OWN stage (per Qualifier.FromGroup), not across all
-    // stages. Today only one stage has groups so competition.Groups.IndexOf would happen to agree; using
-    // the stage-scoped list keeps this honest if a future format ever adds a second group stage.
-    var ownGroupIndex = Group.Stage.Groups.IndexOf(Group);
-    if (ownStageIndex < 0 || ownGroupIndex < 0) { return; }
-
-    var laterQualifiers = competition.Stages
-      .Skip(ownStageIndex + 1)
-      .SelectMany(s => s.Games.OfType<KoGame>())
-      .SelectMany(g => new[] { g.HomeGroupQualifier, g.AwayGroupQualifier })
-      .OfType<GroupQualifier>()
-      .ToList();
-
-    foreach (var q in laterQualifiers)
+    // Static walk: depends only on the Group + its competition's KO qualifiers, which are
+    // built once at competition creation. Re-running on every game-finished render across
+    // 12 groups was ~30ms of pure waste — the killer of issue #34.
+    if (!ReferenceEquals(_walkedGroup, Group))
     {
-      if (string.IsNullOrEmpty(q.ThirdPlaceCombination))
+      _walkedGroup = Group;
+      _walkedStageFinished = null; // also force a third-place recompute below
+      _directSlots = [];
+      _thirdPlaceEligible = false;
+
+      var ownStageIndex = competition.Stages.IndexOf(Group.Stage);
+      // GroupQualifier.GroupId is the index within its OWN stage (per Qualifier.FromGroup), not across all
+      // stages. Today only one stage has groups so competition.Groups.IndexOf would happen to agree;
+      // using the stage-scoped list keeps this honest if a future format ever adds a second group stage.
+      var ownGroupIndex = Group.Stage.Groups.IndexOf(Group);
+      if (ownStageIndex < 0 || ownGroupIndex < 0) { return; }
+
+      _walkedLaterQualifiers = competition.Stages
+        .Skip(ownStageIndex + 1)
+        .SelectMany(s => s.Games.OfType<KoGame>())
+        .SelectMany(g => new[] { g.HomeGroupQualifier, g.AwayGroupQualifier })
+        .OfType<GroupQualifier>()
+        .ToList();
+
+      foreach (var q in _walkedLaterQualifiers)
       {
-        if (q.GroupId == ownGroupIndex) { _directSlots.Add(q.FinalPlacement); }
-      }
-      else if (q.ThirdPlaceCombination.Split('/').Contains(Letter, StringComparer.OrdinalIgnoreCase))
-      {
-        _thirdPlaceEligible = true;
+        if (string.IsNullOrEmpty(q.ThirdPlaceCombination))
+        {
+          if (q.GroupId == ownGroupIndex) { _directSlots.Add(q.FinalPlacement); }
+        }
+        else if (q.ThirdPlaceCombination.Split('/').Contains(Letter, StringComparer.OrdinalIgnoreCase))
+        {
+          _thirdPlaceEligible = true;
+        }
       }
     }
 
-    // Once the group stage is finished we can resolve ThirdPlace qualifiers to actual teams. Position 3 then promotes from "no bar" to advance / out.
-    if (_thirdPlaceEligible && Group.Stage.IsFinished)
+    // Third-place resolution: depends on Stage.IsFinished. Recompute only on the false → true transition.
+    var stageFinishedNow = Group.Stage?.IsFinished ?? false;
+    if (_walkedStageFinished != stageFinishedNow)
     {
-      var ownThirdPlaceTeam = _standings.ElementAtOrDefault(2)?.Team;
-      if (ownThirdPlaceTeam is not null)
+      _walkedStageFinished = stageFinishedNow;
+      _thirdPlaceAdvanced = null;
+      if (_thirdPlaceEligible && stageFinishedNow && _walkedLaterQualifiers is not null)
       {
-        // NamedUniqueId.Equals handles both worlds: ReferenceEquals fallback for Id=0 entities
-        // (LocalStorage path — Team instances inside Competition have unset Ids), and Id-equality
-        // for Id>0 entities (future SQLite-backed BlazorWebView host). Stable across both paths.
-        _thirdPlaceAdvanced = laterQualifiers
-          .Where(q => !string.IsNullOrEmpty(q.ThirdPlaceCombination))
-          .Any(q => Equals(q.Get(), ownThirdPlaceTeam));
+        var ownThirdPlaceTeam = _standings.ElementAtOrDefault(2)?.Team;
+        if (ownThirdPlaceTeam is not null)
+        {
+          // NamedUniqueId.Equals handles ReferenceEquals fallback for Id=0 entities (LocalStorage path)
+          // and Id-equality for Id>0 entities (future SQLite-backed BlazorWebView host).
+          _thirdPlaceAdvanced = _walkedLaterQualifiers
+            .Where(q => !string.IsNullOrEmpty(q.ThirdPlaceCombination))
+            .Any(q => Equals(q.Get(), ownThirdPlaceTeam));
+        }
       }
     }
   }

--- a/src/FantasyFootball.UI/FantasyFootball.UI.csproj
+++ b/src/FantasyFootball.UI/FantasyFootball.UI.csproj
@@ -16,6 +16,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="10.0.8" />
     <PackageReference Include="MudBlazor" Version="9.4.0" />
+    <PackageReference Include="Serilog" Version="4.3.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/FantasyFootball.UI/GlobalUsings.cs
+++ b/src/FantasyFootball.UI/GlobalUsings.cs
@@ -1,1 +1,2 @@
 global using System.Globalization;
+global using Serilog;

--- a/src/FantasyFootball.UI/Pages/CompetitionDetail.razor
+++ b/src/FantasyFootball.UI/Pages/CompetitionDetail.razor
@@ -87,6 +87,8 @@ else
         <div class="round-chip-row">
           @foreach (var r in ViewModel.Rounds)
           {
+            var roundForChip = r;
+            var roundIdxForChip = ViewModel.Rounds.IndexOf(r);
             var isSelected = ReferenceEquals(r, ViewModel.SelectedRound);
             var isCurrent  = ReferenceEquals(r, ViewModel.SelectedStage?.CurrentRound);
             var isDone     = r.IsFinished;
@@ -95,7 +97,7 @@ else
                      Variant="@(isSelected ? Variant.Filled : Variant.Outlined)"
                      Color="@(isSelected ? Color.Primary : isDone ? Color.Success : isCurrent ? Color.Primary : Color.Default)"
                      Size="Size.Small"
-                     OnClick="@(() => ViewModel.SelectedRound = r)">
+                     OnClick="@(async () => await OnRoundChipClick(roundForChip, roundIdxForChip))">
               @r.Name@(isDone ? " ✓" : "")
             </MudChip>
           }
@@ -117,35 +119,53 @@ else
                              title="Simulate round (R or Shift+Space)" />
             }
           </MudStack>
-          @if (ViewModel.SelectedRound is not null)
+          @if (ViewModel.SelectedStage is not null)
           {
-            var games = ViewModel.SelectedRound.AllGames.OrderBy(g => g.PlayedOn).ToList();
-            var multiDay = games.Select(g => g.PlayedOn.Date).Distinct().Count() > 1;
-            // Reference-compare, not Id-compare: nested entities in the LocalStorage path keep Id=0
-            // (LocalStorageRepository only assigns IDs to aggregate roots), so `game.Id == X.Id` is true
-            // for every row when X.Id is also 0. Reference equality works because both sides come from
-            // the live Competition graph rendered this pass.
+            // Variant B: render ALL rounds in the selected stage, each as its own section with a header,
+            // so user keeps prior results visible while scrolling forward. Chip strip above acts as a
+            // scroll-to anchor (see OnRoundChipClick). Day-grouping dividers stay per-round.
+            // Reference-compare, not Id-compare: nested entities in the LocalStorage path keep Id=0.
             var currentGame = ViewModel.Competition?.CurrentGame;
             var undoTargetGame = ViewModel.UndoTargetGame;
-            @foreach (var dayGroup in games.GroupBy(g => g.PlayedOn.Date))
+            @foreach (var round in ViewModel.SelectedStage.Rounds)
             {
-              @if (multiDay)
-              {
-                <div class="game-day-divider">@dayGroup.Key.ToString("ddd d MMM", System.Globalization.CultureInfo.CurrentCulture)</div>
-              }
-              @foreach (var game in dayGroup)
-              {
-                <GameViewRow Game="game"
-                             ShowSim="@(ReferenceEquals(game, currentGame))"
-                             ShowUndo="@(ReferenceEquals(game, undoTargetGame))"
-                             IsJustFinished="@(ReferenceEquals(game, ViewModel.RecentlyFinishedGame))"
-                             Disabled="@ViewModel.IsBusy"
-                             DetailsOpen="@(ReferenceEquals(game, _openDetailsGame))"
-                             OnDetailsToggle="@(() => ToggleDetailsGame(game))"
-                             OnSim="@(async () => await ViewModel.SimulateGame())"
-                             OnUndo="@(() => ViewModel.Undo())"
-                             OnRedo="@(async () => await ViewModel.RedoLastGame())" />
-              }
+              var roundIdx = ViewModel.SelectedStage.Rounds.IndexOf(round);
+              var games = round.AllGames.OrderBy(g => g.PlayedOn).ToList();
+              var multiDay = games.Select(g => g.PlayedOn.Date).Distinct().Count() > 1;
+              <section id="@($"round-{roundIdx}")"
+                       class="round-section @(ReferenceEquals(round, ViewModel.SelectedRound) ? "round-section-selected" : "")">
+                <div class="round-header">
+                  <span class="round-header-name">@round.Name</span>
+                  @if (round.IsFinished)
+                  {
+                    <span class="round-header-status">✓</span>
+                  }
+                  else if (ReferenceEquals(round, ViewModel.SelectedStage.CurrentRound))
+                  {
+                    <span class="round-header-status round-header-status-current">current</span>
+                  }
+                </div>
+                @foreach (var dayGroup in games.GroupBy(g => g.PlayedOn.Date))
+                {
+                  @if (multiDay)
+                  {
+                    <div class="game-day-divider">@dayGroup.Key.ToString("ddd d MMM", System.Globalization.CultureInfo.CurrentCulture)</div>
+                  }
+                  @foreach (var game in dayGroup)
+                  {
+                    <GameViewRow Game="game"
+                                 ShowSim="@(ReferenceEquals(game, currentGame))"
+                                 ShowUndo="@(ReferenceEquals(game, undoTargetGame))"
+                                 IsJustFinished="@(ReferenceEquals(game, ViewModel.RecentlyFinishedGame))"
+                                 Disabled="@ViewModel.IsBusy"
+                                 DetailsOpen="@(ReferenceEquals(game, _openDetailsGame))"
+                                 OnDetailsToggle="@(() => ToggleDetailsGame(game))"
+                                 OnSim="@(async () => await ViewModel.SimulateGame())"
+                                 OnUndo="@(() => ViewModel.Undo())"
+                                 OnRedo="@(async () => await ViewModel.RedoLastGame())" />
+                  }
+                }
+              </section>
             }
           }
         </MudPaper>
@@ -206,6 +226,13 @@ else
   DotNetObjectReference<CompetitionDetail>? _selfRef;
 
   void ToggleDetailsGame(Game game) => _openDetailsGame = ReferenceEquals(_openDetailsGame, game) ? null : game;
+
+  async Task OnRoundChipClick(Round round, int idx)
+  {
+    ViewModel.SelectedRound = round;
+    try { await JS.InvokeVoidAsync("ffScroll.toElement", $"round-{idx}"); }
+    catch (JSDisconnectedException) { /* page disposing */ }
+  }
 
   async Task ReplayCompetition()
   {

--- a/src/FantasyFootball.UI/Pages/CompetitionDetail.razor
+++ b/src/FantasyFootball.UI/Pages/CompetitionDetail.razor
@@ -38,6 +38,11 @@ else
                        OnClick="@(async () => await ViewModel.SimulateAll())"
                        Disabled="ViewModel.IsBusy"
                        title="Simulate tournament (T)" />
+        <MudIconButton Icon="@Icons.Material.Filled.MyLocation"
+                       Size="Size.Small"
+                       OnClick="JumpToCurrent"
+                       Disabled="ViewModel.Competition?.CurrentGame is null"
+                       title="Jump to the current round" />
       }
       @if (ViewModel.IsBusy)
       {
@@ -64,61 +69,75 @@ else
                      title="Quick settings &amp; keyboard shortcuts (H or ?)" />
     </MudStack>
 
-    <MudGrid Spacing="2">
-      <MudItem xs="12" sm="4">
-        <MudSelect T="Stage"
-                   Label="Stage"
-                   Value="ViewModel.SelectedStage"
-                   ValueChanged="@(v => ViewModel.SelectedStage = v)"
-                   ToStringFunc="@(s => s?.Name ?? "")"
-                   FullWidth="true">
+    @* Hierarchical timeline pickers: Stage chips on top, Round chips below indented under the selected stage.
+       Each row has a dotted-line backdrop to evoke "timeline / temporal progression". Stage rows are slightly
+       larger and use Medium chips; round rows use Small chips. Status semantics shared between both:
+       Selected → filled primary; Done → outlined success + ✓; Current → outlined primary; Future → outlined default. *@
+    <div class="timeline-pickers">
+      <div class="timeline-row timeline-row-stage">
+        <span class="timeline-label">Stage</span>
+        <div class="timeline-chips">
           @foreach (var s in ViewModel.Stages)
           {
-            <MudSelectItem Value="@s">@s.Name</MudSelectItem>
+            var stageForChip = s;
+            var isSelected = ReferenceEquals(s, ViewModel.SelectedStage);
+            var isCurrent  = ReferenceEquals(s, ViewModel.Competition?.CurrentStage);
+            var isDone     = s.IsFinished;
+            <MudChip T="Stage"
+                     Value="@s"
+                     Variant="@(isSelected ? Variant.Filled : Variant.Outlined)"
+                     Color="@(isSelected ? Color.Primary : Color.Default)"
+                     Size="Size.Medium"
+                     Class="@ChipStatusClass(isSelected, isCurrent, isDone)"
+                     OnClick="@(() => ViewModel.SelectedStage = stageForChip)">
+              @s.Name@(isDone ? " ✓" : "")
+            </MudChip>
           }
-        </MudSelect>
-      </MudItem>
-      <MudItem xs="12" sm="8">
-        @* Round picker as a horizontal chip strip. Each chip's visual state encodes status:
-           - Selected round → filled primary.
-           - Finished round (results available)  → outlined success + ✓.
-           - Current round (next to sim)         → outlined primary.
-           - Future round                        → outlined default. *@
-        <div class="round-chip-row">
+        </div>
+      </div>
+      <div class="timeline-row timeline-row-round">
+        <span class="timeline-label">Round</span>
+        <div class="timeline-chips">
           @foreach (var r in ViewModel.Rounds)
           {
             var roundForChip = r;
             var roundIdxForChip = ViewModel.Rounds.IndexOf(r);
             var isSelected = ReferenceEquals(r, ViewModel.SelectedRound);
-            var isCurrent  = ReferenceEquals(r, ViewModel.SelectedStage?.CurrentRound);
+            // "Current" = the single round being played NOW across the whole tournament — not "first
+            // non-finished in the currently-selected stage". The latter incorrectly flagged KO round 1
+            // as current while group stage was still being simmed.
+            var isCurrent  = ReferenceEquals(r, ViewModel.Competition?.CurrentGame?.Round);
             var isDone     = r.IsFinished;
             <MudChip T="Round"
                      Value="@r"
                      Variant="@(isSelected ? Variant.Filled : Variant.Outlined)"
-                     Color="@(isSelected ? Color.Primary : isDone ? Color.Success : isCurrent ? Color.Primary : Color.Default)"
+                     Color="@(isSelected ? Color.Primary : Color.Default)"
                      Size="Size.Small"
+                     Class="@ChipStatusClass(isSelected, isCurrent, isDone)"
                      OnClick="@(async () => await OnRoundChipClick(roundForChip, roundIdxForChip))">
               @r.Name@(isDone ? " ✓" : "")
             </MudChip>
+            @* Inter-chip "sim this round" affordance: visible only when the round still has games
+               to simulate. Replaces the previous Games-header sim-round button. *@
+            @if (!r.IsFinished)
+            {
+              <MudIconButton Icon="@Icons.Material.Filled.PlayArrow"
+                             Size="Size.Small"
+                             Color="Color.Primary"
+                             OnClick="@(async () => await SimulateRoundChip(roundForChip))"
+                             Disabled="ViewModel.IsBusy"
+                             title="@($"Simulate {r.Name}")"
+                             Class="round-sim-button" />
+            }
           }
         </div>
-      </MudItem>
-    </MudGrid>
+      </div>
+    </div>
 
     <MudGrid Spacing="3">
       <MudItem xs="12" md="7">
-        <MudPaper Class="pa-3" Elevation="1">
-          <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1" Class="mb-2">
-            <MudText Typo="Typo.h6">Games</MudText>
-            @if (!ViewModel.IsFinished && ViewModel.SelectedRound is not null)
-            {
-              <MudIconButton Icon="@Icons.Material.Filled.SkipNext"
-                             Size="Size.Small"
-                             OnClick="@(async () => await ViewModel.SimulateRound())"
-                             Disabled="ViewModel.IsBusy"
-                             title="Simulate round (R or Shift+Space)" />
-            }
-          </MudStack>
+        <MudPaper Class="pa-3 bounded-scroll-card" Elevation="4">
+          <MudText Typo="Typo.h6" Class="mb-2">Games</MudText>
           @if (ViewModel.SelectedStage is not null)
           {
             // Variant B: render ALL rounds in the selected stage, each as its own section with a header,
@@ -136,42 +155,38 @@ else
                        class="round-section @(ReferenceEquals(round, ViewModel.SelectedRound) ? "round-section-selected" : "")">
                 <div class="round-header">
                   <span class="round-header-name">@round.Name</span>
-                  @if (round.IsFinished)
+                </div>
+                @* Auto-fit games grid: as many columns as fit at min 22rem each. Single col on narrow,
+                   2-3 cols on wider screens. Day-grouping dividers span all columns via grid-column: 1 / -1. *@
+                <div class="round-games-grid">
+                  @foreach (var dayGroup in games.GroupBy(g => g.PlayedOn.Date))
                   {
-                    <span class="round-header-status">✓</span>
-                  }
-                  else if (ReferenceEquals(round, ViewModel.SelectedStage.CurrentRound))
-                  {
-                    <span class="round-header-status round-header-status-current">current</span>
+                    @if (multiDay)
+                    {
+                      <div class="game-day-divider">@dayGroup.Key.ToString("ddd d MMM", System.Globalization.CultureInfo.CurrentCulture)</div>
+                    }
+                    @foreach (var game in dayGroup)
+                    {
+                      <GameViewRow Game="game"
+                                   ShowSim="@(ReferenceEquals(game, currentGame))"
+                                   ShowUndo="@(ReferenceEquals(game, undoTargetGame))"
+                                   IsJustFinished="@(ReferenceEquals(game, ViewModel.RecentlyFinishedGame))"
+                                   Disabled="@ViewModel.IsBusy"
+                                   DetailsOpen="@(ReferenceEquals(game, _openDetailsGame))"
+                                   OnDetailsToggle="@(() => ToggleDetailsGame(game))"
+                                   OnSim="@(async () => await ViewModel.SimulateGame())"
+                                   OnUndo="@(() => ViewModel.Undo())"
+                                   OnRedo="@(async () => await ViewModel.RedoLastGame())" />
+                    }
                   }
                 </div>
-                @foreach (var dayGroup in games.GroupBy(g => g.PlayedOn.Date))
-                {
-                  @if (multiDay)
-                  {
-                    <div class="game-day-divider">@dayGroup.Key.ToString("ddd d MMM", System.Globalization.CultureInfo.CurrentCulture)</div>
-                  }
-                  @foreach (var game in dayGroup)
-                  {
-                    <GameViewRow Game="game"
-                                 ShowSim="@(ReferenceEquals(game, currentGame))"
-                                 ShowUndo="@(ReferenceEquals(game, undoTargetGame))"
-                                 IsJustFinished="@(ReferenceEquals(game, ViewModel.RecentlyFinishedGame))"
-                                 Disabled="@ViewModel.IsBusy"
-                                 DetailsOpen="@(ReferenceEquals(game, _openDetailsGame))"
-                                 OnDetailsToggle="@(() => ToggleDetailsGame(game))"
-                                 OnSim="@(async () => await ViewModel.SimulateGame())"
-                                 OnUndo="@(() => ViewModel.Undo())"
-                                 OnRedo="@(async () => await ViewModel.RedoLastGame())" />
-                  }
-                }
               </section>
             }
           }
         </MudPaper>
       </MudItem>
       <MudItem xs="12" md="5">
-        <MudPaper Class="pa-3" Elevation="1">
+        <MudPaper Class="pa-3 bounded-scroll-card" Elevation="4">
           <MudText Typo="Typo.h6" GutterBottom="true">Standings</MudText>
           @foreach (var group in ViewModel.Groups)
           {
@@ -182,6 +197,13 @@ else
     </MudGrid>
   </MudStack>
 }
+
+<!-- Click-outside-to-dismiss for the per-row game-details popover. Transparent overlay catches clicks
+     anywhere on the page; MudPopover sits at its default z-index ~1300 which is above the 1100 here. -->
+<MudOverlay Visible="@(_openDetailsGame is not null)"
+            DarkBackground="false"
+            ZIndex="1100"
+            @onclick="@(() => _openDetailsGame = null)" />
 
 <MudOverlay Visible="_helpOpen" DarkBackground="true" ZIndex="9999" @onclick="@(() => _helpOpen = false)">
   <MudPaper Class="pa-4" Elevation="6" Style="max-width: 36rem;" @onclick:stopPropagation="true">
@@ -222,7 +244,11 @@ else
   int? _lastLoadedId;
   bool _helpOpen;
   Game? _openDetailsGame;
-  int? _confettiFiredFor;
+  // Tracks the *Competition reference* we've already fired confetti for. Reference comparison survives
+  // the race where ViewModel.Load fires property changes BEFORE swapping Competition (so a lambda sees
+  // IsFinished=true on the old comp while Id has already flipped to the new one). Id-based guard misfired
+  // confetti on Simulate Again in that window.
+  Competition? _confettiFiredCompetition;
   DotNetObjectReference<CompetitionDetail>? _selfRef;
 
   void ToggleDetailsGame(Game game) => _openDetailsGame = ReferenceEquals(_openDetailsGame, game) ? null : game;
@@ -233,6 +259,40 @@ else
     try { await JS.InvokeVoidAsync("ffScroll.toElement", $"round-{idx}"); }
     catch (JSDisconnectedException) { /* page disposing */ }
   }
+
+  async Task JumpToCurrent()
+  {
+    var cur = ViewModel.Competition?.CurrentGame?.Round;
+    if (cur is null) { return; }
+    ViewModel.SelectedStage = cur.Stage;
+    ViewModel.SelectedRound = cur;
+    // Scroll to the actual current-game row (the one rendering the Sim button), not just the round
+    // header — a round can have 10+ games and the active one might be far below the header.
+    try { await JS.InvokeVoidAsync("ffScroll.toElement", "current-game"); }
+    catch (JSDisconnectedException) { /* page disposing */ }
+  }
+
+  // SimulateRound triggered by the inter-chip play icon. Switches to that round before simming so the
+  // panel scrolls there (auto-advance in the VM keeps it tracked too).
+  async Task SimulateRoundChip(Round round)
+  {
+    ViewModel.SelectedStage = round.Stage;
+    ViewModel.SelectedRound = round;
+    await ViewModel.SimulateRound();
+  }
+
+  // Tracks the last round we've scrolled to so OnVmChanged doesn't fire scrollIntoView on every
+  // unrelated property change. -1 means "no scroll yet".
+  int _lastScrolledRoundIdx = -1;
+
+  // Chip status visual encoding (color + border + opacity, not color alone).
+  // Selected: filled brand-primary via Color.Primary. Done: default outline (looks "white" on dark theme).
+  // Current: default outline + dashed border (.chip-current). Future: default outline + 50% opacity (.chip-future).
+  static string ChipStatusClass(bool isSelected, bool isCurrent, bool isDone) =>
+    isSelected ? "" :
+    isCurrent ? "chip-current" :
+    isDone ? "chip-done" :
+    "chip-future";
 
   async Task ReplayCompetition()
   {
@@ -253,7 +313,7 @@ else
     ViewModel.Load(Id);
     // Loading an already-finished comp from the list: suppress confetti so the user only sees it
     // when their own sim crosses the finish line, not when they revisit an old result.
-    _confettiFiredFor = ViewModel.IsFinished ? Id : null;
+    _confettiFiredCompetition = ViewModel.IsFinished ? ViewModel.Competition : null;
   }
 
   protected override async Task OnAfterRenderAsync(bool firstRender)
@@ -269,12 +329,44 @@ else
 
   void OnVmChanged(object? sender, EventArgs e) => InvokeAsync(async () =>
   {
-    if (ViewModel.IsFinished && _confettiFiredFor != Id)
+    // Reference comparison: survives the race where Load fires events before swapping Competition.
+    if (ViewModel.IsFinished
+        && ViewModel.Competition is not null
+        && !ReferenceEquals(_confettiFiredCompetition, ViewModel.Competition))
     {
-      _confettiFiredFor = Id;
+      _confettiFiredCompetition = ViewModel.Competition;
       try { await JS.InvokeVoidAsync("ffConfetti.celebrate"); }
       catch (JSDisconnectedException) { /* Page navigated away while the call was in flight. */ }
     }
+
+    // Auto-scroll to follow SelectedRound during ACTIVE multi-game sims, but ONLY on round transitions
+    // (not on the first IsBusy fire). A single-game sim keeps the same SelectedRound — without this
+    // guard the page would scroll to the top of the round the user was already viewing, losing their
+    // place within the round.
+    if (ViewModel.IsBusy)
+    {
+      var stage = ViewModel.SelectedStage;
+      var selectedIdx = (stage is not null && ViewModel.SelectedRound is not null)
+        ? stage.Rounds.IndexOf(ViewModel.SelectedRound)
+        : -1;
+      if (selectedIdx >= 0 && _lastScrolledRoundIdx < 0)
+      {
+        // First IsBusy event in this batch — remember the current round without scrolling.
+        _lastScrolledRoundIdx = selectedIdx;
+      }
+      else if (selectedIdx >= 0 && selectedIdx != _lastScrolledRoundIdx)
+      {
+        // Round changed mid-sim — scroll to the new one.
+        _lastScrolledRoundIdx = selectedIdx;
+        try { await JS.InvokeVoidAsync("ffScroll.toElement", $"round-{selectedIdx}"); }
+        catch (JSDisconnectedException) { /* */ }
+      }
+    }
+    else
+    {
+      _lastScrolledRoundIdx = -1;
+    }
+
     StateHasChanged();
   });
 
@@ -288,7 +380,6 @@ else
     if (_helpOpen)
     {
       if (key == "Escape") { _helpOpen = false; StateHasChanged(); }
-      // Swallow everything else while the overlay is up — no sim shortcuts firing behind it.
       return;
     }
 

--- a/src/FantasyFootball.UI/Pages/CompetitionDetail.razor
+++ b/src/FantasyFootball.UI/Pages/CompetitionDetail.razor
@@ -65,7 +65,7 @@ else
     </MudStack>
 
     <MudGrid Spacing="2">
-      <MudItem xs="12" sm="6">
+      <MudItem xs="12" sm="4">
         <MudSelect T="Stage"
                    Label="Stage"
                    Value="ViewModel.SelectedStage"
@@ -78,18 +78,28 @@ else
           }
         </MudSelect>
       </MudItem>
-      <MudItem xs="12" sm="6">
-        <MudSelect T="Round"
-                   Label="Round"
-                   Value="ViewModel.SelectedRound"
-                   ValueChanged="@(v => ViewModel.SelectedRound = v)"
-                   ToStringFunc="@(r => r?.Name ?? "")"
-                   FullWidth="true">
+      <MudItem xs="12" sm="8">
+        @* Round picker as a horizontal chip strip. Each chip's visual state encodes status:
+           - Selected round → filled primary.
+           - Finished round (results available)  → outlined success + ✓.
+           - Current round (next to sim)         → outlined primary.
+           - Future round                        → outlined default. *@
+        <div class="round-chip-row">
           @foreach (var r in ViewModel.Rounds)
           {
-            <MudSelectItem Value="@r">@r.Name</MudSelectItem>
+            var isSelected = ReferenceEquals(r, ViewModel.SelectedRound);
+            var isCurrent  = ReferenceEquals(r, ViewModel.SelectedStage?.CurrentRound);
+            var isDone     = r.IsFinished;
+            <MudChip T="Round"
+                     Value="@r"
+                     Variant="@(isSelected ? Variant.Filled : Variant.Outlined)"
+                     Color="@(isSelected ? Color.Primary : isDone ? Color.Success : isCurrent ? Color.Primary : Color.Default)"
+                     Size="Size.Small"
+                     OnClick="@(() => ViewModel.SelectedRound = r)">
+              @r.Name@(isDone ? " ✓" : "")
+            </MudChip>
           }
-        </MudSelect>
+        </div>
       </MudItem>
     </MudGrid>
 

--- a/src/FantasyFootball.UI/Pages/CompetitionDetail.razor
+++ b/src/FantasyFootball.UI/Pages/CompetitionDetail.razor
@@ -41,7 +41,7 @@ else
         <MudIconButton Icon="@Icons.Material.Filled.MyLocation"
                        Size="Size.Small"
                        OnClick="JumpToCurrent"
-                       Disabled="ViewModel.Competition?.CurrentGame is null"
+                       Disabled="ViewModel.Competition?.CurrentGame is null || ViewModel.IsBusy"
                        title="Jump to the current round" />
       }
       @if (ViewModel.IsBusy)
@@ -89,7 +89,8 @@ else
                      Color="@(isSelected ? Color.Primary : Color.Default)"
                      Size="Size.Medium"
                      Class="@ChipStatusClass(isSelected, isCurrent, isDone)"
-                     OnClick="@(() => ViewModel.SelectedStage = stageForChip)">
+                     Disabled="ViewModel.IsBusy"
+                     OnClick="@(() => OnStageChipClick(stageForChip))">
               @s.Name@(isDone ? " ✓" : "")
             </MudChip>
           }
@@ -103,9 +104,7 @@ else
             var roundForChip = r;
             var roundIdxForChip = ViewModel.Rounds.IndexOf(r);
             var isSelected = ReferenceEquals(r, ViewModel.SelectedRound);
-            // "Current" = the single round being played NOW across the whole tournament — not "first
-            // non-finished in the currently-selected stage". The latter incorrectly flagged KO round 1
-            // as current while group stage was still being simmed.
+            // "Current" = round of the tournament's CurrentGame, not SelectedStage.CurrentRound (latter mis-flagged KO rounds while group stage was still being simmed).
             var isCurrent  = ReferenceEquals(r, ViewModel.Competition?.CurrentGame?.Round);
             var isDone     = r.IsFinished;
             <MudChip T="Round"
@@ -114,12 +113,12 @@ else
                      Color="@(isSelected ? Color.Primary : Color.Default)"
                      Size="Size.Small"
                      Class="@ChipStatusClass(isSelected, isCurrent, isDone)"
+                     Disabled="ViewModel.IsBusy"
                      OnClick="@(async () => await OnRoundChipClick(roundForChip, roundIdxForChip))">
               @r.Name@(isDone ? " ✓" : "")
             </MudChip>
-            @* Inter-chip "sim this round" affordance: visible only when the round still has games
-               to simulate. Replaces the previous Games-header sim-round button. *@
-            @if (!r.IsFinished)
+            @* Sim button only on the tournament-current round — ViewModel.SimulateRound always sims CurrentStage.CurrentRound, so rendering on future rounds would mismatch tooltip with behaviour. *@
+            @if (!r.IsFinished && ReferenceEquals(r, ViewModel.Competition?.CurrentGame?.Round))
             {
               <MudIconButton Icon="@Icons.Material.Filled.PlayArrow"
                              Size="Size.Small"
@@ -140,10 +139,7 @@ else
           <MudText Typo="Typo.h6" Class="mb-2">Games</MudText>
           @if (ViewModel.SelectedStage is not null)
           {
-            // Variant B: render ALL rounds in the selected stage, each as its own section with a header,
-            // so user keeps prior results visible while scrolling forward. Chip strip above acts as a
-            // scroll-to anchor (see OnRoundChipClick). Day-grouping dividers stay per-round.
-            // Reference-compare, not Id-compare: nested entities in the LocalStorage path keep Id=0.
+            // Render all rounds in the selected stage; chip strip scrolls between them via round-{idx} anchors. Reference-compare since LocalStorage entities keep Id=0.
             var currentGame = ViewModel.Competition?.CurrentGame;
             var undoTargetGame = ViewModel.UndoTargetGame;
             @foreach (var round in ViewModel.SelectedStage.Rounds)
@@ -156,8 +152,6 @@ else
                 <div class="round-header">
                   <span class="round-header-name">@round.Name</span>
                 </div>
-                @* Auto-fit games grid: as many columns as fit at min 22rem each. Single col on narrow,
-                   2-3 cols on wider screens. Day-grouping dividers span all columns via grid-column: 1 / -1. *@
                 <div class="round-games-grid">
                   @foreach (var dayGroup in games.GroupBy(g => g.PlayedOn.Date))
                   {
@@ -244,14 +238,27 @@ else
   int? _lastLoadedId;
   bool _helpOpen;
   Game? _openDetailsGame;
-  // Tracks the *Competition reference* we've already fired confetti for. Reference comparison survives
-  // the race where ViewModel.Load fires property changes BEFORE swapping Competition (so a lambda sees
-  // IsFinished=true on the old comp while Id has already flipped to the new one). Id-based guard misfired
-  // confetti on Simulate Again in that window.
+  // Guard tracks Competition reference, not Id — survives the load-race window where Id swaps before Competition is reassigned.
   Competition? _confettiFiredCompetition;
+  // Scroll target to flush after the next render — set when a state change (e.g. SelectedStage in JumpToCurrent) needs DOM that doesn't exist yet.
+  string? _pendingScrollId;
+  // Tracks last scrolled round during active sim; -1 = no scroll yet.
+  int _lastScrolledRoundIdx = -1;
   DotNetObjectReference<CompetitionDetail>? _selfRef;
 
   void ToggleDetailsGame(Game game) => _openDetailsGame = ReferenceEquals(_openDetailsGame, game) ? null : game;
+
+  // Mirror StepStage's scroll-queue behaviour so mouse and keyboard stage navigation feel consistent.
+  void OnStageChipClick(Stage stage)
+  {
+    _openDetailsGame = null;
+    ViewModel.SelectedStage = stage;
+    if (ViewModel.SelectedRound is { } round)
+    {
+      var idx = stage.Rounds.IndexOf(round);
+      if (idx >= 0) { _pendingScrollId = $"round-{idx}"; }
+    }
+  }
 
   async Task OnRoundChipClick(Round round, int idx)
   {
@@ -264,16 +271,20 @@ else
   {
     var cur = ViewModel.Competition?.CurrentGame?.Round;
     if (cur is null) { return; }
-    ViewModel.SelectedStage = cur.Stage;
+    // OnSelectedStageChanged snaps SelectedRound on stage change; only set explicitly when staying in the same stage.
+    if (!ReferenceEquals(cur.Stage, ViewModel.SelectedStage))
+    {
+      // Stage change queues a re-render — the new stage's #current-game element doesn't exist yet, so defer to OnAfterRenderAsync.
+      ViewModel.SelectedStage = cur.Stage;
+      _pendingScrollId = "current-game";
+      return;
+    }
     ViewModel.SelectedRound = cur;
-    // Scroll to the actual current-game row (the one rendering the Sim button), not just the round
-    // header — a round can have 10+ games and the active one might be far below the header.
     try { await JS.InvokeVoidAsync("ffScroll.toElement", "current-game"); }
     catch (JSDisconnectedException) { /* page disposing */ }
   }
 
-  // SimulateRound triggered by the inter-chip play icon. Switches to that round before simming so the
-  // panel scrolls there (auto-advance in the VM keeps it tracked too).
+  // Switches to the round before simming so the panel follows (VM auto-advance also tracks it).
   async Task SimulateRoundChip(Round round)
   {
     ViewModel.SelectedStage = round.Stage;
@@ -281,13 +292,7 @@ else
     await ViewModel.SimulateRound();
   }
 
-  // Tracks the last round we've scrolled to so OnVmChanged doesn't fire scrollIntoView on every
-  // unrelated property change. -1 means "no scroll yet".
-  int _lastScrolledRoundIdx = -1;
-
-  // Chip status visual encoding (color + border + opacity, not color alone).
-  // Selected: filled brand-primary via Color.Primary. Done: default outline (looks "white" on dark theme).
-  // Current: default outline + dashed border (.chip-current). Future: default outline + 50% opacity (.chip-future).
+  // Chip status: selected=filled primary; current=dashed outline; future=50% opacity; done=solid outline.
   static string ChipStatusClass(bool isSelected, bool isCurrent, bool isDone) =>
     isSelected ? "" :
     isCurrent ? "chip-current" :
@@ -320,10 +325,15 @@ else
   {
     if (firstRender)
     {
-      // Document-level keydown forwarder. Listening on document (not the page root div) means Space + arrows
-      // work without the user clicking into the page first; the JS side skips when focus is on an input.
+      // Document-level keydown forwarder so Space + arrows work without clicking into the page first; JS skips when focus is on an input.
       _selfRef = DotNetObjectReference.Create(this);
       await JS.InvokeVoidAsync("ffKeyboard.registerDocumentHandler", _selfRef);
+    }
+    if (_pendingScrollId is { } id)
+    {
+      _pendingScrollId = null;
+      try { await JS.InvokeVoidAsync("ffScroll.toElement", id); }
+      catch (JSDisconnectedException) { /* page disposing */ }
     }
   }
 
@@ -339,10 +349,7 @@ else
       catch (JSDisconnectedException) { /* Page navigated away while the call was in flight. */ }
     }
 
-    // Auto-scroll to follow SelectedRound during ACTIVE multi-game sims, but ONLY on round transitions
-    // (not on the first IsBusy fire). A single-game sim keeps the same SelectedRound — without this
-    // guard the page would scroll to the top of the round the user was already viewing, losing their
-    // place within the round.
+    // Follow round transitions during active sim; first IsBusy fire just records (don't scroll a single-game sim away from the user's viewport).
     if (ViewModel.IsBusy)
     {
       var stage = ViewModel.SelectedStage;
@@ -351,15 +358,13 @@ else
         : -1;
       if (selectedIdx >= 0 && _lastScrolledRoundIdx < 0)
       {
-        // First IsBusy event in this batch — remember the current round without scrolling.
         _lastScrolledRoundIdx = selectedIdx;
       }
       else if (selectedIdx >= 0 && selectedIdx != _lastScrolledRoundIdx)
       {
-        // Round changed mid-sim — scroll to the new one.
         _lastScrolledRoundIdx = selectedIdx;
         try { await JS.InvokeVoidAsync("ffScroll.toElement", $"round-{selectedIdx}"); }
-        catch (JSDisconnectedException) { /* */ }
+        catch (JSDisconnectedException) { /* page disposing */ }
       }
     }
     else
@@ -422,7 +427,9 @@ else
     if (rounds.Count == 0 || ViewModel.SelectedRound is null) { return; }
     var i = rounds.IndexOf(ViewModel.SelectedRound);
     if (i < 0) { return; }
-    ViewModel.SelectedRound = rounds[(i + delta + rounds.Count) % rounds.Count];
+    var newIdx = (i + delta + rounds.Count) % rounds.Count;
+    ViewModel.SelectedRound = rounds[newIdx];
+    _pendingScrollId = $"round-{newIdx}";
   }
 
   void StepStage(int delta)
@@ -432,6 +439,12 @@ else
     var i = stages.IndexOf(ViewModel.SelectedStage);
     if (i < 0) { return; }
     ViewModel.SelectedStage = stages[(i + delta + stages.Count) % stages.Count];
+    // OnSelectedStageChanged snapped SelectedRound; queue scroll to that round's section (which re-renders next).
+    if (ViewModel.SelectedStage is { } stage && ViewModel.SelectedRound is { } round)
+    {
+      var idx = stage.Rounds.IndexOf(round);
+      if (idx >= 0) { _pendingScrollId = $"round-{idx}"; }
+    }
   }
 
   public async ValueTask DisposeAsync()

--- a/src/FantasyFootball.UI/Pages/CompetitionSetup.razor
+++ b/src/FantasyFootball.UI/Pages/CompetitionSetup.razor
@@ -54,19 +54,21 @@
   <MudGrid Spacing="2">
     @foreach (var group in ViewModel.Groups)
     {
-      <MudItem xs="12" sm="6" md="4" lg="3">
+      <MudItem xs="12" sm="6" md="4">
         <MudPaper Class="pa-3" Elevation="1" Style="height: 100%;">
           <MudText Typo="Typo.subtitle1" GutterBottom="true">@group.Name</MudText>
           <MudDivider Class="mb-2" />
-          @foreach (var team in group.Teams)
-          {
-            <div class="d-flex align-center mb-1" style="gap: 0.5rem;">
-              <FlagIcon Team="team" Size="20" />
-              <MudText Typo="Typo.body2">@team.Name</MudText>
-              <MudSpacer />
-              <MudText Typo="Typo.caption" Color="Color.Secondary">@team.Elo</MudText>
-            </div>
-          }
+          <div class="setup-team-list">
+            @foreach (var team in group.Teams)
+            {
+              <div class="setup-team-row">
+                <FlagIcon Team="team" Size="28" />
+                <MudText Typo="Typo.body2">@team.Name</MudText>
+                <MudSpacer />
+                <MudText Typo="Typo.caption" Color="Color.Secondary">@team.Elo</MudText>
+              </div>
+            }
+          </div>
         </MudPaper>
       </MudItem>
     }

--- a/src/FantasyFootball.UI/ViewModels/CompetitionDetailViewModel.cs
+++ b/src/FantasyFootball.UI/ViewModels/CompetitionDetailViewModel.cs
@@ -118,6 +118,22 @@ public partial class CompetitionDetailViewModel : ObservableObject
 
 	partial void OnSpeedChanged(SimulationSpeed value) => ApplySpeedToSimulator();
 
+	/// <summary>
+	/// When the user picks a new stage (e.g. clicks the K.O. Phase chip while viewing the Group Stage),
+	/// snap <see cref="SelectedRound"/> to a sensible round inside that stage instead of leaving it
+	/// pointing at the previous stage's round (which the round chip strip would then render as nothing
+	/// matching the highlight state). Prefer the tournament's current round if it's in this stage;
+	/// otherwise fall back to the stage's first round.
+	/// </summary>
+	partial void OnSelectedStageChanged(Stage? value)
+	{
+		if (value is null) { SelectedRound = null; return; }
+		var currentRound = Competition?.CurrentGame?.Round;
+		SelectedRound = currentRound is not null && value.Rounds.Contains(currentRound)
+			? currentRound
+			: value.Rounds.FirstOrDefault();
+	}
+
 	void ApplySpeedToSimulator()
 	{
 		if (_simulator is null) { return; }
@@ -129,12 +145,7 @@ public partial class CompetitionDetailViewModel : ObservableObject
 	{
 		if (_simulator is null || Competition?.CurrentGame is null || IsBusy) { return; }
 		var gameBeingSimmed = Competition.CurrentGame;
-		// Set undo target + pulse marker UP FRONT, before the sim's Task.Delay throws an
-		// async yield. The next render flushes them in the same frame as the new score —
-		// otherwise the buttons + pulse appear ~Task.Delay(GameDelay) ms after the score,
-		// visibly lagging the click.
 		PushUndoEntry(gameBeingSimmed);
-		_ = FlashRecentlyFinished(gameBeingSimmed);
 		IsBusy = true;
 		try
 		{
@@ -142,6 +153,14 @@ public partial class CompetitionDetailViewModel : ObservableObject
 			// the post-sim Task.Delay so the busy spinner clears immediately after the result.
 			await _simulator.SimulateGame(gameBeingSimmed, delayAfter: false);
 			_repo.Save(Competition);
+			// Pulse marker is set AFTER the sim so the row class transition + new score text
+			// happen in the same render frame regardless of Blazor's render batching. Setting it
+			// up front caused intermediate renders on the keyboard-shortcut path (Space) — the row
+			// gained the class while score was still "-:-", browser saw the animationstart fire
+			// against the wrong content, and the visible animation was lost in the render churn.
+			// EventCallback path (click) coalesces renders so both timings worked there; this is
+			// the consistent path.
+			_ = FlashRecentlyFinished(gameBeingSimmed);
 		}
 		finally
 		{
@@ -204,9 +223,6 @@ public partial class CompetitionDetailViewModel : ObservableObject
 		if (_simulator is null || Competition is null || IsBusy) { return; }
 		if (!_undoStack.TryPeek(out var game)) { return; }
 
-		// Pulse fires before the await — same reasoning as SimulateGame, so the new score
-		// and the pulse animation land in the same render frame.
-		_ = FlashRecentlyFinished(game);
 		IsBusy = true;
 		try
 		{
@@ -214,6 +230,8 @@ public partial class CompetitionDetailViewModel : ObservableObject
 			// Same as SimulateGame: single-game user click, no inter-game pacing.
 			await _simulator.SimulateGame(game, delayAfter: false);
 			_repo.Save(Competition);
+			// FlashRecentlyFinished AFTER the sim — same render-batching reason as SimulateGame.
+			_ = FlashRecentlyFinished(game);
 		}
 		finally
 		{
@@ -319,9 +337,19 @@ public partial class CompetitionDetailViewModel : ObservableObject
 		if (Competition is null || finished.Round?.Stage?.Competition is null) { return; }
 		if (finished.Round.Stage.Competition.Id != Competition.Id) { return; }
 
-		// Re-publish Competition change so groupings + standings + winner re-evaluate. Auto-advance is left
-		// to OnSimBatchComplete: doing it per-game during a multi-game sim flipped the panel away from the
-		// round being simmed the moment its last game resolved, hiding the results the user was watching.
+		// During multi-game sims the user wants the chip strip + page to FOLLOW the currently-playing
+		// round as it advances, not stay pinned on a manually-clicked round.
+		if (IsBusy)
+		{
+			var currentRound = Competition.CurrentGame?.Round;
+			if (currentRound is not null && !ReferenceEquals(currentRound, SelectedRound))
+			{
+				SelectedStage = currentRound.Stage; // cross-stage too (group → KO transition)
+				SelectedRound = currentRound;
+			}
+		}
+
+		// Re-publish Competition change so groupings + standings + winner re-evaluate.
 		OnPropertyChanged(nameof(Competition));
 	}
 }

--- a/src/FantasyFootball.UI/ViewModels/CompetitionDetailViewModel.cs
+++ b/src/FantasyFootball.UI/ViewModels/CompetitionDetailViewModel.cs
@@ -28,6 +28,9 @@ public partial class CompetitionDetailViewModel : ObservableObject
 
 	CompetitionSimulator? _simulator;
 
+	// True during SimulateAll only; SimulateRound leaves it false to keep the user on the round they just simmed.
+	bool _liveTracking;
+
 	// In-memory undo stack of *just-simmed games*. Undo = pop, call game.ClearResult().
 	// No snapshots / serialization needed: a simmed game is fully reversible by clearing its score
 	// and state back to SCHEDULED. Downstream state (standings, qualifiers, KO bracket) recomputes
@@ -153,13 +156,7 @@ public partial class CompetitionDetailViewModel : ObservableObject
 			// the post-sim Task.Delay so the busy spinner clears immediately after the result.
 			await _simulator.SimulateGame(gameBeingSimmed, delayAfter: false);
 			_repo.Save(Competition);
-			// Pulse marker is set AFTER the sim so the row class transition + new score text
-			// happen in the same render frame regardless of Blazor's render batching. Setting it
-			// up front caused intermediate renders on the keyboard-shortcut path (Space) — the row
-			// gained the class while score was still "-:-", browser saw the animationstart fire
-			// against the wrong content, and the visible animation was lost in the render churn.
-			// EventCallback path (click) coalesces renders so both timings worked there; this is
-			// the consistent path.
+			// Pulse marker AFTER the sim so the class transition + final score land in one render (Space path needs this; click batches via EventCallback).
 			_ = FlashRecentlyFinished(gameBeingSimmed);
 		}
 		finally
@@ -194,12 +191,13 @@ public partial class CompetitionDetailViewModel : ObservableObject
 		if (_simulator is null || Competition is null || Competition.IsFinished || IsBusy) { return; }
 		ClearUndo();
 		IsBusy = true;
+		_liveTracking = true;
 		try
 		{
 			await _simulator.Simulate();
 			_repo.Save(Competition);
 		}
-		finally { OnSimBatchComplete(); }
+		finally { _liveTracking = false; OnSimBatchComplete(); }
 	}
 
 	public void Undo()
@@ -337,15 +335,15 @@ public partial class CompetitionDetailViewModel : ObservableObject
 		if (Competition is null || finished.Round?.Stage?.Competition is null) { return; }
 		if (finished.Round.Stage.Competition.Id != Competition.Id) { return; }
 
-		// During multi-game sims the user wants the chip strip + page to FOLLOW the currently-playing
-		// round as it advances, not stay pinned on a manually-clicked round.
-		if (IsBusy)
+		// Live multi-round sims (SimulateAll) follow the playing round; SimulateRound stays put.
+		if (_liveTracking)
 		{
 			var currentRound = Competition.CurrentGame?.Round;
 			if (currentRound is not null && !ReferenceEquals(currentRound, SelectedRound))
 			{
-				SelectedStage = currentRound.Stage; // cross-stage too (group → KO transition)
-				SelectedRound = currentRound;
+				// Setting SelectedStage triggers OnSelectedStageChanged which snaps SelectedRound; avoid the double-fire.
+				if (!ReferenceEquals(currentRound.Stage, SelectedStage)) { SelectedStage = currentRound.Stage; }
+				else { SelectedRound = currentRound; }
 			}
 		}
 

--- a/src/FantasyFootball.Web/FantasyFootball.Web.csproj
+++ b/src/FantasyFootball.Web/FantasyFootball.Web.csproj
@@ -23,6 +23,10 @@
     <PackageReference Include="Blazored.LocalStorage" Version="4.5.0" />
     <PackageReference Include="MudBlazor" Version="9.4.0" />
     <PackageReference Include="PublishSPAforGitHubPages.Build" Version="3.0.3" />
+    <!-- Serilog → browser console sink. Without this, Log.Debug / Log.Information from C# only reach
+         the Debug + File sinks configured in ISettingsService.StandardLoggerConfig, neither of which
+         is visible to a developer with the browser DevTools open. -->
+    <PackageReference Include="Serilog.Sinks.BrowserConsole" Version="1.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/FantasyFootball.Web/Program.cs
+++ b/src/FantasyFootball.Web/Program.cs
@@ -7,6 +7,17 @@ using FantasyFootball.Web.Services;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
 using MudBlazor.Services;
+using Serilog;
+
+// Serilog logger for the WASM host. BrowserConsole sink so Log.Debug / Log.Information reach the
+// browser DevTools console — the standard config (ISettingsService.StandardLoggerConfig) writes to
+// the System.Diagnostics Debug stream + a temp-dir file, neither of which is reachable from a
+// browser DevTools session. Without this sink, Log calls land in the void on WASM.
+Log.Logger = new LoggerConfiguration()
+    .MinimumLevel.Debug()
+    .Enrich.FromLogContext()
+    .WriteTo.BrowserConsole()
+    .CreateLogger();
 
 var builder = WebAssemblyHostBuilder.CreateDefault(args);
 

--- a/src/FantasyFootball.Web/Program.cs
+++ b/src/FantasyFootball.Web/Program.cs
@@ -9,12 +9,15 @@ using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
 using MudBlazor.Services;
 using Serilog;
 
-// Serilog logger for the WASM host. BrowserConsole sink so Log.Debug / Log.Information reach the
-// browser DevTools console — the standard config (ISettingsService.StandardLoggerConfig) writes to
-// the System.Diagnostics Debug stream + a temp-dir file, neither of which is reachable from a
-// browser DevTools session. Without this sink, Log calls land in the void on WASM.
+// Serilog → browser DevTools console for the WASM host. Debug in dev; Warning in Release (avoids leaking diagnostics to public-deploy visitors' consoles).
 Log.Logger = new LoggerConfiguration()
-    .MinimumLevel.Debug()
+    .MinimumLevel.Is(
+#if DEBUG
+        Serilog.Events.LogEventLevel.Debug
+#else
+        Serilog.Events.LogEventLevel.Warning
+#endif
+    )
     .Enrich.FromLogContext()
     .WriteTo.BrowserConsole()
     .CreateLogger();

--- a/src/FantasyFootball.Web/wwwroot/app.css
+++ b/src/FantasyFootball.Web/wwwroot/app.css
@@ -83,6 +83,48 @@ body {
   padding-top: 0.25rem;
 }
 
+/* Variant B: whole-stage scroll. Each round renders as a section with a header. */
+.round-section {
+  scroll-margin-top: 1rem;
+  padding-top: 0.25rem;
+}
+
+.round-section + .round-section {
+  margin-top: 1.5rem;
+  border-top: 1px solid var(--mud-palette-action-hover, rgba(0, 0, 0, 0.08));
+  padding-top: 1rem;
+}
+
+.round-header {
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+  font-family: 'Barlow Condensed', 'Inter', sans-serif;
+  font-weight: 700;
+  font-size: 1.1rem;
+  letter-spacing: 0.5px;
+  text-transform: uppercase;
+  color: var(--mud-palette-text-secondary);
+  margin-bottom: 0.4rem;
+}
+
+.round-section-selected .round-header {
+  color: var(--mud-palette-primary);
+}
+
+.round-header-status {
+  font-size: 0.75rem;
+  font-weight: 400;
+  color: var(--mud-palette-success);
+  letter-spacing: 0;
+  text-transform: none;
+}
+
+.round-header-status-current {
+  color: var(--mud-palette-primary);
+  font-style: italic;
+}
+
 .scoreboard-row:hover {
   background: var(--mud-palette-action-hover, rgba(0, 0, 0, 0.04));
 }

--- a/src/FantasyFootball.Web/wwwroot/app.css
+++ b/src/FantasyFootball.Web/wwwroot/app.css
@@ -74,6 +74,15 @@ body {
   cursor: pointer;
 }
 
+/* Round picker — horizontal chip strip replacing the dropdown. Wraps if the stage has many rounds (group stage = 3, KO = 4-5). */
+.round-chip-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  align-items: center;
+  padding-top: 0.25rem;
+}
+
 .scoreboard-row:hover {
   background: var(--mud-palette-action-hover, rgba(0, 0, 0, 0.04));
 }

--- a/src/FantasyFootball.Web/wwwroot/app.css
+++ b/src/FantasyFootball.Web/wwwroot/app.css
@@ -74,13 +74,90 @@ body {
   cursor: pointer;
 }
 
-/* Round picker — horizontal chip strip replacing the dropdown. Wraps if the stage has many rounds (group stage = 3, KO = 4-5). */
-.round-chip-row {
+/* Hierarchical stage→round chip pickers with a dotted-timeline backdrop. Stage row larger, round row
+   smaller + indented to suggest "rounds belong to the selected stage". The ::before dashed line on each
+   .timeline-chips evokes temporal progression. Chips need an opaque background so the line doesn't
+   show through outlined chips on dark mode (--mud-palette-surface).  */
+.timeline-pickers {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.timeline-row {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.timeline-row-round {
+  padding-left: 1.5rem; /* indent rounds under stages — hierarchical cue */
+}
+
+.timeline-label {
+  font-family: 'Barlow Condensed', 'Inter', sans-serif;
+  font-weight: 700;
+  font-size: 0.85rem;
+  letter-spacing: 0.5px;
+  text-transform: uppercase;
+  color: var(--mud-palette-text-secondary);
+  min-width: 3.5rem;
+}
+
+.timeline-chips {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.4rem;
+  gap: 0.6rem;
   align-items: center;
-  padding-top: 0.25rem;
+  position: relative;
+  flex: 1;
+}
+
+.timeline-chips::before {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 0.5rem;
+  right: 0.5rem;
+  border-top: 1px dashed var(--mud-palette-text-secondary);
+  opacity: 0.3;
+  z-index: 0;
+  pointer-events: none;
+}
+
+.timeline-chips .mud-chip {
+  position: relative;
+  z-index: 1;
+}
+
+/* Chip status — encoded redundantly via border style + opacity, not color alone.
+   chip-current: dashed border distinguishes the actively-played round from solid-bordered done/future.
+   chip-future:  dimmed to indicate "not reached yet" without changing chip shape.
+   chip-done:    no border/opacity override; default outlined+default reads as the "white" finished state.
+   All three status classes get an opaque background so the dashed timeline line doesn't pass visibly
+   through them. The filled selected chip has no status class → no override → keeps its primary green. */
+.mud-chip.chip-current,
+.mud-chip.chip-future,
+.mud-chip.chip-done {
+  /* `background` shorthand to also reset background-image; MudBlazor's outlined variant set
+     `background: transparent` which beat the property-level override. */
+  background: var(--mud-palette-background) !important;
+}
+
+/* Inter-chip sim button — sits between round chips on the timeline. Opaque backdrop so the dashed
+   timeline line doesn't pass through. */
+.round-sim-button {
+  background: var(--mud-palette-background) !important;
+  position: relative;
+  z-index: 1;
+}
+
+.mud-chip.chip-current {
+  border-style: dashed !important;
+}
+
+.mud-chip.chip-future {
+  opacity: 0.5;
 }
 
 /* Variant B: whole-stage scroll. Each round renders as a section with a header. */
@@ -93,6 +170,34 @@ body {
   margin-top: 1.5rem;
   border-top: 1px solid var(--mud-palette-action-hover, rgba(0, 0, 0, 0.08));
   padding-top: 1rem;
+}
+
+/* Setup page team list — gap-based spacing so the top (after divider) matches the bottom (before card edge). */
+.setup-team-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.setup-team-row {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+/* Single-column game flow — multi-column was visually noisy; user preferred one column. */
+.round-games-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+
+/* Bounded-height card with internal scroll. Page-level scroll is annoying when chip clicks jump
+   between rounds; per-card scroll keeps the chips + header pinned at top. The calc leaves room for
+   the app bar (~64px) + breadcrumb / title (~80px) + chip rows (~100px) + grid spacing.  */
+.bounded-scroll-card {
+  max-height: calc(100vh - 18rem);
+  overflow-y: auto;
 }
 
 .round-header {

--- a/src/FantasyFootball.Web/wwwroot/app.css
+++ b/src/FantasyFootball.Web/wwwroot/app.css
@@ -217,19 +217,6 @@ body {
   color: var(--mud-palette-primary);
 }
 
-.round-header-status {
-  font-size: 0.75rem;
-  font-weight: 400;
-  color: var(--mud-palette-success);
-  letter-spacing: 0;
-  text-transform: none;
-}
-
-.round-header-status-current {
-  color: var(--mud-palette-primary);
-  font-style: italic;
-}
-
 .scoreboard-row:hover {
   background: var(--mud-palette-action-hover, rgba(0, 0, 0, 0.04));
 }

--- a/src/FantasyFootball.Web/wwwroot/index.html
+++ b/src/FantasyFootball.Web/wwwroot/index.html
@@ -29,6 +29,7 @@
 
     <script src="_content/MudBlazor/MudBlazor.min.js"></script>
     <script src="js/keyboard.js"></script>
+    <script src="js/scroll.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/canvas-confetti@1.9.3/dist/confetti.browser.min.js"
             integrity="sha256-XAXr7WaJcRT+HM+lo4/TccjvLjuXvAS7Og3dyBT8CIE="
             crossorigin="anonymous"></script>

--- a/src/FantasyFootball.Web/wwwroot/js/scroll.js
+++ b/src/FantasyFootball.Web/wwwroot/js/scroll.js
@@ -1,0 +1,8 @@
+// Tiny scroll helper for the variant-B whole-stage games panel.
+// Round chips invoke this to jump to a round's <section id="round-N"> anchor.
+window.ffScroll = {
+    toElement: (id) => {
+        const el = document.getElementById(id);
+        if (el) { el.scrollIntoView({ behavior: 'smooth', block: 'start' }); }
+    }
+};


### PR DESCRIPTION
## Summary

Iteration on the games-panel layout. Three commits, themed:

| SHA | Chunk |
|---|---|
| \`1ccc757\` | Variant A: round dropdown → chip strip baseline |
| \`6e561ad\` | Variant B: render whole stage as scrollable round sections |
| \`d4e7552\` | Iteration: hierarchical pickers, polish, perf, score-anim fix, Serilog→browser console |

The first two were variant-explorations on separate branches (also tried variant C — horizontal carousel; rejected); the third commit is the substantial iteration of variant B based on visual feedback.

### What changes for the user
- **Stage + Round pickers are chip strips on a hierarchical timeline.** Stage chips above (\`Size.Medium\`), Round chips below (indented under stages). Dashed-line backdrop evokes temporal progression. Status encoded via fill + border + opacity (selected = filled brand-green; done = outlined default + ✓; current = outlined default + dashed border; future = outlined default + 50% opacity).
- **Whole-stage scroll layout.** Each round renders as its own section, all visible in the games panel (single column). Both Games + Standings cards are bounded-scroll (max-height tied to viewport), so the picker + page header stay pinned while content scrolls per-card.
- **Sim-round button moves between chips.** Visible only where the round has games remaining. Header-level Sim-Round IconButton is gone.
- **Jump-to-current** 📍 icon at the top scrolls to the actual current-game row (not the round header).
- **Click-popover dismisses on click anywhere** via transparent overlay.
- **Stage chip click auto-selects** the round currently being played in that stage (or first round if not started).

### Bug fixes
- **Score-reveal animation now fires consistently on both click and Space.** Root cause was diagnosed via instrumented C# + JS console logs comparing the two paths: \`EventCallback\` (click) batches renders, \`[JSInvokable]\` (Space) doesn't, so \`FlashRecentlyFinished\` being set up-front caused intermediate renders where the row gained the just-finished class while score was still \`"-:-"\`. Fix: move \`FlashRecentlyFinished\` to AFTER the sim so the class transition + final score land in the same render frame either way.
- **Confetti no longer fires on Simulate Again.** Guard switched from \`int? Id\` to \`Competition?\` reference so it survives the load-race window.
- **OnVmChanged scroll-on-IsBusy only fires on round transitions**, not the first IsBusy event — single-game sim doesn't yank view to the round header.
- **"Current" round semantics**: now \`Competition.CurrentGame.Round\` (the round actually being played in the tournament) instead of \`SelectedStage.CurrentRound\` (which misflagged KO round 1 as current while group stage was unfinished).

### Performance (partial fix for #34)
- \`GroupView.OnParametersSet\` caches the qualifier walk per \`Group\` instance. The standings panel was re-walking ~1920 iterations (12 groups × 160 KO-qualifier checks) on every game-finished property change — the headline hotspot from issue #34. Now walks once per Group reference, plus once more on Stage.IsFinished transitioning false → true. The other items in #34 (Replay storage round-trip, render coalescing, etc.) remain open.

### Infrastructure
- **Serilog → BrowserConsole sink wired in \`Program.cs\`.** C# \`Log.Debug\` / \`Log.Information\` now reach the browser DevTools console (previously only the System.Diagnostics Debug stream + temp-dir file, both invisible to a developer with DevTools open). This unblocks future diagnosis sessions — the script-shy debugging dance for the score-animation bug above wouldn't have needed multiple Console.WriteLine fallbacks with this in place.
- New behavioural memory: instrument timestamped logs + compare working-vs-broken traces instead of speculating with "want me to try X?" questions.

## Related issues

- #34 — perf pass. Headline GroupView hotspot fixed; other suspected hotspots still listed there for follow-up.

## Test plan

- [ ] Open a competition. Stage chips show above, Round chips below, dotted line behind each row.
- [ ] Click between Gruppenphase / K.O. Phase chips — round chips swap and the round selection snaps to a sensible default (current round if in-stage, else first).
- [ ] Sim a single game (Space and the per-row ▶ button). Score animation visible on both — pops in with brand-green tint.
- [ ] Sim a round via the inter-chip ▶ — that round's chip animates, the games fill in chronologically.
- [ ] Sim Tournament → page follows the sim live (chip strip + scroll). Confetti fires once at finish.
- [ ] Click Simulate Again → new comp loads, no confetti residual or re-fire.
- [ ] Click any scoreboard row → popover; click anywhere else → dismisses.
- [ ] Jump-to-current 📍 → scrolls to the actual current-game row.
- [ ] DevTools console shows Serilog \`Log.Debug\` / \`Log.Information\` output.
- [ ] WC2026 sim doesn't freeze mid-sim or post-finish nearly as long as before (GroupView cache).