### PR TITLE
Release 0.3.0

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -120,6 +120,33 @@ running build — skip features that landed in earlier rounds and are
 already signed off. If the previous run was many commits ago, summarise
 the commits being verified at the top so the user knows the scope.
 
+## PR merge hygiene
+
+After auto-review rounds, the branch accumulates per-round-fix commits
+("Address PR #N auto-review round K"). **Before merging back to
+`develop`, rebase those into a couple of topical commits aligned with
+the PR's logical feature chunks.** The PR discussion thread already
+records the review history; commits should record the feature work, not
+the round-by-round paper trail. This is what PRs #25, #28, #29 landed
+with.
+
+Mechanics (per session constraints — no `-i` or `-p` flags):
+
+```bash
+git tag prNN-pre-rebase                    # safety net
+git reset --soft <feature-commit-base>     # back to last feature commit; later changes restaged
+git commit -m "<themed summary>"           # one commit per logical chunk
+git diff prNN-pre-rebase HEAD --stat       # verify empty — tree unchanged
+git push --force-with-lease
+```
+
+For cases where review fixes split across multiple feature themes,
+restage by file (and accept that the rebase may produce one "review
+fixes" commit rather than perfectly themed ones — better that than
+patch-mode staging the user can't approve).
+
+Skip the rebase only when explicitly told `merge as-is`.
+
 ## Out of scope
 
 **Accessibility (a11y) is not a priority at this stage.** Do not invest effort

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -164,6 +164,10 @@ also happen to be accessible) remain in scope under their non-a11y framing.
   and PR back to `develop`.
 - **`main`** is the release branch. When `develop` is release-ready, open a PR
   from `develop` → `main`, bump version, tag the merge commit (e.g. `0.3.0`).
+  The `develop` → `main` PR is a **pure formality** — everything substantial
+  has already been reviewed on its way into `develop`. **Skip the auto-review
+  wait; do not address auto-review comments on these PRs.** Open, then merge
+  as soon as the .NET build is green (the build is real CI, not review).
 - **GitHub Pages deployment** is handled by `.github/workflows/github-pages.yml`,
   which auto-deploys on push to `main`. It uses the modern Pages-from-Actions
   artifact pattern (`actions/configure-pages` + `upload-pages-artifact` +

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -165,9 +165,10 @@ also happen to be accessible) remain in scope under their non-a11y framing.
 - **`main`** is the release branch. When `develop` is release-ready, open a PR
   from `develop` → `main`, bump version, tag the merge commit (e.g. `0.3.0`).
   The `develop` → `main` PR is a **pure formality** — everything substantial
-  has already been reviewed on its way into `develop`. **Skip the auto-review
-  wait; do not address auto-review comments on these PRs.** Open, then merge
-  as soon as the .NET build is green (the build is real CI, not review).
+  has already been reviewed on its way into `develop`. Auto-review is
+  **disabled** at the workflow level on PRs targeting `main` (see
+  `claude-auto-review` in `.github/workflows/claude.yml`); open, then merge as
+  soon as the .NET build is green (the build is real CI, not review).
 - **GitHub Pages deployment** is handled by `.github/workflows/github-pages.yml`,
   which auto-deploys on push to `main`. It uses the modern Pages-from-Actions
   artifact pattern (`actions/configure-pages` + `upload-pages-artifact` +

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -38,7 +38,9 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
   claude-auto-review:
-    if: github.event_name == 'pull_request'
+    # Skip auto-review on develop→main PRs — those are pure-formality release PRs
+    # where everything substantial was already reviewed on its way into develop.
+    if: github.event_name == 'pull_request' && github.base_ref != 'main'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/docs/failure-log.md
+++ b/docs/failure-log.md
@@ -1,15 +1,13 @@
 # UI polish PR 1 — failure log
 
-Session handoff doc. Read this first if you're picking up the polish work
-cold. Companion to `docs/ui-polish-plan.md` (the strategic plan) — this
-file is the tactical "what bugs we hit, what's fixed, what's still
-lurking" log.
+**Archival**. PR #25 merged to `develop` on 2026-05-19; PR #28 (Identity),
+PR #29 (Sim feel), and release PR #31 followed. This file is kept as
+historical context for the diagnostic affordances + bug catalog from the
+PR 1 era. The bug histories below are accurate as of merge; tracker
+state has moved on.
 
-**Branch**: `feature/ui-polish-1-ia-speed` (pushed as PR #25 → `develop`).
-**State at last update (2026-05-19)**: 13 commits ahead of `develop`.
-Build is clean (0 errors). Tests: 34 passing / 6 failing — the 6 are
-the pre-existing greedy 3rd-place tournament-sim tests (Outstanding A,
-issue #12), unchanged by any work in this PR.
+For the current state of polish work, see `docs/ui-polish-plan.md`.
+For known follow-up cleanup, see issues #12, #27, #32, #33.
 
 ## What PR 1 was supposed to do
 
@@ -178,7 +176,7 @@ slot. Hidden by the placeholder fallback in #6 — the user sees a
 official 495-scenario lookup table per the TODO at the top of
 `ExpandedWorldCupFormat.cs`. Out of scope for the polish PR.
 
-### B. JSON bloat from un-`[Ignore]`'d computed getters — **investigated, NOT fixed (revert in working memory)**
+### B. JSON bloat from un-`[Ignore]`'d computed getters — **tracked in #32**
 
 Audit during this session identified four computed getters on
 persisted types that STJ serializes (unnecessarily):
@@ -192,14 +190,7 @@ simulation tests because **the same SQLite `[Ignore]` attribute also
 removes columns from the SQLite schema**. The audit changes were
 reverted (uncommitted). The fix is structural: separate JSON's
 `[JsonIgnore]` from SQLite's `[Ignore]`. **Not a crash risk** —
-just JSON bloat. Belongs in a follow-up cleanup PR, not this polish
-work.
-
-### C. (done) Merge Competitions + Statistics — PR 1 is now complete
-
-Landed: PR #25 on `feature/ui-polish-1-ia-speed`. Single `/competitions`
-page with Active / Finished tabs; all-time TeamRecord aggregate below
-the Finished list. `/statistics` route + NavMenu link removed.
+just JSON bloat. Now tracked as issue #32.
 
 ## Diagnostic affordances we added
 
@@ -223,15 +214,3 @@ the Finished list. `/statistics` route + NavMenu link removed.
   works (the override is read-only, deserialize discards, getter
   recomputes), but it's noise. Outstanding (B).
 
-## Quick start (for tomorrow / next session)
-
-```bash
-git checkout feature/ui-polish-1-ia-speed
-git pull
-dotnet test src/FantasyFootball.Tests/FantasyFootball.Tests.csproj
-dotnet run --project src/FantasyFootball.Web --launch-profile https
-# → https://localhost:7140
-```
-
-Next coding task: once PR #25 merges, start PR 2 (Identity) on a
-fresh branch off `develop`.

--- a/docs/ui-polish-plan.md
+++ b/docs/ui-polish-plan.md
@@ -375,19 +375,10 @@ around third-place resolve, corrupt-blob quarantine on load.
 
 ### PR 3 — Sim feel
 
-**Status**: in flight on branch `feature/ui-polish-3-sim-feel`. Five
-chunks committed locally (not pushed yet). Pick up the remaining items
-in a fresh session; merge PR 3 once a meaningful slice is complete.
-
-Local commits on this branch (latest first):
-
-| SHA | Chunk |
-|---|---|
-| `e450e07` | Standings: qualification-zone left-edge bar + group-letter spacing |
-| `db91c3e` | Group letter + kickoff time on scoreboard rows |
-| `7fae924` | Day-grouping dividers in the games panel |
-| `bbe6df0` | Unify Settings speed UI with detail picker |
-| `1095c86` | Move competition delete from detail page to per-row list action |
+**Status**: merged via PR #29 (2026-05-19). Branch
+`feature/ui-polish-3-sim-feel` was rebased into 6 themed commits
+(`a40310a..70b6127`) plus 5 auto-review rounds, then merged to
+`develop` and re-released to `main` via PR #31.
 
 Done:
 
@@ -406,31 +397,41 @@ Done:
 - [x] **Standings qualifier highlight** (left-edge bar) — slim 3px
   muted-green / muted-red column inset from row edges; resolves
   ThirdPlace combination eligibility once the group stage finishes.
+- [x] **Keyboard navigation** — document-level handler, full mapping,
+  help overlay (`?`), About-page reference.
+- [x] **Undo stack** — in-memory, per-game snapshot, capped at 50; UI
+  attaches the Undo button to the row of the just-simmed game.
+  Speculative undo pop moved into a `finally` block so a simulator
+  exception can't leave a stale entry pointing at a SCHEDULED game.
+- [x] **Just-finished game highlight** — single-game sim and Redo
+  trigger a 1.5s green pulse on the row. Standings-row pulse deferred
+  to a follow-up (see § PR 4 successors).
 
-Still open (next session):
+Still open — candidates for a future PR (PR 3.5 polish round, or
+folded into PR 4):
 
-- [x] Keyboard navigation (full mapping; help overlay; About reference).
-- [x] Undo stack (in-memory, per-game snapshot, capped at 50; UI attaches the
-  Undo button to the row of the just-simmed game).
-- [x] Just-finished game highlight (game row pulse on single-game sim and redo;
-  standings-row pulse deferred to a follow-up).
-- [ ] Score reveal animation.
-- [ ] Standings row reorder via FLIP.
+- [ ] Score reveal animation (count-up or fade `-:-` → final).
+- [ ] Standings row reorder via FLIP technique.
 - [ ] Optional `Qual %` column in group stage (Monte Carlo).
 - [ ] Click-for-game-details popover / drawer.
 - [ ] Replay button on `Competition.IsFinished`.
 - [ ] Confetti burst on finish.
 
-Open visual / correctness questions deferred from this session:
+Open visual / correctness questions:
 
-- Group H standings sometimes show GD/Pts combos that contradict the
-  sort (e.g. Spain GD +7, Pts 4, sitting above teams with higher GD).
-  Tie-break logic or `Standings.CreateFrom` ordering is suspect — file
-  a separate bug rather than rolling into PR 3.
+- Group standings GD/Pts ordering anomaly — tracked in issue #33.
+  Either a tie-break issue in `Standings.CreateFrom`, a stale-snapshot
+  redraw, or a display-only bug.
 - Per-row delete confirmation dialog text wording: revisit once the
   About page mentions the action.
 
-### PR 4 — KO bracket
+### PR 4 — KO bracket (deferred, maybe never)
+
+**Status**: deferred indefinitely (2026-05-20). The bracket-view
+visualization may be added later as a polish item; treat the
+round-list + dropdown as the canonical KO-stage UI for now.
+
+Original scope, preserved for if/when this comes back:
 
 - `<BracketView>` Razor component, CSS-grid based.
 - Replaces the round-list-and-dropdown on KO stages.

--- a/src/FantasyFootball.Core/Data/CompetitionSimulator.cs
+++ b/src/FantasyFootball.Core/Data/CompetitionSimulator.cs
@@ -68,18 +68,22 @@ public class CompetitionSimulator(Competition competition, IRepository repo, int
 		Log.Debug("--------------------------------------");
 		Log.Debug($"Starting Round: {round.Name}");
 		Log.Debug("--------------------------------------");
-		Game? lastAttempted = null;
-		while (!round.IsFinished)
+		// Iterate by PlayedOn so non-Instant sims fill rows in the same order the UI displays them
+		// (CompetitionDetail orders games by PlayedOn). Round.AllGames is factory-defined order
+		// (group A first, then B, …) which interleaves with chronological kickoff times — without
+		// this snapshot, row 3 (16:00) would update *after* row 4 (15:00) once we work down each group.
+		var ordered = round.AllGames.OrderBy(g => g.PlayedOn).ToList();
+		foreach (var game in ordered)
 		{
-			var current = round.CurrentGame!;
-			// Bail if CurrentGame doesn't progress — placeholder-team KO games would otherwise spin forever (issue #12).
-			if (ReferenceEquals(current, lastAttempted))
+			if (game.IsFinished) { continue; }
+			// Skip rather than break: a placeholder-team KO game (issue #12 territory) shouldn't sim,
+			// but it also shouldn't block later games in the same round from running.
+			if (!game.IsReadyToStart)
 			{
-				Log.Warning($"Round {round.Name}: game {current} stays non-ready; bailing out of sim loop.");
-				break;
+				Log.Warning($"Round {round.Name}: game {game} is not ready; skipping.");
+				continue;
 			}
-			lastAttempted = current;
-			await SimulateGame(current);
+			await SimulateGame(game);
 		}
 		Log.Debug("--------------------------------------");
 	}

--- a/src/FantasyFootball.Core/Services/HeadToHeadLookup.cs
+++ b/src/FantasyFootball.Core/Services/HeadToHeadLookup.cs
@@ -1,0 +1,47 @@
+using FantasyFootball.Repositories;
+
+namespace FantasyFootball.Services;
+
+/// <summary>
+/// Cross-competition head-to-head tally. Walks every stored Competition's finished games once;
+/// callers should treat this as a one-shot lookup (no caching).
+/// </summary>
+public static class HeadToHeadLookup
+{
+	public readonly record struct Result(int TeamAWins, int Draws, int TeamBWins)
+	{
+		public int Total => TeamAWins + Draws + TeamBWins;
+	}
+
+	public static Result Across(IRepository repo, Team teamA, Team teamB)
+	{
+		// Cross-competition: each competition deserializes its own Team instances. ReferenceEquals
+		// (via NamedUniqueId.Equals on Id=0 entities) would never match across the graph boundary;
+		// fall back to Name, which is stable. SQLite path with Id>0 would also match Name.
+		var nameA = teamA.Name;
+		var nameB = teamB.Name;
+		var aWins = 0;
+		var bWins = 0;
+		var draws = 0;
+
+		foreach (var comp in repo.GetAll<Competition>())
+		{
+			foreach (var game in comp.GamesByDate)
+			{
+				if (!game.IsFinished) { continue; }
+
+				var home = game.HomeTeam?.Name;
+				var away = game.AwayTeam?.Name;
+				var isMatchup = (home == nameA && away == nameB) || (home == nameB && away == nameA);
+				if (!isMatchup) { continue; }
+
+				var winnerName = game.Winner?.Name;
+				if (winnerName is null) { draws++; }
+				else if (winnerName == nameA) { aWins++; }
+				else { bWins++; }
+			}
+		}
+
+		return new Result(aWins, draws, bWins);
+	}
+}

--- a/src/FantasyFootball.Core/Services/HeadToHeadLookup.cs
+++ b/src/FantasyFootball.Core/Services/HeadToHeadLookup.cs
@@ -38,7 +38,8 @@ public static class HeadToHeadLookup
 				var winnerName = game.Winner?.Name;
 				if (winnerName is null) { draws++; }
 				else if (winnerName == nameA) { aWins++; }
-				else { bWins++; }
+				else if (winnerName == nameB) { bWins++; }
+				// else: winner is neither — unreachable today (isMatchup above guarantees it), but the explicit branch keeps the intent legible if Game ever gains a separate winner-track entity.
 			}
 		}
 

--- a/src/FantasyFootball.Core/Services/MatchProbability.cs
+++ b/src/FantasyFootball.Core/Services/MatchProbability.cs
@@ -1,0 +1,41 @@
+using MathNet.Numerics.Distributions;
+
+namespace FantasyFootball.Services;
+
+/// <summary>
+/// Pre-match outcome probabilities matching <see cref="Game.Simulate"/>'s generative model:
+/// total goals ~ Poisson(2.5 + 0.001 * (Elo_home - Elo_away)); each goal independently goes
+/// home with probability 10^(diff/400) / (1 + 10^(diff/400)). By Poisson thinning the
+/// marginal home/away scores are independent Poisson with λ split by that probability.
+/// </summary>
+public static class MatchProbability
+{
+	public readonly record struct WinDrawLossResult(double Home, double Draw, double Away);
+
+	public static WinDrawLossResult WinDrawLoss(int eloHome, int eloAway)
+	{
+		var diff = eloHome - eloAway;
+		var lambdaTotal = System.Math.Max(0.5, 2.5 + 0.001 * diff);
+		var pAwayGoal = 1.0 / (1 + System.Math.Pow(10, diff / 400.0));
+		var lambdaHome = (1 - pAwayGoal) * lambdaTotal;
+		var lambdaAway = pAwayGoal * lambdaTotal;
+
+		const int MaxGoals = 10;
+		double pH = 0, pD = 0, pA = 0;
+		for (int i = 0; i <= MaxGoals; i++)
+		{
+			for (int j = 0; j <= MaxGoals; j++)
+			{
+				var p = Poisson.PMF(lambdaHome, i) * Poisson.PMF(lambdaAway, j);
+				if (i > j) { pH += p; }
+				else if (i == j) { pD += p; }
+				else { pA += p; }
+			}
+		}
+
+		// Renormalize: truncating at MaxGoals=10 loses ~1e-9 of mass at the goal counts we care about, but make it exact for callers.
+		var sum = pH + pD + pA;
+
+		return new WinDrawLossResult(pH / sum, pD / sum, pA / sum);
+	}
+}

--- a/src/FantasyFootball.Core/Services/MatchProbability.cs
+++ b/src/FantasyFootball.Core/Services/MatchProbability.cs
@@ -33,7 +33,7 @@ public static class MatchProbability
 			}
 		}
 
-		// Renormalize: truncating at MaxGoals=10 loses ~1e-9 of mass at the goal counts we care about, but make it exact for callers.
+		// Renormalize: truncating at MaxGoals=10 loses a negligible fraction of mass for near-equal Elos but rises to ~0.1% at extreme spreads (λ near 4.5); the renorm makes the H/D/A split exact regardless.
 		var sum = pH + pD + pA;
 
 		return new WinDrawLossResult(pH / sum, pD / sum, pA / sum);

--- a/src/FantasyFootball.Maui/FantasyFootball.Maui.csproj
+++ b/src/FantasyFootball.Maui/FantasyFootball.Maui.csproj
@@ -17,8 +17,8 @@
     <ApplicationIdGuid>79ED65DE-EAF1-41AE-B7F2-1FEB20D9A0FF</ApplicationIdGuid>
 
     <!-- Versions -->
-    <ApplicationDisplayVersion>0.2</ApplicationDisplayVersion>
-    <ApplicationVersion>2</ApplicationVersion>
+    <ApplicationDisplayVersion>0.3.0</ApplicationDisplayVersion>
+    <ApplicationVersion>3</ApplicationVersion>
     <!-- Fix for MAUI issue https://github.com/dotnet/maui/issues/12636 -->
     <Version>$(ApplicationDisplayVersion)</Version>
 

--- a/src/FantasyFootball.Tests/HeadToHeadLookupTests.cs
+++ b/src/FantasyFootball.Tests/HeadToHeadLookupTests.cs
@@ -1,0 +1,143 @@
+using FantasyFootball.Repositories;
+
+namespace FantasyFootball.Tests;
+
+public class HeadToHeadLookupTests
+{
+	[Fact]
+	public void Across_NoCompetitions_ReturnsZeros()
+	{
+		var repo = new FakeRepo();
+		var teamA = new Team { Name = "A" };
+		var teamB = new Team { Name = "B" };
+
+		var result = HeadToHeadLookup.Across(repo, teamA, teamB);
+
+		result.Should().Be(new HeadToHeadLookup.Result(0, 0, 0));
+		result.Total.Should().Be(0);
+	}
+
+	[Fact]
+	public void Across_CountsWinsDrawsAndLosses_AcrossMultipleCompetitions()
+	{
+		var repo = new FakeRepo
+		{
+			Competitions =
+			{
+				// First comp: A beats B 2-1, then they draw 1-1.
+				BuildComp(("A", "B", 2, 1), ("B", "A", 1, 1)),
+				// Second comp: B beats A 2-0. Game between A and C is irrelevant — should not count.
+				BuildComp(("A", "B", 0, 2), ("A", "C", 3, 0)),
+			}
+		};
+
+		var result = HeadToHeadLookup.Across(repo, new Team { Name = "A" }, new Team { Name = "B" });
+
+		result.TeamAWins.Should().Be(1);
+		result.Draws.Should().Be(1);
+		result.TeamBWins.Should().Be(1);
+		result.Total.Should().Be(3);
+	}
+
+	[Fact]
+	public void Across_DirectionAgnostic_TeamAHomeOrAwayBothCountForTeamAWins()
+	{
+		var repo = new FakeRepo
+		{
+			Competitions =
+			{
+				BuildComp(
+					("A", "B", 1, 0),  // A wins as home
+					("B", "A", 0, 1)),  // A wins as away
+			}
+		};
+
+		var result = HeadToHeadLookup.Across(repo, new Team { Name = "A" }, new Team { Name = "B" });
+
+		result.TeamAWins.Should().Be(2);
+		result.TeamBWins.Should().Be(0);
+		result.Draws.Should().Be(0);
+	}
+
+	[Fact]
+	public void Across_IgnoresUnfinishedGames()
+	{
+		var repo = new FakeRepo
+		{
+			Competitions =
+			{
+				BuildComp(
+					("A", "B", 1, 0),  // finished
+					new ScheduledGame("A", "B")),  // not yet played
+			}
+		};
+
+		var result = HeadToHeadLookup.Across(repo, new Team { Name = "A" }, new Team { Name = "B" });
+
+		result.TeamAWins.Should().Be(1);
+		result.Total.Should().Be(1);
+	}
+
+	// Each comp builds its own fresh Team instances per name — mirrors the LocalStorage path where every deserialized
+	// Competition graph has its own Team objects (NamedUniqueId.Equals would not match them; name-based matching does).
+	static Competition BuildComp(params object[] entries)
+	{
+		var round = new Round { Name = "Round 1" };
+		var teams = new Dictionary<string, Team>(StringComparer.Ordinal);
+		Team Get(string name) => teams.TryGetValue(name, out var t) ? t : teams[name] = new Team { Name = name };
+
+		foreach (var entry in entries)
+		{
+			switch (entry)
+			{
+				case (string home, string away, int homeScore, int awayScore):
+					round.RegularGames.Add(new Game
+					{
+						HomeTeam = Get(home),
+						AwayTeam = Get(away),
+						HomeScore = homeScore,
+						AwayScore = awayScore,
+						State = GameState.FINISHED,
+						Round = round,
+					});
+					break;
+				case ScheduledGame sg:
+					round.RegularGames.Add(new Game
+					{
+						HomeTeam = Get(sg.Home),
+						AwayTeam = Get(sg.Away),
+						State = GameState.SCHEDULED,
+						Round = round,
+					});
+					break;
+				default:
+					throw new ArgumentException($"Unsupported entry type {entry.GetType()}");
+			}
+		}
+
+		var stage = new Stage { Name = "Group Stage", Rounds = [round] };
+		round.Stage = stage;
+		var comp = new Competition { Name = "test", ShortName = "T", Stages = [stage] };
+		stage.Competition = comp;
+
+		return comp;
+	}
+
+	record ScheduledGame(string Home, string Away);
+
+	sealed class FakeRepo : IRepository
+	{
+		public List<Competition> Competitions { get; init; } = [];
+
+		public List<T> GetAll<T>() where T : NamedUniqueId, new()
+			=> typeof(T) == typeof(Competition) ? Competitions.Cast<T>().ToList() : [];
+
+		public Task<List<T>> GetAllAsync<T>() where T : NamedUniqueId, new() => Task.FromResult(GetAll<T>());
+		public T? Get<T>(int id) where T : NamedUniqueId, new() => null;
+		public int Count<T>() where T : NamedUniqueId, new() => GetAll<T>().Count;
+		public void Save<T>(T item) where T : NamedUniqueId, new() { }
+		public void Delete<T>(T item) where T : NamedUniqueId, new() { }
+		public void Reset() { }
+		public void Dispose() { }
+	}
+}

--- a/src/FantasyFootball.Tests/MatchProbabilityTests.cs
+++ b/src/FantasyFootball.Tests/MatchProbabilityTests.cs
@@ -1,0 +1,32 @@
+namespace FantasyFootball.Tests;
+
+public class MatchProbabilityTests
+{
+	[Fact]
+	public void EqualElos_HomeAndAwayMirror_DrawNonTrivial()
+	{
+		var p = MatchProbability.WinDrawLoss(1500, 1500);
+
+		p.Home.Should().BeApproximately(p.Away, 1e-9);
+		p.Draw.Should().BeGreaterThan(0.15);
+		(p.Home + p.Draw + p.Away).Should().BeApproximately(1.0, 1e-9);
+	}
+
+	[Fact]
+	public void StrongHomeFavorite_HomeProbDominates()
+	{
+		var p = MatchProbability.WinDrawLoss(1900, 1300);
+
+		p.Home.Should().BeGreaterThan(0.75);
+		p.Away.Should().BeLessThan(0.10);
+	}
+
+	[Fact]
+	public void StrongAwayFavorite_AwayProbDominates()
+	{
+		var p = MatchProbability.WinDrawLoss(1300, 1900);
+
+		p.Away.Should().BeGreaterThan(0.75);
+		p.Home.Should().BeLessThan(0.10);
+	}
+}

--- a/src/FantasyFootball.UI/Components/GameViewRow.razor
+++ b/src/FantasyFootball.UI/Components/GameViewRow.razor
@@ -6,8 +6,7 @@
 
 <div class="scoreboard-row-wrapper">
 <div class="scoreboard-row @(IsJustFinished ? "scoreboard-row-just-finished" : "") @(DetailsOpen ? "scoreboard-row-open" : "")"
-     @onclick="OnDetailsToggle"
-     style="cursor: pointer;">
+     @onclick="OnDetailsToggle">
   <div class="scoreboard-group-tag">
     <span class="scoreboard-group-tag-letter">@_groupLetter</span>
     <span class="scoreboard-group-tag-time">@Game.PlayedOn.ToString("HH:mm")</span>
@@ -141,7 +140,8 @@
     _prevDetailsOpen = DetailsOpen;
   }
 
-  static string FormatPct(double p) => $"{p * 100:0}%";
+  // Floor at "<1%": "0%" reads as impossible for a heavy underdog who could still win.
+  static string FormatPct(double p) => p > 0 && p < 0.005 ? "<1%" : $"{p * 100:0}%";
 
   static string PctClass(bool isActualOutcome) => isActualOutcome ? "game-details-pct-actual" : "";
 }

--- a/src/FantasyFootball.UI/Components/GameViewRow.razor
+++ b/src/FantasyFootball.UI/Components/GameViewRow.razor
@@ -1,6 +1,13 @@
 @using FantasyFootball.Models
+@using FantasyFootball.Data
+@using FantasyFootball.Services
+@using FantasyFootball.Repositories
+@inject IRepository Repo
 
-<div class="scoreboard-row @(IsJustFinished ? "scoreboard-row-just-finished" : "")">
+<div class="scoreboard-row-wrapper">
+<div class="scoreboard-row @(IsJustFinished ? "scoreboard-row-just-finished" : "") @(DetailsOpen ? "scoreboard-row-open" : "")"
+     @onclick="OnDetailsToggle"
+     style="cursor: pointer;">
   <div class="scoreboard-group-tag">
     <span class="scoreboard-group-tag-letter">@_groupLetter</span>
     <span class="scoreboard-group-tag-time">@Game.PlayedOn.ToString("HH:mm")</span>
@@ -14,7 +21,7 @@
     <FlagIcon Team="Game.AwayTeam" Size="24" />
     <span class="scoreboard-team-name">@Game.AwayTeam.Name</span>
   </div>
-  <div class="scoreboard-action">
+  <div class="scoreboard-action" @onclick:stopPropagation="true">
     @if (ShowSim)
     {
       <MudIconButton Icon="@Icons.Material.Filled.PlayArrow"
@@ -40,6 +47,49 @@
     }
   </div>
 </div>
+<MudPopover Open="DetailsOpen"
+            AnchorOrigin="Origin.BottomCenter"
+            TransformOrigin="Origin.TopCenter"
+            Paper="true"
+            Class="game-details-popover">
+  @if (DetailsOpen)
+  {
+    @if (Game.HomeTeam.Type == TeamType.PLACEHOLDER || Game.AwayTeam.Type == TeamType.PLACEHOLDER)
+    {
+      <MudText Typo="Typo.body2">Teams not yet decided.</MudText>
+    }
+    else
+    {
+      <div class="game-details-row">
+        <span class="game-details-label">Elo</span>
+        <span class="game-details-value">@Game.HomeTeam.Elo <span class="game-details-sep">—</span> @Game.AwayTeam.Elo</span>
+      </div>
+      <div class="game-details-row">
+        <span class="game-details-label">Win / Draw / Loss</span>
+        <span class="game-details-value">
+          <span class="@PctClass(HomeIsWinner)">@FormatPct(_prob.Home)</span>
+          <span class="game-details-sep">/</span>
+          <span class="@PctClass(IsDraw)">@FormatPct(_prob.Draw)</span>
+          <span class="game-details-sep">/</span>
+          <span class="@PctClass(AwayIsWinner)">@FormatPct(_prob.Away)</span>
+        </span>
+      </div>
+      <div class="game-details-row">
+        <span class="game-details-label">H2H (all sims)</span>
+        <span class="game-details-value">
+          @if (_h2h.Total == 0) { <em>none</em> }
+          else { @($"{_h2h.TeamAWins}–{_h2h.Draws}–{_h2h.TeamBWins}") }
+        </span>
+      </div>
+      <MudDivider Class="my-2" />
+      <div class="game-details-links">
+        <MudLink Href="@($"/teams/{Game.HomeTeam.Id}")" Typo="Typo.body2">@Game.HomeTeam.Name</MudLink>
+        <MudLink Href="@($"/teams/{Game.AwayTeam.Id}")" Typo="Typo.body2">@Game.AwayTeam.Name</MudLink>
+      </div>
+    }
+  }
+</MudPopover>
+</div>
 
 @code {
   [Parameter] public Game Game { get; set; } = null!;
@@ -47,6 +97,8 @@
   [Parameter] public bool ShowUndo { get; set; }
   [Parameter] public bool IsJustFinished { get; set; }
   [Parameter] public bool Disabled { get; set; }
+  [Parameter] public bool DetailsOpen { get; set; }
+  [Parameter] public EventCallback OnDetailsToggle { get; set; }
   [Parameter] public EventCallback OnSim { get; set; }
   [Parameter] public EventCallback OnUndo { get; set; }
   [Parameter] public EventCallback OnRedo { get; set; }
@@ -66,11 +118,30 @@
   // Group letter when both teams sit in the same group of the parent stage (group-stage games). KO games span groups → blank.
   string _groupLetter = "";
 
+  bool _prevDetailsOpen;
+  MatchProbability.WinDrawLossResult _prob;
+  HeadToHeadLookup.Result _h2h;
+
   protected override void OnParametersSet()
   {
     var stage = Game.Round?.Stage;
-    if (stage is null) { _groupLetter = ""; return; }
-    var group = stage.Groups.FirstOrDefault(g => g.Teams.Contains(Game.HomeTeam) && g.Teams.Contains(Game.AwayTeam));
+    var group = stage?.Groups.FirstOrDefault(g => g.Teams.Contains(Game.HomeTeam) && g.Teams.Contains(Game.AwayTeam));
     _groupLetter = group?.Name?.Split(' ', StringSplitOptions.RemoveEmptyEntries).LastOrDefault()?.ToUpperInvariant() ?? "";
+
+    // Compute popover data only on open-transition. Recomputing every render would re-walk GetAll<Competition>()
+    // on every keypress / VM property change while a popover stays open.
+    if (DetailsOpen
+        && !_prevDetailsOpen
+        && Game.HomeTeam.Type != TeamType.PLACEHOLDER
+        && Game.AwayTeam.Type != TeamType.PLACEHOLDER)
+    {
+      _prob = MatchProbability.WinDrawLoss(Game.HomeTeam.Elo, Game.AwayTeam.Elo);
+      _h2h = HeadToHeadLookup.Across(Repo, Game.HomeTeam, Game.AwayTeam);
+    }
+    _prevDetailsOpen = DetailsOpen;
   }
+
+  static string FormatPct(double p) => $"{p * 100:0}%";
+
+  static string PctClass(bool isActualOutcome) => isActualOutcome ? "game-details-pct-actual" : "";
 }

--- a/src/FantasyFootball.UI/Components/GameViewRow.razor
+++ b/src/FantasyFootball.UI/Components/GameViewRow.razor
@@ -4,7 +4,7 @@
 @using FantasyFootball.Repositories
 @inject IRepository Repo
 
-<div class="scoreboard-row-wrapper">
+<div class="scoreboard-row-wrapper" id="@(ShowSim ? "current-game" : null)">
 <div class="scoreboard-row @(IsJustFinished ? "scoreboard-row-just-finished" : "") @(DetailsOpen ? "scoreboard-row-open" : "")"
      @onclick="OnDetailsToggle">
   <div class="scoreboard-group-tag">

--- a/src/FantasyFootball.UI/Components/GroupView.razor
+++ b/src/FantasyFootball.UI/Components/GroupView.razor
@@ -44,10 +44,7 @@
   bool _thirdPlaceEligible;
   bool? _thirdPlaceAdvanced; // null = stage not finished yet (undetermined), true/false = resolved.
 
-  // Cache keys for issue #34: the qualifier walk inputs are structurally invariant within a
-  // competition (Stages + KoGame qualifiers don't change after construction), so we only need
-  // to compute once per Group reference. Third-place resolution depends on Stage.IsFinished
-  // additionally, which DOES change once during the comp.
+  // Qualifier-walk cache (issue #34): inputs are invariant per Group; only recompute on Group change or Stage.IsFinished transition.
   Group? _walkedGroup;
   bool? _walkedStageFinished;
   List<GroupQualifier>? _walkedLaterQualifiers;
@@ -59,22 +56,20 @@
     var competition = Group.Stage?.Competition;
     if (competition is null) { return; }
 
-    // Static walk: depends only on the Group + its competition's KO qualifiers, which are
-    // built once at competition creation. Re-running on every game-finished render across
-    // 12 groups was ~30ms of pure waste — the killer of issue #34.
     if (!ReferenceEquals(_walkedGroup, Group))
     {
       _walkedGroup = Group;
       _walkedStageFinished = null; // also force a third-place recompute below
       _directSlots = [];
       _thirdPlaceEligible = false;
+      _thirdPlaceAdvanced = null;
+      _walkedLaterQualifiers = null;
 
       var ownStageIndex = competition.Stages.IndexOf(Group.Stage);
-      // GroupQualifier.GroupId is the index within its OWN stage (per Qualifier.FromGroup), not across all
-      // stages. Today only one stage has groups so competition.Groups.IndexOf would happen to agree;
-      // using the stage-scoped list keeps this honest if a future format ever adds a second group stage.
+      // GroupQualifier.GroupId is the index within its OWN stage (per Qualifier.FromGroup); using the stage-scoped list keeps this honest if a future format adds a second group stage.
       var ownGroupIndex = Group.Stage.Groups.IndexOf(Group);
-      if (ownStageIndex < 0 || ownGroupIndex < 0) { return; }
+      // Reset _walkedGroup so the next render retries (the ReferenceEquals guard above would otherwise permanently skip the walk).
+      if (ownStageIndex < 0 || ownGroupIndex < 0) { _walkedGroup = null; return; }
 
       _walkedLaterQualifiers = competition.Stages
         .Skip(ownStageIndex + 1)
@@ -107,8 +102,7 @@
         var ownThirdPlaceTeam = _standings.ElementAtOrDefault(2)?.Team;
         if (ownThirdPlaceTeam is not null)
         {
-          // NamedUniqueId.Equals handles ReferenceEquals fallback for Id=0 entities (LocalStorage path)
-          // and Id-equality for Id>0 entities (future SQLite-backed BlazorWebView host).
+          // NamedUniqueId.Equals: ReferenceEquals fallback for Id=0 (LocalStorage), Id-equality for Id>0 (future SQLite host).
           _thirdPlaceAdvanced = _walkedLaterQualifiers
             .Where(q => !string.IsNullOrEmpty(q.ThirdPlaceCombination))
             .Any(q => Equals(q.Get(), ownThirdPlaceTeam));

--- a/src/FantasyFootball.UI/Components/GroupView.razor
+++ b/src/FantasyFootball.UI/Components/GroupView.razor
@@ -44,54 +44,75 @@
   bool _thirdPlaceEligible;
   bool? _thirdPlaceAdvanced; // null = stage not finished yet (undetermined), true/false = resolved.
 
+  // Cache keys for issue #34: the qualifier walk inputs are structurally invariant within a
+  // competition (Stages + KoGame qualifiers don't change after construction), so we only need
+  // to compute once per Group reference. Third-place resolution depends on Stage.IsFinished
+  // additionally, which DOES change once during the comp.
+  Group? _walkedGroup;
+  bool? _walkedStageFinished;
+  List<GroupQualifier>? _walkedLaterQualifiers;
+
   protected override void OnParametersSet()
   {
     _standings = Group.GetStandings();
-    _directSlots = [];
-    _thirdPlaceEligible = false;
-    _thirdPlaceAdvanced = null;
 
     var competition = Group.Stage?.Competition;
     if (competition is null) { return; }
 
-    var ownStageIndex = competition.Stages.IndexOf(Group.Stage);
-    // GroupQualifier.GroupId is the index within its OWN stage (per Qualifier.FromGroup), not across all
-    // stages. Today only one stage has groups so competition.Groups.IndexOf would happen to agree; using
-    // the stage-scoped list keeps this honest if a future format ever adds a second group stage.
-    var ownGroupIndex = Group.Stage.Groups.IndexOf(Group);
-    if (ownStageIndex < 0 || ownGroupIndex < 0) { return; }
-
-    var laterQualifiers = competition.Stages
-      .Skip(ownStageIndex + 1)
-      .SelectMany(s => s.Games.OfType<KoGame>())
-      .SelectMany(g => new[] { g.HomeGroupQualifier, g.AwayGroupQualifier })
-      .OfType<GroupQualifier>()
-      .ToList();
-
-    foreach (var q in laterQualifiers)
+    // Static walk: depends only on the Group + its competition's KO qualifiers, which are
+    // built once at competition creation. Re-running on every game-finished render across
+    // 12 groups was ~30ms of pure waste — the killer of issue #34.
+    if (!ReferenceEquals(_walkedGroup, Group))
     {
-      if (string.IsNullOrEmpty(q.ThirdPlaceCombination))
+      _walkedGroup = Group;
+      _walkedStageFinished = null; // also force a third-place recompute below
+      _directSlots = [];
+      _thirdPlaceEligible = false;
+
+      var ownStageIndex = competition.Stages.IndexOf(Group.Stage);
+      // GroupQualifier.GroupId is the index within its OWN stage (per Qualifier.FromGroup), not across all
+      // stages. Today only one stage has groups so competition.Groups.IndexOf would happen to agree;
+      // using the stage-scoped list keeps this honest if a future format ever adds a second group stage.
+      var ownGroupIndex = Group.Stage.Groups.IndexOf(Group);
+      if (ownStageIndex < 0 || ownGroupIndex < 0) { return; }
+
+      _walkedLaterQualifiers = competition.Stages
+        .Skip(ownStageIndex + 1)
+        .SelectMany(s => s.Games.OfType<KoGame>())
+        .SelectMany(g => new[] { g.HomeGroupQualifier, g.AwayGroupQualifier })
+        .OfType<GroupQualifier>()
+        .ToList();
+
+      foreach (var q in _walkedLaterQualifiers)
       {
-        if (q.GroupId == ownGroupIndex) { _directSlots.Add(q.FinalPlacement); }
-      }
-      else if (q.ThirdPlaceCombination.Split('/').Contains(Letter, StringComparer.OrdinalIgnoreCase))
-      {
-        _thirdPlaceEligible = true;
+        if (string.IsNullOrEmpty(q.ThirdPlaceCombination))
+        {
+          if (q.GroupId == ownGroupIndex) { _directSlots.Add(q.FinalPlacement); }
+        }
+        else if (q.ThirdPlaceCombination.Split('/').Contains(Letter, StringComparer.OrdinalIgnoreCase))
+        {
+          _thirdPlaceEligible = true;
+        }
       }
     }
 
-    // Once the group stage is finished we can resolve ThirdPlace qualifiers to actual teams. Position 3 then promotes from "no bar" to advance / out.
-    if (_thirdPlaceEligible && Group.Stage.IsFinished)
+    // Third-place resolution: depends on Stage.IsFinished. Recompute only on the false → true transition.
+    var stageFinishedNow = Group.Stage?.IsFinished ?? false;
+    if (_walkedStageFinished != stageFinishedNow)
     {
-      var ownThirdPlaceTeam = _standings.ElementAtOrDefault(2)?.Team;
-      if (ownThirdPlaceTeam is not null)
+      _walkedStageFinished = stageFinishedNow;
+      _thirdPlaceAdvanced = null;
+      if (_thirdPlaceEligible && stageFinishedNow && _walkedLaterQualifiers is not null)
       {
-        // NamedUniqueId.Equals handles both worlds: ReferenceEquals fallback for Id=0 entities
-        // (LocalStorage path — Team instances inside Competition have unset Ids), and Id-equality
-        // for Id>0 entities (future SQLite-backed BlazorWebView host). Stable across both paths.
-        _thirdPlaceAdvanced = laterQualifiers
-          .Where(q => !string.IsNullOrEmpty(q.ThirdPlaceCombination))
-          .Any(q => Equals(q.Get(), ownThirdPlaceTeam));
+        var ownThirdPlaceTeam = _standings.ElementAtOrDefault(2)?.Team;
+        if (ownThirdPlaceTeam is not null)
+        {
+          // NamedUniqueId.Equals handles ReferenceEquals fallback for Id=0 entities (LocalStorage path)
+          // and Id-equality for Id>0 entities (future SQLite-backed BlazorWebView host).
+          _thirdPlaceAdvanced = _walkedLaterQualifiers
+            .Where(q => !string.IsNullOrEmpty(q.ThirdPlaceCombination))
+            .Any(q => Equals(q.Get(), ownThirdPlaceTeam));
+        }
       }
     }
   }

--- a/src/FantasyFootball.UI/FantasyFootball.UI.csproj
+++ b/src/FantasyFootball.UI/FantasyFootball.UI.csproj
@@ -16,6 +16,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="10.0.8" />
     <PackageReference Include="MudBlazor" Version="9.4.0" />
+    <PackageReference Include="Serilog" Version="4.3.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/FantasyFootball.UI/GlobalUsings.cs
+++ b/src/FantasyFootball.UI/GlobalUsings.cs
@@ -1,1 +1,2 @@
 global using System.Globalization;
+global using Serilog;

--- a/src/FantasyFootball.UI/Pages/CompetitionDetail.razor
+++ b/src/FantasyFootball.UI/Pages/CompetitionDetail.razor
@@ -199,16 +199,11 @@ else
 
   async Task ReplayCompetition()
   {
-    // Set IsBusy + yield so the spinner flushes to the DOM before the synchronous Replay() blocks on the
-    // LocalStorage save. Without the yield the button appears unresponsive: nothing visibly happens between
-    // click and the new-page navigation. Load() on the new comp's mount resets IsBusy.
-    ViewModel.IsBusy = true;
     // Clear in-flight confetti particles from the previous finish — they'd otherwise keep falling on the
-    // new-comp page for 2-3 seconds and look like a fresh celebration.
+    // new-comp page for 2-3 seconds and look like a fresh celebration. IsBusy + spinner-flush is the VM's job.
     try { await JS.InvokeVoidAsync("ffConfetti.reset"); }
     catch (JSDisconnectedException) { /* page disposing */ }
-    await Task.Yield();
-    var replay = ViewModel.Replay();
+    var replay = await ViewModel.Replay();
     Nav.NavigateTo($"/competitions/{replay.Id}");
   }
 

--- a/src/FantasyFootball.UI/Pages/CompetitionDetail.razor
+++ b/src/FantasyFootball.UI/Pages/CompetitionDetail.razor
@@ -87,6 +87,8 @@ else
         <div class="round-chip-row">
           @foreach (var r in ViewModel.Rounds)
           {
+            var roundForChip = r;
+            var roundIdxForChip = ViewModel.Rounds.IndexOf(r);
             var isSelected = ReferenceEquals(r, ViewModel.SelectedRound);
             var isCurrent  = ReferenceEquals(r, ViewModel.SelectedStage?.CurrentRound);
             var isDone     = r.IsFinished;
@@ -95,7 +97,7 @@ else
                      Variant="@(isSelected ? Variant.Filled : Variant.Outlined)"
                      Color="@(isSelected ? Color.Primary : isDone ? Color.Success : isCurrent ? Color.Primary : Color.Default)"
                      Size="Size.Small"
-                     OnClick="@(() => ViewModel.SelectedRound = r)">
+                     OnClick="@(async () => await OnRoundChipClick(roundForChip, roundIdxForChip))">
               @r.Name@(isDone ? " ✓" : "")
             </MudChip>
           }
@@ -117,35 +119,53 @@ else
                              title="Simulate round (R or Shift+Space)" />
             }
           </MudStack>
-          @if (ViewModel.SelectedRound is not null)
+          @if (ViewModel.SelectedStage is not null)
           {
-            var games = ViewModel.SelectedRound.AllGames.OrderBy(g => g.PlayedOn).ToList();
-            var multiDay = games.Select(g => g.PlayedOn.Date).Distinct().Count() > 1;
-            // Reference-compare, not Id-compare: nested entities in the LocalStorage path keep Id=0
-            // (LocalStorageRepository only assigns IDs to aggregate roots), so `game.Id == X.Id` is true
-            // for every row when X.Id is also 0. Reference equality works because both sides come from
-            // the live Competition graph rendered this pass.
+            // Variant B: render ALL rounds in the selected stage, each as its own section with a header,
+            // so user keeps prior results visible while scrolling forward. Chip strip above acts as a
+            // scroll-to anchor (see OnRoundChipClick). Day-grouping dividers stay per-round.
+            // Reference-compare, not Id-compare: nested entities in the LocalStorage path keep Id=0.
             var currentGame = ViewModel.Competition?.CurrentGame;
             var undoTargetGame = ViewModel.UndoTargetGame;
-            @foreach (var dayGroup in games.GroupBy(g => g.PlayedOn.Date))
+            @foreach (var round in ViewModel.SelectedStage.Rounds)
             {
-              @if (multiDay)
-              {
-                <div class="game-day-divider">@dayGroup.Key.ToString("ddd d MMM", System.Globalization.CultureInfo.CurrentCulture)</div>
-              }
-              @foreach (var game in dayGroup)
-              {
-                <GameViewRow Game="game"
-                             ShowSim="@(ReferenceEquals(game, currentGame))"
-                             ShowUndo="@(ReferenceEquals(game, undoTargetGame))"
-                             IsJustFinished="@(ReferenceEquals(game, ViewModel.RecentlyFinishedGame))"
-                             Disabled="@ViewModel.IsBusy"
-                             DetailsOpen="@(ReferenceEquals(game, _openDetailsGame))"
-                             OnDetailsToggle="@(() => ToggleDetailsGame(game))"
-                             OnSim="@(async () => await ViewModel.SimulateGame())"
-                             OnUndo="@(() => ViewModel.Undo())"
-                             OnRedo="@(async () => await ViewModel.RedoLastGame())" />
-              }
+              var roundIdx = ViewModel.SelectedStage.Rounds.IndexOf(round);
+              var games = round.AllGames.OrderBy(g => g.PlayedOn).ToList();
+              var multiDay = games.Select(g => g.PlayedOn.Date).Distinct().Count() > 1;
+              <section id="@($"round-{roundIdx}")"
+                       class="round-section @(ReferenceEquals(round, ViewModel.SelectedRound) ? "round-section-selected" : "")">
+                <div class="round-header">
+                  <span class="round-header-name">@round.Name</span>
+                  @if (round.IsFinished)
+                  {
+                    <span class="round-header-status">✓</span>
+                  }
+                  else if (ReferenceEquals(round, ViewModel.SelectedStage.CurrentRound))
+                  {
+                    <span class="round-header-status round-header-status-current">current</span>
+                  }
+                </div>
+                @foreach (var dayGroup in games.GroupBy(g => g.PlayedOn.Date))
+                {
+                  @if (multiDay)
+                  {
+                    <div class="game-day-divider">@dayGroup.Key.ToString("ddd d MMM", System.Globalization.CultureInfo.CurrentCulture)</div>
+                  }
+                  @foreach (var game in dayGroup)
+                  {
+                    <GameViewRow Game="game"
+                                 ShowSim="@(ReferenceEquals(game, currentGame))"
+                                 ShowUndo="@(ReferenceEquals(game, undoTargetGame))"
+                                 IsJustFinished="@(ReferenceEquals(game, ViewModel.RecentlyFinishedGame))"
+                                 Disabled="@ViewModel.IsBusy"
+                                 DetailsOpen="@(ReferenceEquals(game, _openDetailsGame))"
+                                 OnDetailsToggle="@(() => ToggleDetailsGame(game))"
+                                 OnSim="@(async () => await ViewModel.SimulateGame())"
+                                 OnUndo="@(() => ViewModel.Undo())"
+                                 OnRedo="@(async () => await ViewModel.RedoLastGame())" />
+                  }
+                }
+              </section>
             }
           }
         </MudPaper>
@@ -206,6 +226,13 @@ else
   DotNetObjectReference<CompetitionDetail>? _selfRef;
 
   void ToggleDetailsGame(Game game) => _openDetailsGame = ReferenceEquals(_openDetailsGame, game) ? null : game;
+
+  async Task OnRoundChipClick(Round round, int idx)
+  {
+    ViewModel.SelectedRound = round;
+    try { await JS.InvokeVoidAsync("ffScroll.toElement", $"round-{idx}"); }
+    catch (JSDisconnectedException) { /* page disposing */ }
+  }
 
   async Task ReplayCompetition()
   {

--- a/src/FantasyFootball.UI/Pages/CompetitionDetail.razor
+++ b/src/FantasyFootball.UI/Pages/CompetitionDetail.razor
@@ -38,6 +38,11 @@ else
                        OnClick="@(async () => await ViewModel.SimulateAll())"
                        Disabled="ViewModel.IsBusy"
                        title="Simulate tournament (T)" />
+        <MudIconButton Icon="@Icons.Material.Filled.MyLocation"
+                       Size="Size.Small"
+                       OnClick="JumpToCurrent"
+                       Disabled="ViewModel.Competition?.CurrentGame is null"
+                       title="Jump to the current round" />
       }
       @if (ViewModel.IsBusy)
       {
@@ -64,61 +69,75 @@ else
                      title="Quick settings &amp; keyboard shortcuts (H or ?)" />
     </MudStack>
 
-    <MudGrid Spacing="2">
-      <MudItem xs="12" sm="4">
-        <MudSelect T="Stage"
-                   Label="Stage"
-                   Value="ViewModel.SelectedStage"
-                   ValueChanged="@(v => ViewModel.SelectedStage = v)"
-                   ToStringFunc="@(s => s?.Name ?? "")"
-                   FullWidth="true">
+    @* Hierarchical timeline pickers: Stage chips on top, Round chips below indented under the selected stage.
+       Each row has a dotted-line backdrop to evoke "timeline / temporal progression". Stage rows are slightly
+       larger and use Medium chips; round rows use Small chips. Status semantics shared between both:
+       Selected → filled primary; Done → outlined success + ✓; Current → outlined primary; Future → outlined default. *@
+    <div class="timeline-pickers">
+      <div class="timeline-row timeline-row-stage">
+        <span class="timeline-label">Stage</span>
+        <div class="timeline-chips">
           @foreach (var s in ViewModel.Stages)
           {
-            <MudSelectItem Value="@s">@s.Name</MudSelectItem>
+            var stageForChip = s;
+            var isSelected = ReferenceEquals(s, ViewModel.SelectedStage);
+            var isCurrent  = ReferenceEquals(s, ViewModel.Competition?.CurrentStage);
+            var isDone     = s.IsFinished;
+            <MudChip T="Stage"
+                     Value="@s"
+                     Variant="@(isSelected ? Variant.Filled : Variant.Outlined)"
+                     Color="@(isSelected ? Color.Primary : Color.Default)"
+                     Size="Size.Medium"
+                     Class="@ChipStatusClass(isSelected, isCurrent, isDone)"
+                     OnClick="@(() => ViewModel.SelectedStage = stageForChip)">
+              @s.Name@(isDone ? " ✓" : "")
+            </MudChip>
           }
-        </MudSelect>
-      </MudItem>
-      <MudItem xs="12" sm="8">
-        @* Round picker as a horizontal chip strip. Each chip's visual state encodes status:
-           - Selected round → filled primary.
-           - Finished round (results available)  → outlined success + ✓.
-           - Current round (next to sim)         → outlined primary.
-           - Future round                        → outlined default. *@
-        <div class="round-chip-row">
+        </div>
+      </div>
+      <div class="timeline-row timeline-row-round">
+        <span class="timeline-label">Round</span>
+        <div class="timeline-chips">
           @foreach (var r in ViewModel.Rounds)
           {
             var roundForChip = r;
             var roundIdxForChip = ViewModel.Rounds.IndexOf(r);
             var isSelected = ReferenceEquals(r, ViewModel.SelectedRound);
-            var isCurrent  = ReferenceEquals(r, ViewModel.SelectedStage?.CurrentRound);
+            // "Current" = the single round being played NOW across the whole tournament — not "first
+            // non-finished in the currently-selected stage". The latter incorrectly flagged KO round 1
+            // as current while group stage was still being simmed.
+            var isCurrent  = ReferenceEquals(r, ViewModel.Competition?.CurrentGame?.Round);
             var isDone     = r.IsFinished;
             <MudChip T="Round"
                      Value="@r"
                      Variant="@(isSelected ? Variant.Filled : Variant.Outlined)"
-                     Color="@(isSelected ? Color.Primary : isDone ? Color.Success : isCurrent ? Color.Primary : Color.Default)"
+                     Color="@(isSelected ? Color.Primary : Color.Default)"
                      Size="Size.Small"
+                     Class="@ChipStatusClass(isSelected, isCurrent, isDone)"
                      OnClick="@(async () => await OnRoundChipClick(roundForChip, roundIdxForChip))">
               @r.Name@(isDone ? " ✓" : "")
             </MudChip>
+            @* Inter-chip "sim this round" affordance: visible only when the round still has games
+               to simulate. Replaces the previous Games-header sim-round button. *@
+            @if (!r.IsFinished)
+            {
+              <MudIconButton Icon="@Icons.Material.Filled.PlayArrow"
+                             Size="Size.Small"
+                             Color="Color.Primary"
+                             OnClick="@(async () => await SimulateRoundChip(roundForChip))"
+                             Disabled="ViewModel.IsBusy"
+                             title="@($"Simulate {r.Name}")"
+                             Class="round-sim-button" />
+            }
           }
         </div>
-      </MudItem>
-    </MudGrid>
+      </div>
+    </div>
 
     <MudGrid Spacing="3">
       <MudItem xs="12" md="7">
-        <MudPaper Class="pa-3" Elevation="1">
-          <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1" Class="mb-2">
-            <MudText Typo="Typo.h6">Games</MudText>
-            @if (!ViewModel.IsFinished && ViewModel.SelectedRound is not null)
-            {
-              <MudIconButton Icon="@Icons.Material.Filled.SkipNext"
-                             Size="Size.Small"
-                             OnClick="@(async () => await ViewModel.SimulateRound())"
-                             Disabled="ViewModel.IsBusy"
-                             title="Simulate round (R or Shift+Space)" />
-            }
-          </MudStack>
+        <MudPaper Class="pa-3 bounded-scroll-card" Elevation="4">
+          <MudText Typo="Typo.h6" Class="mb-2">Games</MudText>
           @if (ViewModel.SelectedStage is not null)
           {
             // Variant B: render ALL rounds in the selected stage, each as its own section with a header,
@@ -136,42 +155,38 @@ else
                        class="round-section @(ReferenceEquals(round, ViewModel.SelectedRound) ? "round-section-selected" : "")">
                 <div class="round-header">
                   <span class="round-header-name">@round.Name</span>
-                  @if (round.IsFinished)
+                </div>
+                @* Auto-fit games grid: as many columns as fit at min 22rem each. Single col on narrow,
+                   2-3 cols on wider screens. Day-grouping dividers span all columns via grid-column: 1 / -1. *@
+                <div class="round-games-grid">
+                  @foreach (var dayGroup in games.GroupBy(g => g.PlayedOn.Date))
                   {
-                    <span class="round-header-status">✓</span>
-                  }
-                  else if (ReferenceEquals(round, ViewModel.SelectedStage.CurrentRound))
-                  {
-                    <span class="round-header-status round-header-status-current">current</span>
+                    @if (multiDay)
+                    {
+                      <div class="game-day-divider">@dayGroup.Key.ToString("ddd d MMM", System.Globalization.CultureInfo.CurrentCulture)</div>
+                    }
+                    @foreach (var game in dayGroup)
+                    {
+                      <GameViewRow Game="game"
+                                   ShowSim="@(ReferenceEquals(game, currentGame))"
+                                   ShowUndo="@(ReferenceEquals(game, undoTargetGame))"
+                                   IsJustFinished="@(ReferenceEquals(game, ViewModel.RecentlyFinishedGame))"
+                                   Disabled="@ViewModel.IsBusy"
+                                   DetailsOpen="@(ReferenceEquals(game, _openDetailsGame))"
+                                   OnDetailsToggle="@(() => ToggleDetailsGame(game))"
+                                   OnSim="@(async () => await ViewModel.SimulateGame())"
+                                   OnUndo="@(() => ViewModel.Undo())"
+                                   OnRedo="@(async () => await ViewModel.RedoLastGame())" />
+                    }
                   }
                 </div>
-                @foreach (var dayGroup in games.GroupBy(g => g.PlayedOn.Date))
-                {
-                  @if (multiDay)
-                  {
-                    <div class="game-day-divider">@dayGroup.Key.ToString("ddd d MMM", System.Globalization.CultureInfo.CurrentCulture)</div>
-                  }
-                  @foreach (var game in dayGroup)
-                  {
-                    <GameViewRow Game="game"
-                                 ShowSim="@(ReferenceEquals(game, currentGame))"
-                                 ShowUndo="@(ReferenceEquals(game, undoTargetGame))"
-                                 IsJustFinished="@(ReferenceEquals(game, ViewModel.RecentlyFinishedGame))"
-                                 Disabled="@ViewModel.IsBusy"
-                                 DetailsOpen="@(ReferenceEquals(game, _openDetailsGame))"
-                                 OnDetailsToggle="@(() => ToggleDetailsGame(game))"
-                                 OnSim="@(async () => await ViewModel.SimulateGame())"
-                                 OnUndo="@(() => ViewModel.Undo())"
-                                 OnRedo="@(async () => await ViewModel.RedoLastGame())" />
-                  }
-                }
               </section>
             }
           }
         </MudPaper>
       </MudItem>
       <MudItem xs="12" md="5">
-        <MudPaper Class="pa-3" Elevation="1">
+        <MudPaper Class="pa-3 bounded-scroll-card" Elevation="4">
           <MudText Typo="Typo.h6" GutterBottom="true">Standings</MudText>
           @foreach (var group in ViewModel.Groups)
           {
@@ -182,6 +197,13 @@ else
     </MudGrid>
   </MudStack>
 }
+
+<!-- Click-outside-to-dismiss for the per-row game-details popover. Transparent overlay catches clicks
+     anywhere on the page; MudPopover sits at its default z-index ~1300 which is above the 1100 here. -->
+<MudOverlay Visible="@(_openDetailsGame is not null)"
+            DarkBackground="false"
+            ZIndex="1100"
+            @onclick="@(() => _openDetailsGame = null)" />
 
 <MudOverlay Visible="_helpOpen" DarkBackground="true" ZIndex="9999" @onclick="@(() => _helpOpen = false)">
   <MudPaper Class="pa-4" Elevation="6" Style="max-width: 36rem;" @onclick:stopPropagation="true">
@@ -222,7 +244,11 @@ else
   int? _lastLoadedId;
   bool _helpOpen;
   Game? _openDetailsGame;
-  int? _confettiFiredFor;
+  // Tracks the *Competition reference* we've already fired confetti for. Reference comparison survives
+  // the race where ViewModel.Load fires property changes BEFORE swapping Competition (so a lambda sees
+  // IsFinished=true on the old comp while Id has already flipped to the new one). Id-based guard misfired
+  // confetti on Simulate Again in that window.
+  Competition? _confettiFiredCompetition;
   DotNetObjectReference<CompetitionDetail>? _selfRef;
 
   void ToggleDetailsGame(Game game) => _openDetailsGame = ReferenceEquals(_openDetailsGame, game) ? null : game;
@@ -233,6 +259,40 @@ else
     try { await JS.InvokeVoidAsync("ffScroll.toElement", $"round-{idx}"); }
     catch (JSDisconnectedException) { /* page disposing */ }
   }
+
+  async Task JumpToCurrent()
+  {
+    var cur = ViewModel.Competition?.CurrentGame?.Round;
+    if (cur is null) { return; }
+    ViewModel.SelectedStage = cur.Stage;
+    ViewModel.SelectedRound = cur;
+    // Scroll to the actual current-game row (the one rendering the Sim button), not just the round
+    // header — a round can have 10+ games and the active one might be far below the header.
+    try { await JS.InvokeVoidAsync("ffScroll.toElement", "current-game"); }
+    catch (JSDisconnectedException) { /* page disposing */ }
+  }
+
+  // SimulateRound triggered by the inter-chip play icon. Switches to that round before simming so the
+  // panel scrolls there (auto-advance in the VM keeps it tracked too).
+  async Task SimulateRoundChip(Round round)
+  {
+    ViewModel.SelectedStage = round.Stage;
+    ViewModel.SelectedRound = round;
+    await ViewModel.SimulateRound();
+  }
+
+  // Tracks the last round we've scrolled to so OnVmChanged doesn't fire scrollIntoView on every
+  // unrelated property change. -1 means "no scroll yet".
+  int _lastScrolledRoundIdx = -1;
+
+  // Chip status visual encoding (color + border + opacity, not color alone).
+  // Selected: filled brand-primary via Color.Primary. Done: default outline (looks "white" on dark theme).
+  // Current: default outline + dashed border (.chip-current). Future: default outline + 50% opacity (.chip-future).
+  static string ChipStatusClass(bool isSelected, bool isCurrent, bool isDone) =>
+    isSelected ? "" :
+    isCurrent ? "chip-current" :
+    isDone ? "chip-done" :
+    "chip-future";
 
   async Task ReplayCompetition()
   {
@@ -253,7 +313,7 @@ else
     ViewModel.Load(Id);
     // Loading an already-finished comp from the list: suppress confetti so the user only sees it
     // when their own sim crosses the finish line, not when they revisit an old result.
-    _confettiFiredFor = ViewModel.IsFinished ? Id : null;
+    _confettiFiredCompetition = ViewModel.IsFinished ? ViewModel.Competition : null;
   }
 
   protected override async Task OnAfterRenderAsync(bool firstRender)
@@ -269,12 +329,44 @@ else
 
   void OnVmChanged(object? sender, EventArgs e) => InvokeAsync(async () =>
   {
-    if (ViewModel.IsFinished && _confettiFiredFor != Id)
+    // Reference comparison: survives the race where Load fires events before swapping Competition.
+    if (ViewModel.IsFinished
+        && ViewModel.Competition is not null
+        && !ReferenceEquals(_confettiFiredCompetition, ViewModel.Competition))
     {
-      _confettiFiredFor = Id;
+      _confettiFiredCompetition = ViewModel.Competition;
       try { await JS.InvokeVoidAsync("ffConfetti.celebrate"); }
       catch (JSDisconnectedException) { /* Page navigated away while the call was in flight. */ }
     }
+
+    // Auto-scroll to follow SelectedRound during ACTIVE multi-game sims, but ONLY on round transitions
+    // (not on the first IsBusy fire). A single-game sim keeps the same SelectedRound — without this
+    // guard the page would scroll to the top of the round the user was already viewing, losing their
+    // place within the round.
+    if (ViewModel.IsBusy)
+    {
+      var stage = ViewModel.SelectedStage;
+      var selectedIdx = (stage is not null && ViewModel.SelectedRound is not null)
+        ? stage.Rounds.IndexOf(ViewModel.SelectedRound)
+        : -1;
+      if (selectedIdx >= 0 && _lastScrolledRoundIdx < 0)
+      {
+        // First IsBusy event in this batch — remember the current round without scrolling.
+        _lastScrolledRoundIdx = selectedIdx;
+      }
+      else if (selectedIdx >= 0 && selectedIdx != _lastScrolledRoundIdx)
+      {
+        // Round changed mid-sim — scroll to the new one.
+        _lastScrolledRoundIdx = selectedIdx;
+        try { await JS.InvokeVoidAsync("ffScroll.toElement", $"round-{selectedIdx}"); }
+        catch (JSDisconnectedException) { /* */ }
+      }
+    }
+    else
+    {
+      _lastScrolledRoundIdx = -1;
+    }
+
     StateHasChanged();
   });
 
@@ -288,7 +380,6 @@ else
     if (_helpOpen)
     {
       if (key == "Escape") { _helpOpen = false; StateHasChanged(); }
-      // Swallow everything else while the overlay is up — no sim shortcuts firing behind it.
       return;
     }
 

--- a/src/FantasyFootball.UI/Pages/CompetitionDetail.razor
+++ b/src/FantasyFootball.UI/Pages/CompetitionDetail.razor
@@ -65,7 +65,7 @@ else
     </MudStack>
 
     <MudGrid Spacing="2">
-      <MudItem xs="12" sm="6">
+      <MudItem xs="12" sm="4">
         <MudSelect T="Stage"
                    Label="Stage"
                    Value="ViewModel.SelectedStage"
@@ -78,18 +78,28 @@ else
           }
         </MudSelect>
       </MudItem>
-      <MudItem xs="12" sm="6">
-        <MudSelect T="Round"
-                   Label="Round"
-                   Value="ViewModel.SelectedRound"
-                   ValueChanged="@(v => ViewModel.SelectedRound = v)"
-                   ToStringFunc="@(r => r?.Name ?? "")"
-                   FullWidth="true">
+      <MudItem xs="12" sm="8">
+        @* Round picker as a horizontal chip strip. Each chip's visual state encodes status:
+           - Selected round → filled primary.
+           - Finished round (results available)  → outlined success + ✓.
+           - Current round (next to sim)         → outlined primary.
+           - Future round                        → outlined default. *@
+        <div class="round-chip-row">
           @foreach (var r in ViewModel.Rounds)
           {
-            <MudSelectItem Value="@r">@r.Name</MudSelectItem>
+            var isSelected = ReferenceEquals(r, ViewModel.SelectedRound);
+            var isCurrent  = ReferenceEquals(r, ViewModel.SelectedStage?.CurrentRound);
+            var isDone     = r.IsFinished;
+            <MudChip T="Round"
+                     Value="@r"
+                     Variant="@(isSelected ? Variant.Filled : Variant.Outlined)"
+                     Color="@(isSelected ? Color.Primary : isDone ? Color.Success : isCurrent ? Color.Primary : Color.Default)"
+                     Size="Size.Small"
+                     OnClick="@(() => ViewModel.SelectedRound = r)">
+              @r.Name@(isDone ? " ✓" : "")
+            </MudChip>
           }
-        </MudSelect>
+        </div>
       </MudItem>
     </MudGrid>
 

--- a/src/FantasyFootball.UI/Pages/CompetitionDetail.razor
+++ b/src/FantasyFootball.UI/Pages/CompetitionDetail.razor
@@ -122,6 +122,8 @@ else
                              ShowUndo="@(ReferenceEquals(game, undoTargetGame))"
                              IsJustFinished="@(ReferenceEquals(game, ViewModel.RecentlyFinishedGame))"
                              Disabled="@ViewModel.IsBusy"
+                             DetailsOpen="@(ReferenceEquals(game, _openDetailsGame))"
+                             OnDetailsToggle="@(() => ToggleDetailsGame(game))"
                              OnSim="@(async () => await ViewModel.SimulateGame())"
                              OnUndo="@(() => ViewModel.Undo())"
                              OnRedo="@(async () => await ViewModel.RedoLastGame())" />
@@ -181,7 +183,10 @@ else
 
   int? _lastLoadedId;
   bool _helpOpen;
+  Game? _openDetailsGame;
   DotNetObjectReference<CompetitionDetail>? _selfRef;
+
+  void ToggleDetailsGame(Game game) => _openDetailsGame = ReferenceEquals(_openDetailsGame, game) ? null : game;
 
   protected override void OnInitialized() => ViewModel.PropertyChanged += OnVmChanged;
 

--- a/src/FantasyFootball.UI/Pages/CompetitionDetail.razor
+++ b/src/FantasyFootball.UI/Pages/CompetitionDetail.razor
@@ -41,7 +41,7 @@ else
         <MudIconButton Icon="@Icons.Material.Filled.MyLocation"
                        Size="Size.Small"
                        OnClick="JumpToCurrent"
-                       Disabled="ViewModel.Competition?.CurrentGame is null"
+                       Disabled="ViewModel.Competition?.CurrentGame is null || ViewModel.IsBusy"
                        title="Jump to the current round" />
       }
       @if (ViewModel.IsBusy)
@@ -89,7 +89,8 @@ else
                      Color="@(isSelected ? Color.Primary : Color.Default)"
                      Size="Size.Medium"
                      Class="@ChipStatusClass(isSelected, isCurrent, isDone)"
-                     OnClick="@(() => ViewModel.SelectedStage = stageForChip)">
+                     Disabled="ViewModel.IsBusy"
+                     OnClick="@(() => OnStageChipClick(stageForChip))">
               @s.Name@(isDone ? " ✓" : "")
             </MudChip>
           }
@@ -103,9 +104,7 @@ else
             var roundForChip = r;
             var roundIdxForChip = ViewModel.Rounds.IndexOf(r);
             var isSelected = ReferenceEquals(r, ViewModel.SelectedRound);
-            // "Current" = the single round being played NOW across the whole tournament — not "first
-            // non-finished in the currently-selected stage". The latter incorrectly flagged KO round 1
-            // as current while group stage was still being simmed.
+            // "Current" = round of the tournament's CurrentGame, not SelectedStage.CurrentRound (latter mis-flagged KO rounds while group stage was still being simmed).
             var isCurrent  = ReferenceEquals(r, ViewModel.Competition?.CurrentGame?.Round);
             var isDone     = r.IsFinished;
             <MudChip T="Round"
@@ -114,12 +113,12 @@ else
                      Color="@(isSelected ? Color.Primary : Color.Default)"
                      Size="Size.Small"
                      Class="@ChipStatusClass(isSelected, isCurrent, isDone)"
+                     Disabled="ViewModel.IsBusy"
                      OnClick="@(async () => await OnRoundChipClick(roundForChip, roundIdxForChip))">
               @r.Name@(isDone ? " ✓" : "")
             </MudChip>
-            @* Inter-chip "sim this round" affordance: visible only when the round still has games
-               to simulate. Replaces the previous Games-header sim-round button. *@
-            @if (!r.IsFinished)
+            @* Sim button only on the tournament-current round — ViewModel.SimulateRound always sims CurrentStage.CurrentRound, so rendering on future rounds would mismatch tooltip with behaviour. *@
+            @if (!r.IsFinished && ReferenceEquals(r, ViewModel.Competition?.CurrentGame?.Round))
             {
               <MudIconButton Icon="@Icons.Material.Filled.PlayArrow"
                              Size="Size.Small"
@@ -140,10 +139,7 @@ else
           <MudText Typo="Typo.h6" Class="mb-2">Games</MudText>
           @if (ViewModel.SelectedStage is not null)
           {
-            // Variant B: render ALL rounds in the selected stage, each as its own section with a header,
-            // so user keeps prior results visible while scrolling forward. Chip strip above acts as a
-            // scroll-to anchor (see OnRoundChipClick). Day-grouping dividers stay per-round.
-            // Reference-compare, not Id-compare: nested entities in the LocalStorage path keep Id=0.
+            // Render all rounds in the selected stage; chip strip scrolls between them via round-{idx} anchors. Reference-compare since LocalStorage entities keep Id=0.
             var currentGame = ViewModel.Competition?.CurrentGame;
             var undoTargetGame = ViewModel.UndoTargetGame;
             @foreach (var round in ViewModel.SelectedStage.Rounds)
@@ -156,8 +152,6 @@ else
                 <div class="round-header">
                   <span class="round-header-name">@round.Name</span>
                 </div>
-                @* Auto-fit games grid: as many columns as fit at min 22rem each. Single col on narrow,
-                   2-3 cols on wider screens. Day-grouping dividers span all columns via grid-column: 1 / -1. *@
                 <div class="round-games-grid">
                   @foreach (var dayGroup in games.GroupBy(g => g.PlayedOn.Date))
                   {
@@ -244,14 +238,27 @@ else
   int? _lastLoadedId;
   bool _helpOpen;
   Game? _openDetailsGame;
-  // Tracks the *Competition reference* we've already fired confetti for. Reference comparison survives
-  // the race where ViewModel.Load fires property changes BEFORE swapping Competition (so a lambda sees
-  // IsFinished=true on the old comp while Id has already flipped to the new one). Id-based guard misfired
-  // confetti on Simulate Again in that window.
+  // Guard tracks Competition reference, not Id — survives the load-race window where Id swaps before Competition is reassigned.
   Competition? _confettiFiredCompetition;
+  // Scroll target to flush after the next render — set when a state change (e.g. SelectedStage in JumpToCurrent) needs DOM that doesn't exist yet.
+  string? _pendingScrollId;
+  // Tracks last scrolled round during active sim; -1 = no scroll yet.
+  int _lastScrolledRoundIdx = -1;
   DotNetObjectReference<CompetitionDetail>? _selfRef;
 
   void ToggleDetailsGame(Game game) => _openDetailsGame = ReferenceEquals(_openDetailsGame, game) ? null : game;
+
+  // Mirror StepStage's scroll-queue behaviour so mouse and keyboard stage navigation feel consistent.
+  void OnStageChipClick(Stage stage)
+  {
+    _openDetailsGame = null;
+    ViewModel.SelectedStage = stage;
+    if (ViewModel.SelectedRound is { } round)
+    {
+      var idx = stage.Rounds.IndexOf(round);
+      if (idx >= 0) { _pendingScrollId = $"round-{idx}"; }
+    }
+  }
 
   async Task OnRoundChipClick(Round round, int idx)
   {
@@ -264,16 +271,20 @@ else
   {
     var cur = ViewModel.Competition?.CurrentGame?.Round;
     if (cur is null) { return; }
-    ViewModel.SelectedStage = cur.Stage;
+    // OnSelectedStageChanged snaps SelectedRound on stage change; only set explicitly when staying in the same stage.
+    if (!ReferenceEquals(cur.Stage, ViewModel.SelectedStage))
+    {
+      // Stage change queues a re-render — the new stage's #current-game element doesn't exist yet, so defer to OnAfterRenderAsync.
+      ViewModel.SelectedStage = cur.Stage;
+      _pendingScrollId = "current-game";
+      return;
+    }
     ViewModel.SelectedRound = cur;
-    // Scroll to the actual current-game row (the one rendering the Sim button), not just the round
-    // header — a round can have 10+ games and the active one might be far below the header.
     try { await JS.InvokeVoidAsync("ffScroll.toElement", "current-game"); }
     catch (JSDisconnectedException) { /* page disposing */ }
   }
 
-  // SimulateRound triggered by the inter-chip play icon. Switches to that round before simming so the
-  // panel scrolls there (auto-advance in the VM keeps it tracked too).
+  // Switches to the round before simming so the panel follows (VM auto-advance also tracks it).
   async Task SimulateRoundChip(Round round)
   {
     ViewModel.SelectedStage = round.Stage;
@@ -281,13 +292,7 @@ else
     await ViewModel.SimulateRound();
   }
 
-  // Tracks the last round we've scrolled to so OnVmChanged doesn't fire scrollIntoView on every
-  // unrelated property change. -1 means "no scroll yet".
-  int _lastScrolledRoundIdx = -1;
-
-  // Chip status visual encoding (color + border + opacity, not color alone).
-  // Selected: filled brand-primary via Color.Primary. Done: default outline (looks "white" on dark theme).
-  // Current: default outline + dashed border (.chip-current). Future: default outline + 50% opacity (.chip-future).
+  // Chip status: selected=filled primary; current=dashed outline; future=50% opacity; done=solid outline.
   static string ChipStatusClass(bool isSelected, bool isCurrent, bool isDone) =>
     isSelected ? "" :
     isCurrent ? "chip-current" :
@@ -320,10 +325,15 @@ else
   {
     if (firstRender)
     {
-      // Document-level keydown forwarder. Listening on document (not the page root div) means Space + arrows
-      // work without the user clicking into the page first; the JS side skips when focus is on an input.
+      // Document-level keydown forwarder so Space + arrows work without clicking into the page first; JS skips when focus is on an input.
       _selfRef = DotNetObjectReference.Create(this);
       await JS.InvokeVoidAsync("ffKeyboard.registerDocumentHandler", _selfRef);
+    }
+    if (_pendingScrollId is { } id)
+    {
+      _pendingScrollId = null;
+      try { await JS.InvokeVoidAsync("ffScroll.toElement", id); }
+      catch (JSDisconnectedException) { /* page disposing */ }
     }
   }
 
@@ -339,10 +349,7 @@ else
       catch (JSDisconnectedException) { /* Page navigated away while the call was in flight. */ }
     }
 
-    // Auto-scroll to follow SelectedRound during ACTIVE multi-game sims, but ONLY on round transitions
-    // (not on the first IsBusy fire). A single-game sim keeps the same SelectedRound — without this
-    // guard the page would scroll to the top of the round the user was already viewing, losing their
-    // place within the round.
+    // Follow round transitions during active sim; first IsBusy fire just records (don't scroll a single-game sim away from the user's viewport).
     if (ViewModel.IsBusy)
     {
       var stage = ViewModel.SelectedStage;
@@ -351,15 +358,13 @@ else
         : -1;
       if (selectedIdx >= 0 && _lastScrolledRoundIdx < 0)
       {
-        // First IsBusy event in this batch — remember the current round without scrolling.
         _lastScrolledRoundIdx = selectedIdx;
       }
       else if (selectedIdx >= 0 && selectedIdx != _lastScrolledRoundIdx)
       {
-        // Round changed mid-sim — scroll to the new one.
         _lastScrolledRoundIdx = selectedIdx;
         try { await JS.InvokeVoidAsync("ffScroll.toElement", $"round-{selectedIdx}"); }
-        catch (JSDisconnectedException) { /* */ }
+        catch (JSDisconnectedException) { /* page disposing */ }
       }
     }
     else
@@ -422,7 +427,9 @@ else
     if (rounds.Count == 0 || ViewModel.SelectedRound is null) { return; }
     var i = rounds.IndexOf(ViewModel.SelectedRound);
     if (i < 0) { return; }
-    ViewModel.SelectedRound = rounds[(i + delta + rounds.Count) % rounds.Count];
+    var newIdx = (i + delta + rounds.Count) % rounds.Count;
+    ViewModel.SelectedRound = rounds[newIdx];
+    _pendingScrollId = $"round-{newIdx}";
   }
 
   void StepStage(int delta)
@@ -432,6 +439,12 @@ else
     var i = stages.IndexOf(ViewModel.SelectedStage);
     if (i < 0) { return; }
     ViewModel.SelectedStage = stages[(i + delta + stages.Count) % stages.Count];
+    // OnSelectedStageChanged snapped SelectedRound; queue scroll to that round's section (which re-renders next).
+    if (ViewModel.SelectedStage is { } stage && ViewModel.SelectedRound is { } round)
+    {
+      var idx = stage.Rounds.IndexOf(round);
+      if (idx >= 0) { _pendingScrollId = $"round-{idx}"; }
+    }
   }
 
   public async ValueTask DisposeAsync()

--- a/src/FantasyFootball.UI/Pages/CompetitionDetail.razor
+++ b/src/FantasyFootball.UI/Pages/CompetitionDetail.razor
@@ -48,6 +48,14 @@ else
         <MudChip T="string" Color="Color.Success" Icon="@Icons.Material.Filled.EmojiEvents" Size="Size.Small">
           Winner: @ViewModel.Winner.Name
         </MudChip>
+        <MudButton Variant="Variant.Outlined"
+                   Color="Color.Primary"
+                   Size="Size.Small"
+                   StartIcon="@Icons.Material.Filled.Refresh"
+                   OnClick="ReplayCompetition"
+                   Disabled="ViewModel.IsBusy">
+          Simulate again
+        </MudButton>
       }
       <MudSpacer />
       <MudIconButton Icon="@Icons.Material.Filled.Keyboard"
@@ -184,9 +192,25 @@ else
   int? _lastLoadedId;
   bool _helpOpen;
   Game? _openDetailsGame;
+  int? _confettiFiredFor;
   DotNetObjectReference<CompetitionDetail>? _selfRef;
 
   void ToggleDetailsGame(Game game) => _openDetailsGame = ReferenceEquals(_openDetailsGame, game) ? null : game;
+
+  async Task ReplayCompetition()
+  {
+    // Set IsBusy + yield so the spinner flushes to the DOM before the synchronous Replay() blocks on the
+    // LocalStorage save. Without the yield the button appears unresponsive: nothing visibly happens between
+    // click and the new-page navigation. Load() on the new comp's mount resets IsBusy.
+    ViewModel.IsBusy = true;
+    // Clear in-flight confetti particles from the previous finish — they'd otherwise keep falling on the
+    // new-comp page for 2-3 seconds and look like a fresh celebration.
+    try { await JS.InvokeVoidAsync("ffConfetti.reset"); }
+    catch (JSDisconnectedException) { /* page disposing */ }
+    await Task.Yield();
+    var replay = ViewModel.Replay();
+    Nav.NavigateTo($"/competitions/{replay.Id}");
+  }
 
   protected override void OnInitialized() => ViewModel.PropertyChanged += OnVmChanged;
 
@@ -195,6 +219,9 @@ else
     if (_lastLoadedId == Id) { return; }
     _lastLoadedId = Id;
     ViewModel.Load(Id);
+    // Loading an already-finished comp from the list: suppress confetti so the user only sees it
+    // when their own sim crosses the finish line, not when they revisit an old result.
+    _confettiFiredFor = ViewModel.IsFinished ? Id : null;
   }
 
   protected override async Task OnAfterRenderAsync(bool firstRender)
@@ -208,7 +235,16 @@ else
     }
   }
 
-  void OnVmChanged(object? sender, EventArgs e) => InvokeAsync(StateHasChanged);
+  void OnVmChanged(object? sender, EventArgs e) => InvokeAsync(async () =>
+  {
+    if (ViewModel.IsFinished && _confettiFiredFor != Id)
+    {
+      _confettiFiredFor = Id;
+      try { await JS.InvokeVoidAsync("ffConfetti.celebrate"); }
+      catch (JSDisconnectedException) { /* Page navigated away while the call was in flight. */ }
+    }
+    StateHasChanged();
+  });
 
   // Invoked by the document-level JS keydown listener. Sim keys no-op once finished; nav keys remain.
   [JSInvokable]

--- a/src/FantasyFootball.UI/Pages/CompetitionSetup.razor
+++ b/src/FantasyFootball.UI/Pages/CompetitionSetup.razor
@@ -54,19 +54,21 @@
   <MudGrid Spacing="2">
     @foreach (var group in ViewModel.Groups)
     {
-      <MudItem xs="12" sm="6" md="4" lg="3">
+      <MudItem xs="12" sm="6" md="4">
         <MudPaper Class="pa-3" Elevation="1" Style="height: 100%;">
           <MudText Typo="Typo.subtitle1" GutterBottom="true">@group.Name</MudText>
           <MudDivider Class="mb-2" />
-          @foreach (var team in group.Teams)
-          {
-            <div class="d-flex align-center mb-1" style="gap: 0.5rem;">
-              <FlagIcon Team="team" Size="20" />
-              <MudText Typo="Typo.body2">@team.Name</MudText>
-              <MudSpacer />
-              <MudText Typo="Typo.caption" Color="Color.Secondary">@team.Elo</MudText>
-            </div>
-          }
+          <div class="setup-team-list">
+            @foreach (var team in group.Teams)
+            {
+              <div class="setup-team-row">
+                <FlagIcon Team="team" Size="28" />
+                <MudText Typo="Typo.body2">@team.Name</MudText>
+                <MudSpacer />
+                <MudText Typo="Typo.caption" Color="Color.Secondary">@team.Elo</MudText>
+              </div>
+            }
+          </div>
         </MudPaper>
       </MudItem>
     }

--- a/src/FantasyFootball.UI/ViewModels/CompetitionDetailViewModel.cs
+++ b/src/FantasyFootball.UI/ViewModels/CompetitionDetailViewModel.cs
@@ -1,6 +1,7 @@
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Messaging;
 using FantasyFootball.Data;
+using FantasyFootball.Data.CompetitionFactories;
 using FantasyFootball.Models;
 using FantasyFootball.Repositories;
 using FantasyFootball.Services;
@@ -98,6 +99,8 @@ public partial class CompetitionDetailViewModel : ObservableObject
 		// Clear any in-flight pulse target — a FlashRecentlyFinished from a previous
 		// competition would otherwise eventually fire StateHasChanged on this page for nothing.
 		RecentlyFinishedGame = null;
+		// Replay flow sets IsBusy=true before navigating; clear here so the new comp's view starts idle.
+		IsBusy = false;
 		Competition = _repo.Get<Competition>(competitionId);
 		if (Competition is null) { return; }
 
@@ -163,7 +166,8 @@ public partial class CompetitionDetailViewModel : ObservableObject
 			await _simulator.SimulateRound(Competition.CurrentStage.CurrentRound);
 			_repo.Save(Competition);
 		}
-		finally { OnSimBatchComplete(); }
+		// Keep the user on the round they just simmed — auto-advancing to the next round hides the results they wanted to see.
+		finally { OnSimBatchComplete(advanceSelection: false); }
 	}
 
 	public async Task SimulateAll()
@@ -252,19 +256,21 @@ public partial class CompetitionDetailViewModel : ObservableObject
 	}
 
 	/// <summary>
-	/// Post-sim-batch hook called from every <c>SimulateX</c> finally. Advances
-	/// Stage/Round to the current non-finished entry, re-publishes Competition
-	/// so the page rebinds, and clears <see cref="IsBusy"/>. OnGameFinished
-	/// keeps selection live in non-Quiet mode per game, but Quiet/Instant
-	/// suppresses those broadcasts — without this hook the page would still be
-	/// pinned to the round selected before the batch started.
+	/// Post-sim-batch hook called from every <c>SimulateX</c> finally. Optionally advances
+	/// Stage/Round to the current non-finished entry, re-publishes Competition so the page
+	/// rebinds, and clears <see cref="IsBusy"/>. SimulateRound passes <c>advanceSelection: false</c>
+	/// so the user stays on the round they just simmed; SimulateGame and SimulateAll let the
+	/// default advance fire (next-game flow and trophy-landing respectively).
 	/// </summary>
-	void OnSimBatchComplete()
+	void OnSimBatchComplete(bool advanceSelection = true)
 	{
 		if (Competition is not null)
 		{
-			SelectedStage = Competition.CurrentStage ?? Competition.Stages.LastOrDefault();
-			SelectedRound = SelectedStage?.CurrentRound ?? SelectedStage?.Rounds.LastOrDefault();
+			if (advanceSelection)
+			{
+				SelectedStage = Competition.CurrentStage ?? Competition.Stages.LastOrDefault();
+				SelectedRound = SelectedStage?.CurrentRound ?? SelectedStage?.Rounds.LastOrDefault();
+			}
 			OnPropertyChanged(nameof(Competition));
 			// Finished competitions are immutable in the UX — the user can't go back to before the trophy.
 			if (Competition.IsFinished) { ClearUndo(); }
@@ -274,18 +280,34 @@ public partial class CompetitionDetailViewModel : ObservableObject
 		OnPropertyChanged(nameof(UndoTargetGame));
 	}
 
+	/// <summary>
+	/// Clones the current competition's team lineup into a fresh competition with the same Type + Year
+	/// and saves it. Returns the new Id so the page can navigate to it. Uses today's Elo on each Team
+	/// instance, not a snapshot from the finished comp — issue #19 will tighten this once the per-comp
+	/// Elo snapshot lands. Group.ShallowClone strips Stage / Games / Id; the factory wires everything else fresh.
+	/// </summary>
+	public Competition Replay()
+	{
+		if (Competition is null) { throw new InvalidOperationException("No competition loaded to replay."); }
+		var year = Competition.Start?.Year ?? DateTime.Now.Year;
+		var clonedGroups = Competition.Groups.Select(g => g.ShallowClone()).ToList();
+		var factory = CompetitionFactory.For(Competition.Type, year, clonedGroups);
+		var replay = factory.Create();
+		_repo.Save(replay);
+		MessageBus.Send(new CompetitionCreatedMessage(replay));
+
+		return replay;
+	}
+
 	void OnGameFinished(Game finished)
 	{
 		// Bail if the message is for a different competition.
 		if (Competition is null || finished.Round?.Stage?.Competition is null) { return; }
 		if (finished.Round.Stage.Competition.Id != Competition.Id) { return; }
 
-		// Auto-advance Stage/Round to the next non-finished one so the games
-		// pane follows the simulation forward.
-		SelectedStage = Competition.CurrentStage ?? Competition.Stages.LastOrDefault();
-		SelectedRound = SelectedStage?.CurrentRound ?? SelectedStage?.Rounds.LastOrDefault();
-
-		// Re-publish Competition change so groupings + standings + winner re-evaluate.
+		// Re-publish Competition change so groupings + standings + winner re-evaluate. Auto-advance is left
+		// to OnSimBatchComplete: doing it per-game during a multi-game sim flipped the panel away from the
+		// round being simmed the moment its last game resolved, hiding the results the user was watching.
 		OnPropertyChanged(nameof(Competition));
 	}
 }

--- a/src/FantasyFootball.UI/ViewModels/CompetitionDetailViewModel.cs
+++ b/src/FantasyFootball.UI/ViewModels/CompetitionDetailViewModel.cs
@@ -285,18 +285,32 @@ public partial class CompetitionDetailViewModel : ObservableObject
 	/// and saves it. Returns the new Id so the page can navigate to it. Uses today's Elo on each Team
 	/// instance, not a snapshot from the finished comp — issue #19 will tighten this once the per-comp
 	/// Elo snapshot lands. Group.ShallowClone strips Stage / Games / Id; the factory wires everything else fresh.
+	/// Async so the IsBusy spinner can flush to the DOM before the synchronous LocalStorage save blocks;
+	/// IsBusy is left true on return — Load() on the new comp's mount resets it.
 	/// </summary>
-	public Competition Replay()
+	public async Task<Competition> Replay()
 	{
 		if (Competition is null) { throw new InvalidOperationException("No competition loaded to replay."); }
-		var year = Competition.Start?.Year ?? DateTime.Now.Year;
-		var clonedGroups = Competition.Groups.Select(g => g.ShallowClone()).ToList();
-		var factory = CompetitionFactory.For(Competition.Type, year, clonedGroups);
-		var replay = factory.Create();
-		_repo.Save(replay);
-		MessageBus.Send(new CompetitionCreatedMessage(replay));
+		IsBusy = true;
+		await Task.Yield();
 
-		return replay;
+		try
+		{
+			var year = Competition.Start?.Year ?? DateTime.Now.Year;
+			var clonedGroups = Competition.Groups.Select(g => g.ShallowClone()).ToList();
+			// CompetitionFactory.For raises NotImplementedException for CHAMPIONS_LEAGUE / DOMESTIC_LEAGUE and ArgumentException for unknown types; clear IsBusy on the exception path so the spinner doesn't lock the page until reload.
+			var factory = CompetitionFactory.For(Competition.Type, year, clonedGroups);
+			var replay = factory.Create();
+			_repo.Save(replay);
+			MessageBus.Send(new CompetitionCreatedMessage(replay));
+
+			return replay;
+		}
+		catch
+		{
+			IsBusy = false;
+			throw;
+		}
 	}
 
 	void OnGameFinished(Game finished)

--- a/src/FantasyFootball.UI/ViewModels/CompetitionDetailViewModel.cs
+++ b/src/FantasyFootball.UI/ViewModels/CompetitionDetailViewModel.cs
@@ -118,6 +118,22 @@ public partial class CompetitionDetailViewModel : ObservableObject
 
 	partial void OnSpeedChanged(SimulationSpeed value) => ApplySpeedToSimulator();
 
+	/// <summary>
+	/// When the user picks a new stage (e.g. clicks the K.O. Phase chip while viewing the Group Stage),
+	/// snap <see cref="SelectedRound"/> to a sensible round inside that stage instead of leaving it
+	/// pointing at the previous stage's round (which the round chip strip would then render as nothing
+	/// matching the highlight state). Prefer the tournament's current round if it's in this stage;
+	/// otherwise fall back to the stage's first round.
+	/// </summary>
+	partial void OnSelectedStageChanged(Stage? value)
+	{
+		if (value is null) { SelectedRound = null; return; }
+		var currentRound = Competition?.CurrentGame?.Round;
+		SelectedRound = currentRound is not null && value.Rounds.Contains(currentRound)
+			? currentRound
+			: value.Rounds.FirstOrDefault();
+	}
+
 	void ApplySpeedToSimulator()
 	{
 		if (_simulator is null) { return; }
@@ -129,12 +145,7 @@ public partial class CompetitionDetailViewModel : ObservableObject
 	{
 		if (_simulator is null || Competition?.CurrentGame is null || IsBusy) { return; }
 		var gameBeingSimmed = Competition.CurrentGame;
-		// Set undo target + pulse marker UP FRONT, before the sim's Task.Delay throws an
-		// async yield. The next render flushes them in the same frame as the new score —
-		// otherwise the buttons + pulse appear ~Task.Delay(GameDelay) ms after the score,
-		// visibly lagging the click.
 		PushUndoEntry(gameBeingSimmed);
-		_ = FlashRecentlyFinished(gameBeingSimmed);
 		IsBusy = true;
 		try
 		{
@@ -142,6 +153,14 @@ public partial class CompetitionDetailViewModel : ObservableObject
 			// the post-sim Task.Delay so the busy spinner clears immediately after the result.
 			await _simulator.SimulateGame(gameBeingSimmed, delayAfter: false);
 			_repo.Save(Competition);
+			// Pulse marker is set AFTER the sim so the row class transition + new score text
+			// happen in the same render frame regardless of Blazor's render batching. Setting it
+			// up front caused intermediate renders on the keyboard-shortcut path (Space) — the row
+			// gained the class while score was still "-:-", browser saw the animationstart fire
+			// against the wrong content, and the visible animation was lost in the render churn.
+			// EventCallback path (click) coalesces renders so both timings worked there; this is
+			// the consistent path.
+			_ = FlashRecentlyFinished(gameBeingSimmed);
 		}
 		finally
 		{
@@ -204,9 +223,6 @@ public partial class CompetitionDetailViewModel : ObservableObject
 		if (_simulator is null || Competition is null || IsBusy) { return; }
 		if (!_undoStack.TryPeek(out var game)) { return; }
 
-		// Pulse fires before the await — same reasoning as SimulateGame, so the new score
-		// and the pulse animation land in the same render frame.
-		_ = FlashRecentlyFinished(game);
 		IsBusy = true;
 		try
 		{
@@ -214,6 +230,8 @@ public partial class CompetitionDetailViewModel : ObservableObject
 			// Same as SimulateGame: single-game user click, no inter-game pacing.
 			await _simulator.SimulateGame(game, delayAfter: false);
 			_repo.Save(Competition);
+			// FlashRecentlyFinished AFTER the sim — same render-batching reason as SimulateGame.
+			_ = FlashRecentlyFinished(game);
 		}
 		finally
 		{
@@ -319,9 +337,19 @@ public partial class CompetitionDetailViewModel : ObservableObject
 		if (Competition is null || finished.Round?.Stage?.Competition is null) { return; }
 		if (finished.Round.Stage.Competition.Id != Competition.Id) { return; }
 
-		// Re-publish Competition change so groupings + standings + winner re-evaluate. Auto-advance is left
-		// to OnSimBatchComplete: doing it per-game during a multi-game sim flipped the panel away from the
-		// round being simmed the moment its last game resolved, hiding the results the user was watching.
+		// During multi-game sims the user wants the chip strip + page to FOLLOW the currently-playing
+		// round as it advances, not stay pinned on a manually-clicked round.
+		if (IsBusy)
+		{
+			var currentRound = Competition.CurrentGame?.Round;
+			if (currentRound is not null && !ReferenceEquals(currentRound, SelectedRound))
+			{
+				SelectedStage = currentRound.Stage; // cross-stage too (group → KO transition)
+				SelectedRound = currentRound;
+			}
+		}
+
+		// Re-publish Competition change so groupings + standings + winner re-evaluate.
 		OnPropertyChanged(nameof(Competition));
 	}
 }

--- a/src/FantasyFootball.UI/ViewModels/CompetitionDetailViewModel.cs
+++ b/src/FantasyFootball.UI/ViewModels/CompetitionDetailViewModel.cs
@@ -28,6 +28,9 @@ public partial class CompetitionDetailViewModel : ObservableObject
 
 	CompetitionSimulator? _simulator;
 
+	// True during SimulateAll only; SimulateRound leaves it false to keep the user on the round they just simmed.
+	bool _liveTracking;
+
 	// In-memory undo stack of *just-simmed games*. Undo = pop, call game.ClearResult().
 	// No snapshots / serialization needed: a simmed game is fully reversible by clearing its score
 	// and state back to SCHEDULED. Downstream state (standings, qualifiers, KO bracket) recomputes
@@ -153,13 +156,7 @@ public partial class CompetitionDetailViewModel : ObservableObject
 			// the post-sim Task.Delay so the busy spinner clears immediately after the result.
 			await _simulator.SimulateGame(gameBeingSimmed, delayAfter: false);
 			_repo.Save(Competition);
-			// Pulse marker is set AFTER the sim so the row class transition + new score text
-			// happen in the same render frame regardless of Blazor's render batching. Setting it
-			// up front caused intermediate renders on the keyboard-shortcut path (Space) — the row
-			// gained the class while score was still "-:-", browser saw the animationstart fire
-			// against the wrong content, and the visible animation was lost in the render churn.
-			// EventCallback path (click) coalesces renders so both timings worked there; this is
-			// the consistent path.
+			// Pulse marker AFTER the sim so the class transition + final score land in one render (Space path needs this; click batches via EventCallback).
 			_ = FlashRecentlyFinished(gameBeingSimmed);
 		}
 		finally
@@ -194,12 +191,13 @@ public partial class CompetitionDetailViewModel : ObservableObject
 		if (_simulator is null || Competition is null || Competition.IsFinished || IsBusy) { return; }
 		ClearUndo();
 		IsBusy = true;
+		_liveTracking = true;
 		try
 		{
 			await _simulator.Simulate();
 			_repo.Save(Competition);
 		}
-		finally { OnSimBatchComplete(); }
+		finally { _liveTracking = false; OnSimBatchComplete(); }
 	}
 
 	public void Undo()
@@ -337,15 +335,15 @@ public partial class CompetitionDetailViewModel : ObservableObject
 		if (Competition is null || finished.Round?.Stage?.Competition is null) { return; }
 		if (finished.Round.Stage.Competition.Id != Competition.Id) { return; }
 
-		// During multi-game sims the user wants the chip strip + page to FOLLOW the currently-playing
-		// round as it advances, not stay pinned on a manually-clicked round.
-		if (IsBusy)
+		// Live multi-round sims (SimulateAll) follow the playing round; SimulateRound stays put.
+		if (_liveTracking)
 		{
 			var currentRound = Competition.CurrentGame?.Round;
 			if (currentRound is not null && !ReferenceEquals(currentRound, SelectedRound))
 			{
-				SelectedStage = currentRound.Stage; // cross-stage too (group → KO transition)
-				SelectedRound = currentRound;
+				// Setting SelectedStage triggers OnSelectedStageChanged which snaps SelectedRound; avoid the double-fire.
+				if (!ReferenceEquals(currentRound.Stage, SelectedStage)) { SelectedStage = currentRound.Stage; }
+				else { SelectedRound = currentRound; }
 			}
 		}
 

--- a/src/FantasyFootball.Web/FantasyFootball.Web.csproj
+++ b/src/FantasyFootball.Web/FantasyFootball.Web.csproj
@@ -23,6 +23,10 @@
     <PackageReference Include="Blazored.LocalStorage" Version="4.5.0" />
     <PackageReference Include="MudBlazor" Version="9.4.0" />
     <PackageReference Include="PublishSPAforGitHubPages.Build" Version="3.0.3" />
+    <!-- Serilog → browser console sink. Without this, Log.Debug / Log.Information from C# only reach
+         the Debug + File sinks configured in ISettingsService.StandardLoggerConfig, neither of which
+         is visible to a developer with the browser DevTools open. -->
+    <PackageReference Include="Serilog.Sinks.BrowserConsole" Version="1.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/FantasyFootball.Web/Program.cs
+++ b/src/FantasyFootball.Web/Program.cs
@@ -7,6 +7,17 @@ using FantasyFootball.Web.Services;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
 using MudBlazor.Services;
+using Serilog;
+
+// Serilog logger for the WASM host. BrowserConsole sink so Log.Debug / Log.Information reach the
+// browser DevTools console — the standard config (ISettingsService.StandardLoggerConfig) writes to
+// the System.Diagnostics Debug stream + a temp-dir file, neither of which is reachable from a
+// browser DevTools session. Without this sink, Log calls land in the void on WASM.
+Log.Logger = new LoggerConfiguration()
+    .MinimumLevel.Debug()
+    .Enrich.FromLogContext()
+    .WriteTo.BrowserConsole()
+    .CreateLogger();
 
 var builder = WebAssemblyHostBuilder.CreateDefault(args);
 

--- a/src/FantasyFootball.Web/Program.cs
+++ b/src/FantasyFootball.Web/Program.cs
@@ -9,12 +9,15 @@ using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
 using MudBlazor.Services;
 using Serilog;
 
-// Serilog logger for the WASM host. BrowserConsole sink so Log.Debug / Log.Information reach the
-// browser DevTools console — the standard config (ISettingsService.StandardLoggerConfig) writes to
-// the System.Diagnostics Debug stream + a temp-dir file, neither of which is reachable from a
-// browser DevTools session. Without this sink, Log calls land in the void on WASM.
+// Serilog → browser DevTools console for the WASM host. Debug in dev; Warning in Release (avoids leaking diagnostics to public-deploy visitors' consoles).
 Log.Logger = new LoggerConfiguration()
-    .MinimumLevel.Debug()
+    .MinimumLevel.Is(
+#if DEBUG
+        Serilog.Events.LogEventLevel.Debug
+#else
+        Serilog.Events.LogEventLevel.Warning
+#endif
+    )
     .Enrich.FromLogContext()
     .WriteTo.BrowserConsole()
     .CreateLogger();

--- a/src/FantasyFootball.Web/wwwroot/app.css
+++ b/src/FantasyFootball.Web/wwwroot/app.css
@@ -69,6 +69,11 @@ body {
   margin-top: 4px;
 }
 
+/* Whole-row click opens the details popover (see GameViewRow.razor onclick). */
+.scoreboard-row {
+  cursor: pointer;
+}
+
 .scoreboard-row:hover {
   background: var(--mud-palette-action-hover, rgba(0, 0, 0, 0.04));
 }

--- a/src/FantasyFootball.Web/wwwroot/app.css
+++ b/src/FantasyFootball.Web/wwwroot/app.css
@@ -120,6 +120,20 @@ body {
   animation: scoreboard-pulse 1.5s ease-out;
 }
 
+/* Score reveal — pop in from 140% with the brand-green tint, scale back to 100% over 450ms.
+   Paired with .scoreboard-row-just-finished on single-game sims (and redo) so both the row pulse
+   and the score animation start in the same frame. Opacity catches up faster than scale (35%)
+   so the score reads early; scale + colour settle through the rest. */
+@keyframes scoreboard-score-reveal {
+  0%   { opacity: 0; transform: scale(1.4); color: var(--mud-palette-primary); }
+  35%  { opacity: 1; transform: scale(1.2); color: var(--mud-palette-primary); }
+  100% { opacity: 1; transform: scale(1); color: inherit; }
+}
+.scoreboard-row-just-finished .scoreboard-score {
+  animation: scoreboard-score-reveal 0.45s ease-out;
+  display: inline-block; /* required for transform to apply on inline content */
+}
+
 /* Right-side action column on a game row — Sim on the current game, Redo+Undo on the most recently simmed one. */
 .scoreboard-action {
   min-width: 5rem;

--- a/src/FantasyFootball.Web/wwwroot/app.css
+++ b/src/FantasyFootball.Web/wwwroot/app.css
@@ -83,6 +83,48 @@ body {
   padding-top: 0.25rem;
 }
 
+/* Variant B: whole-stage scroll. Each round renders as a section with a header. */
+.round-section {
+  scroll-margin-top: 1rem;
+  padding-top: 0.25rem;
+}
+
+.round-section + .round-section {
+  margin-top: 1.5rem;
+  border-top: 1px solid var(--mud-palette-action-hover, rgba(0, 0, 0, 0.08));
+  padding-top: 1rem;
+}
+
+.round-header {
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+  font-family: 'Barlow Condensed', 'Inter', sans-serif;
+  font-weight: 700;
+  font-size: 1.1rem;
+  letter-spacing: 0.5px;
+  text-transform: uppercase;
+  color: var(--mud-palette-text-secondary);
+  margin-bottom: 0.4rem;
+}
+
+.round-section-selected .round-header {
+  color: var(--mud-palette-primary);
+}
+
+.round-header-status {
+  font-size: 0.75rem;
+  font-weight: 400;
+  color: var(--mud-palette-success);
+  letter-spacing: 0;
+  text-transform: none;
+}
+
+.round-header-status-current {
+  color: var(--mud-palette-primary);
+  font-style: italic;
+}
+
 .scoreboard-row:hover {
   background: var(--mud-palette-action-hover, rgba(0, 0, 0, 0.04));
 }

--- a/src/FantasyFootball.Web/wwwroot/app.css
+++ b/src/FantasyFootball.Web/wwwroot/app.css
@@ -154,6 +154,58 @@ body {
   font-variant-numeric: tabular-nums;
 }
 
+/* Click-for-game-details popover. Anchored under the row via .scoreboard-row-wrapper (position: relative). */
+.scoreboard-row-wrapper {
+  position: relative;
+}
+
+.scoreboard-row-open {
+  background: var(--mud-palette-action-hover, rgba(0, 0, 0, 0.04));
+  box-shadow: inset 3px 0 0 var(--mud-palette-primary);
+}
+
+.game-details-popover {
+  padding: 0.75rem 1rem;
+  min-width: 18rem;
+  max-width: 22rem;
+}
+
+.game-details-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  font-size: 0.85rem;
+  padding: 0.15rem 0;
+  font-variant-numeric: tabular-nums;
+}
+
+.game-details-label {
+  color: var(--mud-palette-text-secondary);
+  font-weight: 500;
+}
+
+.game-details-value {
+  font-weight: 600;
+}
+
+.game-details-sep {
+  color: var(--mud-palette-text-secondary);
+  font-weight: 400;
+  margin: 0 0.15rem;
+}
+
+/* The percentage that matches the actual outcome (only set when Game.IsFinished). */
+.game-details-pct-actual {
+  color: var(--mud-palette-primary);
+  font-weight: 700;
+}
+
+.game-details-links {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
 /* Day-grouping divider for the games panel when a round spans multiple PlayedOn dates. */
 .game-day-divider {
   font-size: 0.75rem;

--- a/src/FantasyFootball.Web/wwwroot/app.css
+++ b/src/FantasyFootball.Web/wwwroot/app.css
@@ -74,6 +74,15 @@ body {
   cursor: pointer;
 }
 
+/* Round picker — horizontal chip strip replacing the dropdown. Wraps if the stage has many rounds (group stage = 3, KO = 4-5). */
+.round-chip-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  align-items: center;
+  padding-top: 0.25rem;
+}
+
 .scoreboard-row:hover {
   background: var(--mud-palette-action-hover, rgba(0, 0, 0, 0.04));
 }

--- a/src/FantasyFootball.Web/wwwroot/app.css
+++ b/src/FantasyFootball.Web/wwwroot/app.css
@@ -74,13 +74,90 @@ body {
   cursor: pointer;
 }
 
-/* Round picker — horizontal chip strip replacing the dropdown. Wraps if the stage has many rounds (group stage = 3, KO = 4-5). */
-.round-chip-row {
+/* Hierarchical stage→round chip pickers with a dotted-timeline backdrop. Stage row larger, round row
+   smaller + indented to suggest "rounds belong to the selected stage". The ::before dashed line on each
+   .timeline-chips evokes temporal progression. Chips need an opaque background so the line doesn't
+   show through outlined chips on dark mode (--mud-palette-surface).  */
+.timeline-pickers {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.timeline-row {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.timeline-row-round {
+  padding-left: 1.5rem; /* indent rounds under stages — hierarchical cue */
+}
+
+.timeline-label {
+  font-family: 'Barlow Condensed', 'Inter', sans-serif;
+  font-weight: 700;
+  font-size: 0.85rem;
+  letter-spacing: 0.5px;
+  text-transform: uppercase;
+  color: var(--mud-palette-text-secondary);
+  min-width: 3.5rem;
+}
+
+.timeline-chips {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.4rem;
+  gap: 0.6rem;
   align-items: center;
-  padding-top: 0.25rem;
+  position: relative;
+  flex: 1;
+}
+
+.timeline-chips::before {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 0.5rem;
+  right: 0.5rem;
+  border-top: 1px dashed var(--mud-palette-text-secondary);
+  opacity: 0.3;
+  z-index: 0;
+  pointer-events: none;
+}
+
+.timeline-chips .mud-chip {
+  position: relative;
+  z-index: 1;
+}
+
+/* Chip status — encoded redundantly via border style + opacity, not color alone.
+   chip-current: dashed border distinguishes the actively-played round from solid-bordered done/future.
+   chip-future:  dimmed to indicate "not reached yet" without changing chip shape.
+   chip-done:    no border/opacity override; default outlined+default reads as the "white" finished state.
+   All three status classes get an opaque background so the dashed timeline line doesn't pass visibly
+   through them. The filled selected chip has no status class → no override → keeps its primary green. */
+.mud-chip.chip-current,
+.mud-chip.chip-future,
+.mud-chip.chip-done {
+  /* `background` shorthand to also reset background-image; MudBlazor's outlined variant set
+     `background: transparent` which beat the property-level override. */
+  background: var(--mud-palette-background) !important;
+}
+
+/* Inter-chip sim button — sits between round chips on the timeline. Opaque backdrop so the dashed
+   timeline line doesn't pass through. */
+.round-sim-button {
+  background: var(--mud-palette-background) !important;
+  position: relative;
+  z-index: 1;
+}
+
+.mud-chip.chip-current {
+  border-style: dashed !important;
+}
+
+.mud-chip.chip-future {
+  opacity: 0.5;
 }
 
 /* Variant B: whole-stage scroll. Each round renders as a section with a header. */
@@ -93,6 +170,34 @@ body {
   margin-top: 1.5rem;
   border-top: 1px solid var(--mud-palette-action-hover, rgba(0, 0, 0, 0.08));
   padding-top: 1rem;
+}
+
+/* Setup page team list — gap-based spacing so the top (after divider) matches the bottom (before card edge). */
+.setup-team-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.setup-team-row {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+/* Single-column game flow — multi-column was visually noisy; user preferred one column. */
+.round-games-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+
+/* Bounded-height card with internal scroll. Page-level scroll is annoying when chip clicks jump
+   between rounds; per-card scroll keeps the chips + header pinned at top. The calc leaves room for
+   the app bar (~64px) + breadcrumb / title (~80px) + chip rows (~100px) + grid spacing.  */
+.bounded-scroll-card {
+  max-height: calc(100vh - 18rem);
+  overflow-y: auto;
 }
 
 .round-header {

--- a/src/FantasyFootball.Web/wwwroot/app.css
+++ b/src/FantasyFootball.Web/wwwroot/app.css
@@ -217,19 +217,6 @@ body {
   color: var(--mud-palette-primary);
 }
 
-.round-header-status {
-  font-size: 0.75rem;
-  font-weight: 400;
-  color: var(--mud-palette-success);
-  letter-spacing: 0;
-  text-transform: none;
-}
-
-.round-header-status-current {
-  color: var(--mud-palette-primary);
-  font-style: italic;
-}
-
 .scoreboard-row:hover {
   background: var(--mud-palette-action-hover, rgba(0, 0, 0, 0.04));
 }

--- a/src/FantasyFootball.Web/wwwroot/index.html
+++ b/src/FantasyFootball.Web/wwwroot/index.html
@@ -29,6 +29,7 @@
 
     <script src="_content/MudBlazor/MudBlazor.min.js"></script>
     <script src="js/keyboard.js"></script>
+    <script src="js/scroll.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/canvas-confetti@1.9.3/dist/confetti.browser.min.js"
             integrity="sha256-XAXr7WaJcRT+HM+lo4/TccjvLjuXvAS7Og3dyBT8CIE="
             crossorigin="anonymous"></script>

--- a/src/FantasyFootball.Web/wwwroot/index.html
+++ b/src/FantasyFootball.Web/wwwroot/index.html
@@ -29,7 +29,9 @@
 
     <script src="_content/MudBlazor/MudBlazor.min.js"></script>
     <script src="js/keyboard.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/canvas-confetti@1.9.3/dist/confetti.browser.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/canvas-confetti@1.9.3/dist/confetti.browser.min.js"
+            integrity="sha256-XAXr7WaJcRT+HM+lo4/TccjvLjuXvAS7Og3dyBT8CIE="
+            crossorigin="anonymous"></script>
     <script src="js/confetti.js"></script>
     <script src="_framework/blazor.webassembly#[.{fingerprint}].js"></script>
 </body>

--- a/src/FantasyFootball.Web/wwwroot/index.html
+++ b/src/FantasyFootball.Web/wwwroot/index.html
@@ -29,6 +29,8 @@
 
     <script src="_content/MudBlazor/MudBlazor.min.js"></script>
     <script src="js/keyboard.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/canvas-confetti@1.9.3/dist/confetti.browser.min.js"></script>
+    <script src="js/confetti.js"></script>
     <script src="_framework/blazor.webassembly#[.{fingerprint}].js"></script>
 </body>
 

--- a/src/FantasyFootball.Web/wwwroot/js/confetti.js
+++ b/src/FantasyFootball.Web/wwwroot/js/confetti.js
@@ -1,0 +1,22 @@
+// Thin JS interop wrapper around the canvas-confetti library loaded via CDN in index.html.
+// Called from CompetitionDetail when a competition's IsFinished flips true during the visit.
+window.ffConfetti = (() => {
+    function celebrate() {
+        if (typeof confetti !== 'function') { return; }
+        // Two volleys from the bottom corners — condensed version of the canvas-confetti "cannons" README example.
+        const burst = (originX) => confetti({
+            particleCount: 90,
+            spread: 70,
+            startVelocity: 45,
+            origin: { x: originX, y: 0.85 },
+            disableForReducedMotion: true,
+        });
+        burst(0.15);
+        burst(0.85);
+    }
+    function reset() {
+        if (typeof confetti !== 'function' || typeof confetti.reset !== 'function') { return; }
+        confetti.reset();
+    }
+    return { celebrate, reset };
+})();

--- a/src/FantasyFootball.Web/wwwroot/js/scroll.js
+++ b/src/FantasyFootball.Web/wwwroot/js/scroll.js
@@ -1,0 +1,8 @@
+// Tiny scroll helper for the variant-B whole-stage games panel.
+// Round chips invoke this to jump to a round's <section id="round-N"> anchor.
+window.ffScroll = {
+    toElement: (id) => {
+        const el = document.getElementById(id);
+        if (el) { el.scrollIntoView({ behavior: 'smooth', block: 'start' }); }
+    }
+};


### PR DESCRIPTION
## Summary

Release 0.3.0 — games panel redesign with hierarchical chip pickers + whole-stage scroll.

Brings PRs #28, #35, #36 (UI polish rounds 2 / 3.5 / 4) plus the Phase-4 GitHub Pages deploy onto `main`.

### Headline changes since 0.2

- **Games panel (PR #36):** Stage + Round chip strips on a hierarchical timeline, whole-stage scrollable rounds, jump-to-current pin, click-popover dismiss, sim-round button moves between chips. Score-reveal race fix, confetti re-fire fix, GroupView qualifier-walk cache (perf #34 headline hotspot).
- **UI polish 3 (PR #35):** Replay, confetti, score-reveal, sim-feel followups; click-for-game-details popover on scoreboard rows.
- **UI polish 2 identity (PR #28):** Flags, scoreboard, group letter, Elo, comp icons, a11y policy.
- **Phase 4 (#8):** GitHub Pages deploy via Actions on push to main — already on main, this PR brings nothing new there.
- **Infrastructure:** Serilog → BrowserConsole sink (DevTools console gets `Log.Debug`/`Log.Information`); release builds gated to Warning.

### Version

- `ApplicationDisplayVersion`: 0.2 → 0.3.0
- `ApplicationVersion`: 2 → 3

## Test plan

- [ ] CI build/test passes on `main` after merge.
- [ ] GitHub Pages deploy at `stepkie.github.io/FantasyFootball/` reflects 0.3.0.
- [ ] Tag `0.3.0` lands on the merge commit.

Merge strategy: `--merge` (preserves the 4 topical commits from PR #36 plus the version bump).