### PR TITLE
Release 0.3.1 - SPA routing hotfix

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -120,32 +120,19 @@ running build — skip features that landed in earlier rounds and are
 already signed off. If the previous run was many commits ago, summarise
 the commits being verified at the top so the user knows the scope.
 
-## PR merge hygiene
+## PR merge protocol
 
-After auto-review rounds, the branch accumulates per-round-fix commits
-("Address PR #N auto-review round K"). **Before merging back to
-`develop`, rebase those into a couple of topical commits aligned with
-the PR's logical feature chunks.** The PR discussion thread already
-records the review history; commits should record the feature work, not
-the round-by-round paper trail. This is what PRs #25, #28, #29 landed
-with.
+This project follows the **Branch Merge Protocol** in the global
+`~/.claude/CLAUDE.md` — topical commits prepared locally, then
+`gh pr merge --merge` for the GitHub merge. See that section for the
+full mechanics + rationale.
 
-Mechanics (per session constraints — no `-i` or `-p` flags):
+Project-specific notes:
 
-```bash
-git tag prNN-pre-rebase                    # safety net
-git reset --soft <feature-commit-base>     # back to last feature commit; later changes restaged
-git commit -m "<themed summary>"           # one commit per logical chunk
-git diff prNN-pre-rebase HEAD --stat       # verify empty — tree unchanged
-git push --force-with-lease
-```
-
-For cases where review fixes split across multiple feature themes,
-restage by file (and accept that the rebase may produce one "review
-fixes" commit rather than perfectly themed ones — better that than
-patch-mode staging the user can't approve).
-
-Skip the rebase only when explicitly told `merge as-is`.
+- Reference PRs that landed with this protocol: #25, #28, #29, #36.
+- Both `feature → develop` AND `develop → main` use the same protocol.
+- For `develop → main`: bump version + tag the merge commit (`X.Y.Z`)
+  after merge — see "Branching & Releases" below.
 
 ## Out of scope
 

--- a/src/FantasyFootball.Maui/FantasyFootball.Maui.csproj
+++ b/src/FantasyFootball.Maui/FantasyFootball.Maui.csproj
@@ -17,8 +17,8 @@
     <ApplicationIdGuid>79ED65DE-EAF1-41AE-B7F2-1FEB20D9A0FF</ApplicationIdGuid>
 
     <!-- Versions -->
-    <ApplicationDisplayVersion>0.3.0</ApplicationDisplayVersion>
-    <ApplicationVersion>3</ApplicationVersion>
+    <ApplicationDisplayVersion>0.3.1</ApplicationDisplayVersion>
+    <ApplicationVersion>4</ApplicationVersion>
     <!-- Fix for MAUI issue https://github.com/dotnet/maui/issues/12636 -->
     <Version>$(ApplicationDisplayVersion)</Version>
 

--- a/src/FantasyFootball.UI/Layout/MainLayout.razor
+++ b/src/FantasyFootball.UI/Layout/MainLayout.razor
@@ -19,7 +19,7 @@
     <MudSpacer />
     <MudIconButton Icon="@Icons.Material.Filled.HelpOutline"
                    Color="Color.Inherit"
-                   Href="/about"
+                   Href="about"
                    title="About / keyboard shortcuts" />
     <MudIconButton Icon="@(_isDarkMode ? Icons.Material.Filled.LightMode : Icons.Material.Filled.DarkMode)"
                    Color="Color.Inherit"

--- a/src/FantasyFootball.UI/Pages/CompetitionDetail.razor
+++ b/src/FantasyFootball.UI/Pages/CompetitionDetail.razor
@@ -10,7 +10,7 @@
 
 <PageTitle>@(ViewModel.Competition?.ShortName ?? "Competition") — Fantasy Football</PageTitle>
 
-<MudButton Href="/competitions"
+<MudButton Href="competitions"
            StartIcon="@Icons.Material.Filled.ArrowBack"
            Variant="Variant.Text"
            Class="mb-3">
@@ -20,7 +20,7 @@
 @if (ViewModel.Competition is null)
 {
   <MudAlert Severity="Severity.Warning">
-    Competition not found. <MudLink Href="/competitions">Return to the competitions list.</MudLink>
+    Competition not found. <MudLink Href="competitions">Return to the competitions list.</MudLink>
   </MudAlert>
 }
 else
@@ -306,7 +306,7 @@ else
     try { await JS.InvokeVoidAsync("ffConfetti.reset"); }
     catch (JSDisconnectedException) { /* page disposing */ }
     var replay = await ViewModel.Replay();
-    Nav.NavigateTo($"/competitions/{replay.Id}");
+    Nav.NavigateTo($"competitions/{replay.Id}");
   }
 
   protected override void OnInitialized() => ViewModel.PropertyChanged += OnVmChanged;
@@ -417,7 +417,7 @@ else
       case "ArrowRight": StepRound(+1); break;
       case "ArrowUp": StepStage(-1); break;
       case "ArrowDown": StepStage(+1); break;
-      case "Escape": Nav.NavigateTo("/competitions"); break;
+      case "Escape": Nav.NavigateTo("competitions"); break;
     }
   }
 

--- a/src/FantasyFootball.UI/Pages/CompetitionSetup.razor
+++ b/src/FantasyFootball.UI/Pages/CompetitionSetup.razor
@@ -8,7 +8,7 @@
 
 <PageTitle>New competition — Fantasy Football</PageTitle>
 
-<MudButton Href="/competitions"
+<MudButton Href="competitions"
            StartIcon="@Icons.Material.Filled.ArrowBack"
            Variant="Variant.Text"
            Class="mb-3">
@@ -110,7 +110,7 @@
   void StartSim()
   {
     var competition = ViewModel.Create();
-    Nav.NavigateTo($"/competitions/{competition.Id}");
+    Nav.NavigateTo($"competitions/{competition.Id}");
   }
 
   public void Dispose() => ViewModel.PropertyChanged -= OnVmChanged;

--- a/src/FantasyFootball.UI/Pages/Competitions.razor
+++ b/src/FantasyFootball.UI/Pages/Competitions.razor
@@ -181,10 +181,10 @@
   void OnRowClick(TableRowClickEventArgs<Competition> args)
   {
     if (args.Item is null) { return; }
-    Nav.NavigateTo($"/competitions/{args.Item.Id}");
+    Nav.NavigateTo($"competitions/{args.Item.Id}");
   }
 
-  void StartNew() => Nav.NavigateTo("/competitions/setup");
+  void StartNew() => Nav.NavigateTo("competitions/setup");
 
   async Task ConfirmDelete(Competition competition)
   {

--- a/src/FantasyFootball.UI/Pages/TeamDetail.razor
+++ b/src/FantasyFootball.UI/Pages/TeamDetail.razor
@@ -7,7 +7,7 @@
 
 <PageTitle>@(ViewModel.Team?.Name ?? "Team") — Fantasy Football</PageTitle>
 
-<MudButton Href="/teams"
+<MudButton Href="teams"
            StartIcon="@Icons.Material.Filled.ArrowBack"
            Variant="Variant.Text"
            Class="mb-3">
@@ -17,7 +17,7 @@
 @if (ViewModel.Team is null)
 {
   <MudAlert Severity="Severity.Warning">
-    Team not found. <MudLink Href="/teams">Return to the teams list.</MudLink>
+    Team not found. <MudLink Href="teams">Return to the teams list.</MudLink>
   </MudAlert>
 }
 else

--- a/src/FantasyFootball.UI/Pages/Teams.razor
+++ b/src/FantasyFootball.UI/Pages/Teams.razor
@@ -55,7 +55,7 @@
   void OnRowClick(TableRowClickEventArgs<TeamListItem> args)
   {
     // /teams/{id} lands with the TeamDetail page port (#7). 404 expected for now.
-    Nav.NavigateTo($"/teams/{args.Item!.Team.Id}");
+    Nav.NavigateTo($"teams/{args.Item!.Team.Id}");
   }
 
   public void Dispose() => ViewModel.PropertyChanged -= OnViewModelChanged;


### PR DESCRIPTION
## Summary

Hotfix release. The 0.3.0 deploy at stepkie.github.io/FantasyFootball/
was broken on internal navigation: clicking links / buttons that used
root-relative paths sent the browser to `stepkie.github.io/<path>`
(missing the `/FantasyFootball/` prefix) and hit GitHub's own 404.

### Fix

Drop the leading slash from all 12 in-app navigation sites — these
should always be base-href-relative, not root-relative. Local dev was
unaffected because base href is `/` there.

### Version

- `ApplicationDisplayVersion`: 0.3.0 → 0.3.1
- `ApplicationVersion`: 3 → 4

## Test plan

- [ ] Deploy lands on stepkie.github.io/FantasyFootball/
- [ ] "New competition" navigates to stepkie.github.io/FantasyFootball/competitions/setup (not the root domain)
- [ ] Back-to-competitions buttons (CompetitionDetail, CompetitionSetup, TeamDetail) stay under /FantasyFootball/
- [ ] About icon in MainLayout opens /FantasyFootball/about
- [ ] Tag 0.3.1 lands on the merge commit.

Merge strategy: `--merge`.