### PR TITLE
Post-0.3.1 follow-ups: deferred review fixes + standings guard + code-hygiene cleanup

### DIFF
--- a/src/FantasyFootball.Core/Data/CompetitionSimulator.cs
+++ b/src/FantasyFootball.Core/Data/CompetitionSimulator.cs
@@ -76,8 +76,8 @@ public class CompetitionSimulator(Competition competition, IRepository repo, int
 		foreach (var game in ordered)
 		{
 			if (game.IsFinished) { continue; }
-			// Skip rather than break: a placeholder-team KO game (issue #12 territory) shouldn't sim,
-			// but it also shouldn't block later games in the same round from running.
+			// Skip rather than break: a placeholder-team KO game (unresolved qualifier)
+			// shouldn't sim, but also shouldn't block later games in the same round.
 			if (!game.IsReadyToStart)
 			{
 				Log.Warning($"Round {round.Name}: game {game} is not ready; skipping.");

--- a/src/FantasyFootball.Core/Data/Formats/ExpandedWorldCupFormat.cs
+++ b/src/FantasyFootball.Core/Data/Formats/ExpandedWorldCupFormat.cs
@@ -39,7 +39,7 @@ public sealed class ExpandedWorldCupFormat : ITournamentFormat
 			.Take(AdvancingThirdPlaceCount)
 			.ToList();
 
-		// Backtracking over the 8×8 slot/team bipartite graph — greedy could lock out feasible assignments (issue #12). Not the FIFA-canonical 495-scenario map; any feasible draw will do.
+		// Backtracking over the 8×8 slot/team bipartite graph — greedy could lock out feasible assignments. Not the FIFA-canonical 495-scenario map; any feasible draw will do.
 		var assignments = new Team?[_slots.Length];
 		var usedLetters = new HashSet<string>();
 		if (!TryAssign(0))

--- a/src/FantasyFootball.Core/Models/GroupQualifier.cs
+++ b/src/FantasyFootball.Core/Models/GroupQualifier.cs
@@ -33,10 +33,10 @@ public class GroupQualifier : Qualifier
 			_ => null,
 		};
 
-		// The greedy 3rd-place allocation in ExpandedWorldCupFormat can occasionally
-		// fail to fit every slot (issue #12 — the real fix is FIFA's 495-scenario
-		// lookup table). Falling back to null lets the UI show a placeholder
-		// instead of crashing the render or breaking JSON persistence.
+		// The 3rd-place allocation in ExpandedWorldCupFormat can occasionally fail
+		// to fit every slot — the real fix is FIFA's 495-scenario lookup table.
+		// Falling back to null lets the UI show a placeholder instead of crashing
+		// the render or breaking JSON persistence.
 		static Team? TryResolveThirdPlace(Stage stage, string combination)
 		{
 			try { return TournamentFormatRegistry.ForGroupCount(stage.Groups.Count).ResolveThirdPlaceQualifier(stage, combination); }

--- a/src/FantasyFootball.Core/Services/HeadToHeadLookup.cs
+++ b/src/FantasyFootball.Core/Services/HeadToHeadLookup.cs
@@ -25,7 +25,6 @@ public static class HeadToHeadLookup
 		var draws = 0;
 
 		// Stream the games per competition: no date sort, no per-call list allocation.
-		// GamesByDate would re-do SelectMany + OrderBy + ToList per competition each call.
 		foreach (var comp in repo.GetAll<Competition>())
 		{
 			foreach (var stage in comp.Stages)

--- a/src/FantasyFootball.Core/Services/HeadToHeadLookup.cs
+++ b/src/FantasyFootball.Core/Services/HeadToHeadLookup.cs
@@ -24,9 +24,13 @@ public static class HeadToHeadLookup
 		var bWins = 0;
 		var draws = 0;
 
+		// Stream the games per competition: no date sort, no per-call list allocation.
+		// GamesByDate would re-do SelectMany + OrderBy + ToList per competition each call.
 		foreach (var comp in repo.GetAll<Competition>())
 		{
-			foreach (var game in comp.GamesByDate)
+			foreach (var stage in comp.Stages)
+			foreach (var round in stage.Rounds)
+			foreach (var game in round.AllGames)
 			{
 				if (!game.IsFinished) { continue; }
 

--- a/src/FantasyFootball.Tests/BaseTest.cs
+++ b/src/FantasyFootball.Tests/BaseTest.cs
@@ -15,7 +15,7 @@ public class BaseTest
 	{
 		Output = output;
 		// Connect global logger
-		Log.Logger = ISettingsService.StandardLoggerConfig.WriteTo.XUnit3TestOutput().CreateLogger();
+		Log.Logger = ISettingsService.StandardLoggerConfig.MinimumLevel.Is(level).WriteTo.XUnit3TestOutput().CreateLogger();
 		Repo = new Repository(inMemory: true);
 		DataService = new CsvDataService(Repo, new CultureInfo("de"));
 	}

--- a/src/FantasyFootball.Tests/StandingsSortInvariantTests.cs
+++ b/src/FantasyFootball.Tests/StandingsSortInvariantTests.cs
@@ -69,8 +69,9 @@ public class StandingsSortInvariantTests(ITestOutputHelper output) : BaseTest(ou
 			await simulator.SimulateStage(competition.Stages[0]);
 			Repo.Save(competition);
 
-			var reloaded = Repo.Get<Competition>(competition.Id)!;
-			foreach (var group in reloaded.Groups)
+			var reloaded = Repo.Get<Competition>(competition.Id);
+			reloaded.Should().NotBeNull("competition must be retrievable after Save");
+			foreach (var group in reloaded!.Groups)
 			{
 				var standings = group.GetStandings();
 				for (int j = 0; j < standings.Count - 1; j++)

--- a/src/FantasyFootball.Tests/StandingsSortInvariantTests.cs
+++ b/src/FantasyFootball.Tests/StandingsSortInvariantTests.cs
@@ -1,0 +1,94 @@
+namespace FantasyFootball.Tests;
+
+/// <summary>
+/// Simulates the group stage many times across WC32 / WC48 / EM24 and asserts every
+/// group's standings are non-increasing on Points → GoalDifference → GoalsFor.
+/// H2H tie-break is a follow-up; this test only pins the strict-prefix invariant.
+/// </summary>
+public class StandingsSortInvariantTests(ITestOutputHelper output) : BaseTest(output, level: LogEventLevel.Warning)
+{
+	[InlineData(CompetitionType.WM, 2022)] // WC32
+	[InlineData(CompetitionType.WM, 2026)] // WC48
+	[InlineData(CompetitionType.EM, 2024)] // EM24
+	[Theory]
+	public async Task GroupStandings_AreOrderedCorrectly(CompetitionType type, int year)
+	{
+		const int iterations = 20;
+		var violations = new List<string>();
+
+		for (int i = 0; i < iterations; i++)
+		{
+			var competition = InitCompetition(type, year);
+			var simulator = new CompetitionSimulator(competition, Repo);
+			await simulator.SimulateStage(competition.Stages[0]);
+
+			foreach (var group in competition.Groups)
+			{
+				var standings = group.GetStandings();
+				for (int j = 0; j < standings.Count - 1; j++)
+				{
+					var a = standings[j];
+					var b = standings[j + 1];
+					if (a.Points < b.Points)
+					{
+						violations.Add($"[iter {i}] {type} {year} {group.Name}: pos {j + 1} {a.Team.ShortName}(P={a.Points}) above pos {j + 2} {b.Team.ShortName}(P={b.Points})");
+					}
+					else if (a.Points == b.Points && a.GoalDifference < b.GoalDifference)
+					{
+						violations.Add($"[iter {i}] {type} {year} {group.Name}: pos {j + 1} {a.Team.ShortName}(P={a.Points},GD={a.GoalDifference}) above pos {j + 2} {b.Team.ShortName}(P={b.Points},GD={b.GoalDifference})");
+					}
+					else if (a.Points == b.Points && a.GoalDifference == b.GoalDifference && a.GoalsFor < b.GoalsFor)
+					{
+						violations.Add($"[iter {i}] {type} {year} {group.Name}: pos {j + 1} {a.Team.ShortName}(P={a.Points},GD={a.GoalDifference},GF={a.GoalsFor}) above pos {j + 2} {b.Team.ShortName}(P={b.Points},GD={b.GoalDifference},GF={b.GoalsFor})");
+					}
+				}
+			}
+
+			Repo.Delete(competition);
+		}
+
+		violations.Should().BeEmpty($"all groups must sort by Pts DESC → GD DESC → GF DESC\n  - {string.Join("\n  - ", violations)}");
+	}
+
+	/// <summary>
+	/// Storage round-trip variant: serialize → deserialize → re-check sort.
+	/// If the bug is in stored-game reconstruction (Team references not rewired)
+	/// rather than the live sim, this catches it.
+	/// </summary>
+	[InlineData(CompetitionType.WM, 2026)]
+	[Theory]
+	public async Task GroupStandings_AreOrderedCorrectly_AfterStorageRoundTrip(CompetitionType type, int year)
+	{
+		const int iterations = 20;
+		var violations = new List<string>();
+
+		for (int i = 0; i < iterations; i++)
+		{
+			var competition = InitCompetition(type, year);
+			var simulator = new CompetitionSimulator(competition, Repo);
+			await simulator.SimulateStage(competition.Stages[0]);
+			Repo.Save(competition);
+
+			var reloaded = Repo.Get<Competition>(competition.Id)!;
+			foreach (var group in reloaded.Groups)
+			{
+				var standings = group.GetStandings();
+				for (int j = 0; j < standings.Count - 1; j++)
+				{
+					var a = standings[j];
+					var b = standings[j + 1];
+					if (a.Points < b.Points
+						|| (a.Points == b.Points && a.GoalDifference < b.GoalDifference)
+						|| (a.Points == b.Points && a.GoalDifference == b.GoalDifference && a.GoalsFor < b.GoalsFor))
+					{
+						violations.Add($"[iter {i}] {type} {year} {group.Name} (post-roundtrip): {a.Team.ShortName}(P={a.Points},GD={a.GoalDifference},GF={a.GoalsFor}) above {b.Team.ShortName}(P={b.Points},GD={b.GoalDifference},GF={b.GoalsFor})");
+					}
+				}
+			}
+
+			Repo.Delete(reloaded);
+		}
+
+		violations.Should().BeEmpty($"sort invariant must survive storage round-trip\n  - {string.Join("\n  - ", violations)}");
+	}
+}

--- a/src/FantasyFootball.Tests/StandingsSortInvariantTests.cs
+++ b/src/FantasyFootball.Tests/StandingsSortInvariantTests.cs
@@ -77,11 +77,17 @@ public class StandingsSortInvariantTests(ITestOutputHelper output) : BaseTest(ou
 				{
 					var a = standings[j];
 					var b = standings[j + 1];
-					if (a.Points < b.Points
-						|| (a.Points == b.Points && a.GoalDifference < b.GoalDifference)
-						|| (a.Points == b.Points && a.GoalDifference == b.GoalDifference && a.GoalsFor < b.GoalsFor))
+					if (a.Points < b.Points)
 					{
-						violations.Add($"[iter {i}] {type} {year} {group.Name} (post-roundtrip): {a.Team.ShortName}(P={a.Points},GD={a.GoalDifference},GF={a.GoalsFor}) above {b.Team.ShortName}(P={b.Points},GD={b.GoalDifference},GF={b.GoalsFor})");
+						violations.Add($"[iter {i}] {type} {year} {group.Name} (post-roundtrip): pos {j + 1} {a.Team.ShortName}(P={a.Points}) above pos {j + 2} {b.Team.ShortName}(P={b.Points})");
+					}
+					else if (a.Points == b.Points && a.GoalDifference < b.GoalDifference)
+					{
+						violations.Add($"[iter {i}] {type} {year} {group.Name} (post-roundtrip): pos {j + 1} {a.Team.ShortName}(P={a.Points},GD={a.GoalDifference}) above pos {j + 2} {b.Team.ShortName}(P={b.Points},GD={b.GoalDifference})");
+					}
+					else if (a.Points == b.Points && a.GoalDifference == b.GoalDifference && a.GoalsFor < b.GoalsFor)
+					{
+						violations.Add($"[iter {i}] {type} {year} {group.Name} (post-roundtrip): pos {j + 1} {a.Team.ShortName}(P={a.Points},GD={a.GoalDifference},GF={a.GoalsFor}) above pos {j + 2} {b.Team.ShortName}(P={b.Points},GD={b.GoalDifference},GF={b.GoalsFor})");
 					}
 				}
 			}

--- a/src/FantasyFootball.UI/Components/GroupView.razor
+++ b/src/FantasyFootball.UI/Components/GroupView.razor
@@ -44,7 +44,7 @@
   bool _thirdPlaceEligible;
   bool? _thirdPlaceAdvanced; // null = stage not finished yet (undetermined), true/false = resolved.
 
-  // Qualifier-walk cache (issue #34): inputs are invariant per Group; only recompute on Group change or Stage.IsFinished transition.
+  // Qualifier-walk cache: inputs are invariant per Group; only recompute on Group change or Stage.IsFinished transition.
   Group? _walkedGroup;
   bool? _walkedStageFinished;
   List<GroupQualifier>? _walkedLaterQualifiers;

--- a/src/FantasyFootball.UI/Pages/CompetitionDetail.razor
+++ b/src/FantasyFootball.UI/Pages/CompetitionDetail.razor
@@ -161,7 +161,8 @@ else
                     }
                     @foreach (var game in dayGroup)
                     {
-                      <GameViewRow Game="game"
+                      <GameViewRow @key="@game"
+                                   Game="game"
                                    ShowSim="@(ReferenceEquals(game, currentGame))"
                                    ShowUndo="@(ReferenceEquals(game, undoTargetGame))"
                                    IsJustFinished="@(ReferenceEquals(game, ViewModel.RecentlyFinishedGame))"

--- a/src/FantasyFootball.UI/Pages/Competitions.razor
+++ b/src/FantasyFootball.UI/Pages/Competitions.razor
@@ -168,7 +168,7 @@
 
   // Hardcoded English. ExtensionMethods.Name() goes through Res.WorldCup / Res.European_Championship,
   // which picks the de-DE satellite assembly on browsers where Blazor's culture resolution lands on de.
-  // Wire localization properly via the deferred i18n follow-up (Settings PR #17 TODO).
+  // Localization needs proper wiring via the i18n follow-up.
   static string DisplayName(CompetitionType t) => t switch
   {
     CompetitionType.WM => "World Cup",

--- a/src/FantasyFootball.UI/ViewModels/CompetitionDetailViewModel.cs
+++ b/src/FantasyFootball.UI/ViewModels/CompetitionDetailViewModel.cs
@@ -299,8 +299,8 @@ public partial class CompetitionDetailViewModel : ObservableObject
 	/// <summary>
 	/// Clones the current competition's team lineup into a fresh competition with the same Type + Year
 	/// and saves it. Returns the new Id so the page can navigate to it. Uses today's Elo on each Team
-	/// instance, not a snapshot from the finished comp — issue #19 will tighten this once the per-comp
-	/// Elo snapshot lands. Group.ShallowClone strips Stage / Games / Id; the factory wires everything else fresh.
+	/// instance, not a snapshot from the finished comp — per-competition Elo snapshotting is a follow-up.
+	/// Group.ShallowClone strips Stage / Games / Id; the factory wires everything else fresh.
 	/// Async so the IsBusy spinner can flush to the DOM before the synchronous LocalStorage save blocks;
 	/// IsBusy is left true on return — Load() on the new comp's mount resets it.
 	/// </summary>


### PR DESCRIPTION
Three loosely-related chunks landed as separate commits, ready for review.

## 1. \`aef87be\` chore: scrub PR/issue number references from source

New global CLAUDE.md rule: nothing in source (comments, test names, assertion
messages, etc.) should reference GitHub PRs or issues by number. Ticket numbers
belong in commit messages and PR descriptions where they're rooted, not in code
where they rot.

Existing six references cleared.

## 2. \`2f37b99\` test: standings sort invariant regression guard

Tracks the group-standings ordering bug. Test simulates the group stage 20×
across WC32 / WC48 / EM24 and asserts non-increasing on Pts → GD → GF. Storage
round-trip variant included.

**Bug did not reproduce** in any of the randomized runs. Sort logic in
\`Standings.CreateFrom\` + \`TeamRecord\` is correct in isolation. If the original
observation was real, the cause is in the render layer (GroupView caching /
stale snapshot rebind), not the sort itself. Test stays as a regression guard.

## 3. \`1c86a53\` fix: address deferred review on the develop→main release PR

Two findings from the auto-review on the 0.3.0 release PR that should have
landed on the original feature PR — incremental per-push reviews missed the
whole-PR-shape concerns.

- **\`@key=\"@game\"\` on the \`GameViewRow\` loop.** Correctness: \`GameViewRow\`
  now carries \`_prevDetailsOpen\` + \`_h2h\` component state keyed to a Game
  reference. Without \`@key\`, positional reconciliation would attach wrong state
  if the list ever reorders.
- **Non-allocating walk in \`HeadToHeadLookup.Across\`.** Replaced
  \`comp.GamesByDate\` (SelectMany + OrderBy + ToList per access) with a
  streaming nested-foreach over Stages → Rounds → AllGames. H2H doesn't need
  date order; the sort + materialization was wasted work and GC pressure that
  scaled linearly with stored competition count.

## Test plan

- [x] \`dotnet build\` clean
- [x] \`StandingsSortInvariantTests\` pass (4/4, ~15 min)
- [x] \`HeadToHeadLookupTests\` still pass after the rewrite
- [ ] Smoke-test the H2H popover on the running app — verify it still shows
  the expected counts after the walk refactor.