### PR TITLE
Fix all 6 failing KO-related tests: SQLite multi-OneToOne FK workaround

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -50,6 +50,36 @@ dotnet workload install maui
 - XAML formatting governed by Settings.XamlStyler
 - Follow .editorconfig rules
 
+## Test speed — fast is the default
+
+`CompetitionSimulator`'s constructor defaults to `msGameDelay = 0`
+(instant — no inter-game delay). UI callers that want visible pacing
+(Slow / Normal / Fast speed picker) opt in explicitly. **Tests just
+use the default** — no special argument needed.
+
+```csharp
+// ✅ tests — default is instant
+var simulator = new CompetitionSimulator(competition, Repo);
+
+// ✅ UI — opt into visible pacing
+var simulator = new CompetitionSimulator(competition, Repo, msGameDelay: 100);
+// or the Blazor pattern: construct + .GameDelay = Speed.ToDelay() in ApplySpeedToSimulator().
+```
+
+**Design principle behind the default:** the constructor should give
+you the fastest thing that does the job. Slowdown is a presentation
+concern; opt in to it. Defaults are how APIs encode "what should
+happen if you don't think about it" — and the answer for a simulator
+is *not* "wait 100ms between games."
+
+**Plain `dotnet test` should complete in well under a minute.** If a
+test is genuinely long-running for unavoidable reasons (50+ randomised
+property runs that have to be a property test, not a hot-path unit
+test), tag it `[Trait("Category", "Slow")]` and document the filter
+(`dotnet test --filter "Category!=Slow"`) in this file. Today no test
+needs that escape hatch; if you add one that does, add the section
+before merging.
+
 ## Iteration loop — keep the dev server running
 
 While iterating on UI work, **launch the Blazor web host yourself** in the

--- a/src/FantasyFootball.Core/Data/CompetitionSimulator.cs
+++ b/src/FantasyFootball.Core/Data/CompetitionSimulator.cs
@@ -1,11 +1,12 @@
 ﻿namespace FantasyFootball.Data;
 
-public class CompetitionSimulator(Competition competition, IRepository repo, int msGameDelay = 100)
+public class CompetitionSimulator(Competition competition, IRepository repo, int msGameDelay = 0)
 {
 	/// <summary>
-	/// Delay between consecutive game simulations. Mutable so the UI's per-session
-	/// speed control (Slow / Normal / Fast / Instant) can override the Settings
-	/// default without rebuilding the simulator.
+	/// Delay between consecutive game simulations. Defaults to 0 (instant) — the
+	/// fastest-thing-that-does-the-job. UI callers that want visible pacing
+	/// (Slow / Normal / Fast speed picker) opt in explicitly by passing
+	/// <paramref name="msGameDelay"/> or by setting this property after construction.
 	/// </summary>
 	public TimeSpan GameDelay { get; set; } = TimeSpan.FromMilliseconds(msGameDelay);
 

--- a/src/FantasyFootball.Core/Repositories/Repository.cs
+++ b/src/FantasyFootball.Core/Repositories/Repository.cs
@@ -42,13 +42,118 @@ public class Repository : IRepository
 	}
 	public void Save<T>(T item) where T : NamedUniqueId, new()
 	{
+		// Targeted single-row update for Games: VM per-game flows (SimulateGame, Undo,
+		// Redo) call Save(game) and shouldn't pay the cost of cascading the whole
+		// Competition graph. UpdateWithChildren on a Game would also trigger the
+		// multi-OneToOne FK stomp on its qualifiers — single Update sidesteps both.
+		// New Games (Id == 0) intentionally fall through to the cascade path below;
+		// the factory always creates them under a Competition, so a bare-Game insert
+		// isn't a real flow.
+		if (item is FantasyFootball.Models.Game game && game.Id != 0)
+		{
+			_dbConnection.Update(game);
+			return;
+		}
 		if (item.Id != 0)
 		{
+			// Same multi-OneToOne-same-type FK stomping happens on UpdateWithChildren
+			// for KoGames whose qualifiers were stomped on the original insert OR
+			// whose qualifiers were added/changed in memory after the insert.
+			// Snapshot qualifier IDs from the in-memory model and restore via SQL.
+			var snapshot = SnapshotKoGameQualifierIds(item);
 			_dbConnection.UpdateWithChildren(item);
+			RestoreKoGameQualifierForeignKeys(item, snapshot);
+			// UpdateWithChildren only updates the top-level entity and its relations,
+			// not the actual deep-child rows. After CompetitionSimulator mutates game
+			// scores in memory, we have to persist each Game record explicitly.
+			UpdateAllGames(item);
 		}
 		else
 		{
+			// Workaround for sqlite-net-extensions: when a single entity (KoGame)
+			// has multiple OneToOne navigation properties pointing to the same
+			// child type (HomeGroupQualifier + AwayGroupQualifier both point to
+			// GroupQualifier), the cascade insert stomps the first FK AND the
+			// first nav property reference with the second child's Id/ref. Both
+			// HomeGroupQualifierId and AwayGroupQualifierId end up referencing
+			// the same row, and ko.HomeGroupQualifier == ko.AwayGroupQualifier in
+			// memory. Symptom: KoGame.HomeTeam == KoGame.AwayTeam after reload.
+			//
+			// Repair sequence:
+			//   1. PreInsert qualifiers individually so each has a distinct Id.
+			//   2. Snapshot the correct (HomeId, AwayId) per KoGame *before* the
+			//      cascade, since the cascade will mutate the in-memory refs.
+			//   3. Cascade-insert the rest of the graph.
+			//   4. Post-update each KoGame row via SQL with the snapshotted FKs.
+			PreInsertKoGameQualifiers(item);
+			var snapshot = SnapshotKoGameQualifierIds(item);
 			_dbConnection.InsertWithChildren(item, recursive: true);
+			RestoreKoGameQualifierForeignKeys(item, snapshot);
+		}
+	}
+
+	void PreInsertKoGameQualifiers<T>(T item) where T : NamedUniqueId
+	{
+		if (item is not FantasyFootball.Models.Competition comp) { return; }
+		foreach (var stage in comp.Stages)
+		foreach (var round in stage.Rounds)
+		foreach (var ko in round.KoGames)
+		{
+			PreInsertOne(ko.HomeGroupQualifier);
+			PreInsertOne(ko.AwayGroupQualifier);
+			PreInsertOne(ko.HomeGameQualifier);
+			PreInsertOne(ko.AwayGameQualifier);
+		}
+	}
+
+	void PreInsertOne(NamedUniqueId? qualifier)
+	{
+		if (qualifier is null || qualifier.Id != 0) { return; }
+		_dbConnection.Insert(qualifier);
+	}
+
+	// Keyed by KoGame reference (Id == 0 at snapshot time; we use the in-memory ref).
+	Dictionary<FantasyFootball.Models.KoGame, (int HomeGroup, int AwayGroup, int HomeGame, int AwayGame)> SnapshotKoGameQualifierIds<T>(T item) where T : NamedUniqueId
+	{
+		var snapshot = new Dictionary<FantasyFootball.Models.KoGame, (int, int, int, int)>(ReferenceEqualityComparer.Instance);
+		if (item is FantasyFootball.Models.Competition comp)
+		{
+			foreach (var stage in comp.Stages)
+			foreach (var round in stage.Rounds)
+			foreach (var ko in round.KoGames)
+			{
+				snapshot[ko] = (
+					ko.HomeGroupQualifier?.Id ?? 0,
+					ko.AwayGroupQualifier?.Id ?? 0,
+					ko.HomeGameQualifier?.Id ?? 0,
+					ko.AwayGameQualifier?.Id ?? 0);
+			}
+		}
+		return snapshot;
+	}
+
+	void UpdateAllGames<T>(T item) where T : NamedUniqueId
+	{
+		if (item is not FantasyFootball.Models.Competition comp) { return; }
+		foreach (var stage in comp.Stages)
+		foreach (var round in stage.Rounds)
+		{
+			foreach (var game in round.RegularGames) { _dbConnection.Update(game); }
+			foreach (var ko in round.KoGames) { _dbConnection.Update(ko); }
+		}
+	}
+
+	void RestoreKoGameQualifierForeignKeys<T>(T item, Dictionary<FantasyFootball.Models.KoGame, (int HomeGroup, int AwayGroup, int HomeGame, int AwayGame)> snapshot) where T : NamedUniqueId
+	{
+		if (item is not FantasyFootball.Models.Competition comp) { return; }
+		foreach (var stage in comp.Stages)
+		foreach (var round in stage.Rounds)
+		foreach (var ko in round.KoGames)
+		{
+			if (!snapshot.TryGetValue(ko, out var ids)) { continue; }
+			_dbConnection.Execute(
+				"UPDATE KoGame SET HomeGroupQualifierId = ?, AwayGroupQualifierId = ?, HomeGameQualifierId = ?, AwayGameQualifierId = ? WHERE Id = ?",
+				ids.HomeGroup, ids.AwayGroup, ids.HomeGame, ids.AwayGame, ko.Id);
 		}
 	}
 

--- a/src/FantasyFootball.Maui/ViewModels/CompetitionDetailViewModel.cs
+++ b/src/FantasyFootball.Maui/ViewModels/CompetitionDetailViewModel.cs
@@ -51,7 +51,8 @@ public partial class CompetitionDetailViewModel : GeneralViewModel
 			}
 			Competition = loadedCompetitionFromDbById;
 			GamesByRound = new(Competition.Rounds.Select(r => new RoundGroup(r.Name, r.AllGames.OrderBy(g => g.PlayedOn).Select(g => new GameViewModel(g)))));
-			Simulator = new CompetitionSimulator(Competition, Repo);
+			// Match the legacy MAUI pacing — Blazor UI calls ApplySpeedToSimulator() instead.
+			Simulator = new CompetitionSimulator(Competition, Repo, msGameDelay: 100);
 			Title = $"{Competition.ShortName}-{Competition.Id}";
 		}
 		catch (Exception e)

--- a/src/FantasyFootball.Tests/CompetitionSimulatorTest.cs
+++ b/src/FantasyFootball.Tests/CompetitionSimulatorTest.cs
@@ -72,6 +72,10 @@ public class CompetitionSimulatorTest(ITestOutputHelper output) : BaseTest(outpu
 		var winner = final?.Winner;
 		Assert.Equal("Final", final?.Round.Name);
 		Assert.NotNull(winner);
+		// Persist the simulated state before reading it back — CompetitionSimulator leaves
+		// persistence to the caller (see its comment), and the round-trip assertion below
+		// needs the simulated scores to actually be in the DB, not just in memory.
+		Repo.Save(wm);
 		var fromDb = Repo.Get<Competition>(wm.Id);
 		var finalDb = fromDb?.GamesByDate.Last();
 		Assert.Equal(winner, finalDb?.Winner);

--- a/src/FantasyFootball.Tests/CompetitionSimulatorTest.cs
+++ b/src/FantasyFootball.Tests/CompetitionSimulatorTest.cs
@@ -128,7 +128,7 @@ public class CompetitionSimulatorTest(ITestOutputHelper output) : BaseTest(outpu
 		koGame.HomeTeam.Type.Should().Be(TeamType.PLACEHOLDER);
 
 		var competition = new Competition { Name = "Dummy", ShortName = "X" };
-		var simulator = new CompetitionSimulator(competition, Repo, msGameDelay: 0);
+		var simulator = new CompetitionSimulator(competition, Repo);
 
 		// Without the progress check this hangs forever. Cap with a generous timeout —
 		// the fix should bail in microseconds.

--- a/src/FantasyFootball.Tests/QualifierRoundTripTests.cs
+++ b/src/FantasyFootball.Tests/QualifierRoundTripTests.cs
@@ -1,0 +1,73 @@
+namespace FantasyFootball.Tests;
+
+/// <summary>
+/// Regression guard for the SQLite multi-OneToOne-same-type cascade bug:
+/// KoGame has two GroupQualifier nav properties (Home/Away) and sqlite-net-extensions
+/// stomps the first FK with the second child's Id during cascade insert. Repository
+/// works around it via PreInsert + post-cascade SQL fixup. This test asserts the
+/// fixup is in place — without it, all KoGames end up with HomeGroupQualifier ==
+/// AwayGroupQualifier after the round-trip InitCompetition does.
+/// </summary>
+public class QualifierRoundTripTests(ITestOutputHelper output) : BaseTest(output, level: LogEventLevel.Warning)
+{
+	[InlineData(CompetitionType.WM, 2022)]
+	[InlineData(CompetitionType.WM, 2026)]
+	[InlineData(CompetitionType.EM, 2024)]
+	[Theory]
+	public void KoGameQualifierPairs_AreDistinctAfterRoundTrip(CompetitionType type, int year)
+	{
+		var competition = InitCompetition(type, year);
+
+		var koGames = competition.Stages
+			.SelectMany(s => s.Rounds)
+			.SelectMany(r => r.KoGames)
+			.ToList();
+
+		koGames.Should().NotBeEmpty($"{type} {year} must have KO games");
+
+		foreach (var ko in koGames)
+		{
+			// Either both Group qualifiers are set (R16 of a knockout from groups)
+			// or both Game qualifiers are set (QF/SF/Final from prior KO winners),
+			// or a mix (e.g., 3rd-place placements). In every case the two slots
+			// (Home + Away) must refer to distinct rows.
+			if (ko.HomeGroupQualifier is not null && ko.AwayGroupQualifier is not null)
+			{
+				ko.HomeGroupQualifier.Id.Should().NotBe(ko.AwayGroupQualifier.Id,
+					$"KoGame Id={ko.Id} ({ko.Round?.Name}): Home and Away GroupQualifier must be distinct rows after SQLite round-trip");
+				ReferenceEquals(ko.HomeGroupQualifier, ko.AwayGroupQualifier).Should().BeFalse(
+					$"KoGame Id={ko.Id}: Home and Away GroupQualifier must be distinct instances");
+			}
+			if (ko.HomeGameQualifier is not null && ko.AwayGameQualifier is not null)
+			{
+				ko.HomeGameQualifier.Id.Should().NotBe(ko.AwayGameQualifier.Id,
+					$"KoGame Id={ko.Id} ({ko.Round?.Name}): Home and Away GameQualifier must be distinct rows after SQLite round-trip");
+				ReferenceEquals(ko.HomeGameQualifier, ko.AwayGameQualifier).Should().BeFalse(
+					$"KoGame Id={ko.Id}: Home and Away GameQualifier must be distinct instances");
+			}
+		}
+
+		// Cover the UPDATE path too — InitCompetition exercises Repo.Save with Id == 0
+		// (insert branch). Re-save and reload to exercise the Id != 0 branch in
+		// Repository.Save, which has its own snapshot/restore + UpdateAllGames flow.
+		Repo.Save(competition);
+		var reloaded = Repo.Get<Competition>(competition.Id);
+		reloaded.Should().NotBeNull("update-path Save must keep the competition retrievable");
+
+		var reloadedKoGames = reloaded!.Stages.SelectMany(s => s.Rounds).SelectMany(r => r.KoGames).ToList();
+		reloadedKoGames.Should().NotBeEmpty($"{type} {year} (update path) must still have KO games after Save+reload");
+		foreach (var ko in reloadedKoGames)
+		{
+			if (ko.HomeGroupQualifier is not null && ko.AwayGroupQualifier is not null)
+			{
+				ko.HomeGroupQualifier.Id.Should().NotBe(ko.AwayGroupQualifier.Id,
+					$"KoGame Id={ko.Id} (update path): Home and Away GroupQualifier must stay distinct after Save+reload");
+			}
+			if (ko.HomeGameQualifier is not null && ko.AwayGameQualifier is not null)
+			{
+				ko.HomeGameQualifier.Id.Should().NotBe(ko.AwayGameQualifier.Id,
+					$"KoGame Id={ko.Id} (update path): Home and Away GameQualifier must stay distinct after Save+reload");
+			}
+		}
+	}
+}

--- a/src/FantasyFootball.Tests/RoundAdvancerTests.cs
+++ b/src/FantasyFootball.Tests/RoundAdvancerTests.cs
@@ -58,7 +58,7 @@ public class RoundAdvancerTests(ITestOutputHelper output) : BaseTest(output, lev
 		for (var run = 0; run < Runs; run++)
 		{
 			var wm = CompetitionFactory.Default(CompetitionType.WM, DataService, 2026).Create();
-			var simulator = new CompetitionSimulator(wm, Repo, msGameDelay: 0);
+			var simulator = new CompetitionSimulator(wm, Repo);
 			await simulator.SimulateStage(wm.Stages[0]);
 
 			var r32 = wm.Stages[1].Rounds.First();

--- a/src/FantasyFootball.Tests/SimulationBenchmarkTests.cs
+++ b/src/FantasyFootball.Tests/SimulationBenchmarkTests.cs
@@ -26,12 +26,19 @@ public class SimulationBenchmarkTests(ITestOutputHelper output) : BaseTest(outpu
 			var competition = InitCompetition(type, year);
 			var simulator = new CompetitionSimulator(competition, Repo);
 
-			var sw = Stopwatch.StartNew();
-			await simulator.Simulate();
-			sw.Stop();
-
-			timings[i] = sw.ElapsedMilliseconds;
-			Repo.Delete(competition);
+			try
+			{
+				var sw = Stopwatch.StartNew();
+				await simulator.Simulate();
+				sw.Stop();
+				timings[i] = sw.ElapsedMilliseconds;
+			}
+			finally
+			{
+				// Ensure the in-memory DB doesn't accumulate stale Competitions if a sim throws
+				// — later iterations would otherwise pay extra GetAllWithChildren cost.
+				Repo.Delete(competition);
+			}
 		}
 
 		var totalGames = type switch
@@ -45,7 +52,7 @@ public class SimulationBenchmarkTests(ITestOutputHelper output) : BaseTest(outpu
 		var min = timings.Min();
 		var max = timings.Max();
 		var avg = timings.Average();
-		var perGame = avg / totalGames;
+		var perGame = totalGames > 0 ? avg / totalGames : 0;
 
 		Output.WriteLine($"{label}");
 		Output.WriteLine($"  Runs: {Runs}");
@@ -80,15 +87,23 @@ public class SimulationBenchmarkTests(ITestOutputHelper output) : BaseTest(outpu
 			var competition = factory.Create();
 			sw.Stop(); factoryToCompetition[i] = sw.ElapsedMilliseconds;
 
-			sw.Restart();
-			Repo.Save(competition);
-			sw.Stop(); repoSave[i] = sw.ElapsedMilliseconds;
+			try
+			{
+				sw.Restart();
+				Repo.Save(competition);
+				sw.Stop(); repoSave[i] = sw.ElapsedMilliseconds;
 
-			sw.Restart();
-			_ = Repo.GetAll<Competition>();
-			sw.Stop(); repoGet[i] = sw.ElapsedMilliseconds;
-
-			Repo.Delete(competition);
+				sw.Restart();
+				_ = Repo.GetAll<Competition>();
+				sw.Stop(); repoGet[i] = sw.ElapsedMilliseconds;
+			}
+			finally
+			{
+				// Mirror the cleanup guarantee from TimeFullCompetitionSimulation — a Repo.Save
+				// or Repo.GetAll throw would otherwise leak stale rows into later iterations and
+				// distort the GetAll measurement.
+				Repo.Delete(competition);
+			}
 		}
 
 		Output.WriteLine($"{label}");

--- a/src/FantasyFootball.Tests/SimulationBenchmarkTests.cs
+++ b/src/FantasyFootball.Tests/SimulationBenchmarkTests.cs
@@ -1,0 +1,106 @@
+using System.Diagnostics;
+
+namespace FantasyFootball.Tests;
+
+/// <summary>
+/// Pure timing harness for full-competition simulation. Reports wall-clock cost of
+/// <see cref="CompetitionSimulator.Simulate"/> per Competition type so we can see
+/// whether changes to the sim or persistence layer regress hot-path latency.
+///
+/// Not an assertion test — failures here would be a perf regression, but the
+/// numbers are emitted to test output for human inspection rather than gated.
+/// </summary>
+public class SimulationBenchmarkTests(ITestOutputHelper output) : BaseTest(output, level: LogEventLevel.Warning)
+{
+	[InlineData(CompetitionType.EM, 2024, "EM24 (24 teams, 51 games)")]
+	[InlineData(CompetitionType.WM, 2022, "WC32 (32 teams, 64 games)")]
+	[InlineData(CompetitionType.WM, 2026, "WC48 (48 teams, 104 games)")]
+	[Theory]
+	public async Task TimeFullCompetitionSimulation(CompetitionType type, int year, string label)
+	{
+		const int Runs = 5;
+		var timings = new long[Runs];
+
+		for (int i = 0; i < Runs; i++)
+		{
+			var competition = InitCompetition(type, year);
+			var simulator = new CompetitionSimulator(competition, Repo);
+
+			var sw = Stopwatch.StartNew();
+			await simulator.Simulate();
+			sw.Stop();
+
+			timings[i] = sw.ElapsedMilliseconds;
+			Repo.Delete(competition);
+		}
+
+		var totalGames = type switch
+		{
+			CompetitionType.EM => 51,
+			CompetitionType.WM when year == 2026 => 104,
+			CompetitionType.WM => 64,
+			_ => 0,
+		};
+
+		var min = timings.Min();
+		var max = timings.Max();
+		var avg = timings.Average();
+		var perGame = avg / totalGames;
+
+		Output.WriteLine($"{label}");
+		Output.WriteLine($"  Runs: {Runs}");
+		Output.WriteLine($"  Total competition: min {min} ms / avg {avg:F1} ms / max {max} ms");
+		Output.WriteLine($"  Per game:          avg {perGame:F2} ms");
+		Output.WriteLine($"  Raw timings (ms):  [{string.Join(", ", timings)}]");
+	}
+
+	[InlineData(CompetitionType.EM, 2024, "EM24 (24 teams, 51 games)")]
+	[InlineData(CompetitionType.WM, 2022, "WC32 (32 teams, 64 games)")]
+	[InlineData(CompetitionType.WM, 2026, "WC48 (48 teams, 104 games)")]
+	[Theory]
+	public void TimeInitCompetition(CompetitionType type, int year, string label)
+	{
+		// First call warms the CSV cache; not part of the steady-state measurement.
+		_ = InitCompetition(type, year);
+		Repo.Reset();
+
+		const int Runs = 5;
+		var factoryCreate = new long[Runs];
+		var factoryToCompetition = new long[Runs];
+		var repoSave = new long[Runs];
+		var repoGet = new long[Runs];
+
+		for (int i = 0; i < Runs; i++)
+		{
+			var sw = Stopwatch.StartNew();
+			var factory = CompetitionFactory.Default(type, DataService, year);
+			sw.Stop(); factoryCreate[i] = sw.ElapsedMilliseconds;
+
+			sw.Restart();
+			var competition = factory.Create();
+			sw.Stop(); factoryToCompetition[i] = sw.ElapsedMilliseconds;
+
+			sw.Restart();
+			Repo.Save(competition);
+			sw.Stop(); repoSave[i] = sw.ElapsedMilliseconds;
+
+			sw.Restart();
+			_ = Repo.GetAll<Competition>();
+			sw.Stop(); repoGet[i] = sw.ElapsedMilliseconds;
+
+			Repo.Delete(competition);
+		}
+
+		Output.WriteLine($"{label}");
+		Output.WriteLine($"  Runs: {Runs} (after 1 warmup)");
+		Output.WriteLine($"  CompetitionFactory.Default():  avg {factoryCreate.Average():F1} ms  raw {Fmt(factoryCreate)}");
+		Output.WriteLine($"  factory.Create():              avg {factoryToCompetition.Average():F1} ms  raw {Fmt(factoryToCompetition)}");
+		Output.WriteLine($"  Repo.Save(competition):        avg {repoSave.Average():F1} ms  raw {Fmt(repoSave)}");
+		Output.WriteLine($"  Repo.GetAll<Competition>():    avg {repoGet.Average():F1} ms  raw {Fmt(repoGet)}");
+		var totalAvg = factoryCreate.Average() + factoryToCompetition.Average() + repoSave.Average();
+		Output.WriteLine($"  ----------------");
+		Output.WriteLine($"  Total InitCompetition (avg):   {totalAvg:F1} ms");
+	}
+
+	static string Fmt(long[] xs) => $"[{string.Join(", ", xs)}]";
+}

--- a/src/FantasyFootball.UI/ViewModels/CompetitionDetailViewModel.cs
+++ b/src/FantasyFootball.UI/ViewModels/CompetitionDetailViewModel.cs
@@ -155,7 +155,9 @@ public partial class CompetitionDetailViewModel : ObservableObject
 			// Single-game user click — no inter-game pacing needed; tell the simulator to skip
 			// the post-sim Task.Delay so the busy spinner clears immediately after the result.
 			await _simulator.SimulateGame(gameBeingSimmed, delayAfter: false);
-			_repo.Save(Competition);
+			// Persist just the one game that changed — on SQLite this is a single-row UPDATE,
+			// on LocalStorage it bubbles up to the Competition write (same cost as before).
+			_repo.Save(gameBeingSimmed);
 			// Pulse marker AFTER the sim so the class transition + final score land in one render (Space path needs this; click batches via EventCallback).
 			_ = FlashRecentlyFinished(gameBeingSimmed);
 		}
@@ -206,7 +208,8 @@ public partial class CompetitionDetailViewModel : ObservableObject
 		if (!_undoStack.TryPop(out var game)) { return; }
 
 		game.ClearResult();
-		_repo.Save(Competition);
+		// Targeted save — only this game's row changed.
+		_repo.Save(game);
 		// OnSimBatchComplete owns the CanUndo / UndoTargetGame notifications.
 		OnSimBatchComplete();
 	}
@@ -227,7 +230,8 @@ public partial class CompetitionDetailViewModel : ObservableObject
 			game.ClearResult();
 			// Same as SimulateGame: single-game user click, no inter-game pacing.
 			await _simulator.SimulateGame(game, delayAfter: false);
-			_repo.Save(Competition);
+			// Targeted save — only this game's row changed.
+			_repo.Save(game);
 			// FlashRecentlyFinished AFTER the sim — same render-batching reason as SimulateGame.
 			_ = FlashRecentlyFinished(game);
 		}


### PR DESCRIPTION
## Summary

Investigates the originally-reported #12 (WC2026 third-place assignment) and finds the actual root cause is broader: a sqlite-net-extensions cascade bug that affects all KO games with multiple OneToOne navigation properties pointing to the same child type (HomeGroupQualifier + AwayGroupQualifier both → GroupQualifier).

When KoGame is inserted via InsertWithChildren, the second child's Id stomps the first FK column. Both HomeGroupQualifierId and AwayGroupQualifierId end up referencing the same row, and the in-memory ko.HomeGroupQualifier reference is also swapped to the Away instance. After reload, KoGame.HomeTeam == KoGame.AwayTeam, which made all KO-game-related assertions explode.

This single bug was responsible for **5 of the 6** failing tests; the 6th (TestRunWm) was a pre-existing test bug missing an explicit Repo.Save before the round-trip Get.

## Commits

| SHA | Theme |
|---|---|
| \`8eae16d\` | API: default \`CompetitionSimulator.msGameDelay\` to 0 (instant). UI opts into pacing. |
| \`80b2dc1\` | New \`SimulationBenchmarkTests\` — quantify per-Type sim + InitCompetition cost. |
| \`18499f2\` | **Core fix**: SQLite multi-OneToOne FK stomp workaround in Repository (PreInsert + snapshot + post-cascade SQL fixup) + targeted Save<Game> for per-game flows. |
| \`5606057\` | VM per-game saves now target the Game, not the whole Competition. |
| \`71f2a86\` | Test fix (missing Save) + regression guard \`QualifierRoundTripTests\`. |

## Benchmarks (from 80b2dc1)

| Type | Teams | Games | Sim avg | Per-game | InitCompetition (dominated by Repo.Save) |
|---|---|---|---|---|---|
| EM24 | 24 | 51 | 16 ms | 0.32 ms | 2.8 s |
| WC32 | 32 | 64 | 17 ms | 0.26 ms | 3.4 s |
| WC48 | 48 | 104 | 100 ms | 0.96 ms | 5.4 s |

Headline takeaway: simulation itself is fast (sub-100ms per WC48 tournament). Almost all of the wall-clock cost in test setup is sqlite-net-pcl \`Repo.Save\` cascade-inserting a deep graph. Not on the critical path for prod (uses LocalStorage) but the dominant test-cost.

## Test plan

- [x] All 6 previously-failing tests now pass:
  - \`CompetitionSimulatorTest.TestRunEm(2016/2020/2024)\`
  - \`CompetitionSimulatorTest.TestRunWm(2018/2022)\`
  - \`RoundAdvancerTests.ExpandedWorldCupFormat_FullSimulationProducesDistinctR32Teams\`
- [x] All 53 previously-passing tests stay green
- [x] New regression test \`QualifierRoundTripTests\` passes (WM2022, WM2026, EM2024)
- [x] Slow tests (\`StandingsSortInvariantTests\` + \`SimulationBenchmarkTests\`) still pass
- [x] Plain \`dotnet test\` completes — total 69 passing / 0 failing