### PR TITLE
Finish [JsonIgnore] pass for computed getters

### DIFF
--- a/src/FantasyFootball.Core/Models/Confederation.cs
+++ b/src/FantasyFootball.Core/Models/Confederation.cs
@@ -32,7 +32,7 @@ public class Confederation : NamedUniqueId
 	[OneToMany(CascadeOperations = CascadeOperation.CascadeRead), JsonIgnore]
 	public virtual List<Country> Countries { get; init; } = [];
 
-	public string Logo => IconStrings.GetConfederationLogo(this);
+	[JsonIgnore] public string Logo => IconStrings.GetConfederationLogo(this);
 	public int NoOfWmParticipants { get; init; }
 
 	public override bool Equals(object? obj) => GetType() == obj?.GetType() && Name == (obj as Confederation)?.Name;

--- a/src/FantasyFootball.Core/Models/Team.cs
+++ b/src/FantasyFootball.Core/Models/Team.cs
@@ -1,13 +1,15 @@
-﻿namespace FantasyFootball.Models;
+﻿using System.Text.Json.Serialization;
+
+namespace FantasyFootball.Models;
 
 [Table(nameof(Team))]
 public class Team : NamedUniqueId
 {
 	public TeamType Type { get; init; }
-	[Ignore] public bool IsNationalTeam => Type is TeamType.NATIONAL_MEN or TeamType.NATIONAL_WOMEN;
+	[Ignore, JsonIgnore] public bool IsNationalTeam => Type is TeamType.NATIONAL_MEN or TeamType.NATIONAL_WOMEN;
 	public virtual string ShortName { get; init; }
 	public int Elo { get; set; }
-	public virtual string Logo => IconStrings.GetTeamLogo(this);
+	[JsonIgnore] public virtual string Logo => IconStrings.GetTeamLogo(this);
 
 	[ForeignKey(typeof(Country))]
 	public int CountryId { get; set; }


### PR DESCRIPTION
## Summary
- Three `[JsonIgnore]` attribute additions finishing the #32 acceptance criteria not covered by PR #49.
- `Team.Logo`, `Confederation.Logo`, `Team.IsNationalTeam` were computed/derived getters still serializing into LocalStorage; now suppressed.
- Closes #32.

## Test plan
- [x] 155 tests pass locally (`dotnet test`)
- [ ] Manually verify LocalStorage JSON no longer contains `Logo` or `IsNationalTeam` fields after a `SaveAll<Team>` (Settings → Reset triggers this).