### PR TITLE
Venues + attendance: Phase B

### DIFF
--- a/src/FantasyFootball.Core/Definitions/em-2024.json
+++ b/src/FantasyFootball.Core/Definitions/em-2024.json
@@ -93,7 +93,7 @@
     ],
     "F": [
       "TUR",
-      "GRE",
+      "GEO",
       "POR",
       "CZE"
     ]
@@ -105,8 +105,10 @@
       "homeTeamId": "GER",
       "awayTeamId": "SCO",
       "id": 1,
-      "playedOn": "2016-06-10T21:00:00Z",
-      "roundId": "group-r1"
+      "playedOn": "2024-06-14T19:00:00Z",
+      "roundId": "group-r1",
+      "venueId": "allianz-arena",
+      "attendance": 65052
     },
     {
       "kind": "group",
@@ -114,8 +116,10 @@
       "homeTeamId": "HUN",
       "awayTeamId": "SUI",
       "id": 2,
-      "playedOn": "2016-06-11T15:00:00Z",
-      "roundId": "group-r1"
+      "playedOn": "2024-06-15T13:00:00Z",
+      "roundId": "group-r1",
+      "venueId": "rheinenergie-stadion",
+      "attendance": 41676
     },
     {
       "kind": "group",
@@ -123,8 +127,10 @@
       "homeTeamId": "ESP",
       "awayTeamId": "CRO",
       "id": 3,
-      "playedOn": "2016-06-11T18:00:00Z",
-      "roundId": "group-r1"
+      "playedOn": "2024-06-15T16:00:00Z",
+      "roundId": "group-r1",
+      "venueId": "olympiastadion-berlin",
+      "attendance": 68844
     },
     {
       "kind": "group",
@@ -132,8 +138,10 @@
       "homeTeamId": "ITA",
       "awayTeamId": "ALB",
       "id": 4,
-      "playedOn": "2016-06-11T21:00:00Z",
-      "roundId": "group-r1"
+      "playedOn": "2024-06-15T19:00:00Z",
+      "roundId": "group-r1",
+      "venueId": "westfalenstadion",
+      "attendance": 60512
     },
     {
       "kind": "group",
@@ -141,8 +149,10 @@
       "homeTeamId": "POL",
       "awayTeamId": "NED",
       "id": 5,
-      "playedOn": "2016-06-12T15:00:00Z",
-      "roundId": "group-r1"
+      "playedOn": "2024-06-16T13:00:00Z",
+      "roundId": "group-r1",
+      "venueId": "volksparkstadion",
+      "attendance": 48117
     },
     {
       "kind": "group",
@@ -150,8 +160,10 @@
       "homeTeamId": "SVN",
       "awayTeamId": "DEN",
       "id": 6,
-      "playedOn": "2016-06-12T18:00:00Z",
-      "roundId": "group-r1"
+      "playedOn": "2024-06-16T16:00:00Z",
+      "roundId": "group-r1",
+      "venueId": "mhparena",
+      "attendance": 54000
     },
     {
       "kind": "group",
@@ -159,8 +171,10 @@
       "homeTeamId": "SRB",
       "awayTeamId": "ENG",
       "id": 7,
-      "playedOn": "2016-06-12T21:00:00Z",
-      "roundId": "group-r1"
+      "playedOn": "2024-06-16T19:00:00Z",
+      "roundId": "group-r1",
+      "venueId": "arena-aufschalke",
+      "attendance": 48953
     },
     {
       "kind": "group",
@@ -168,8 +182,10 @@
       "homeTeamId": "BEL",
       "awayTeamId": "SVK",
       "id": 8,
-      "playedOn": "2016-06-13T15:00:00Z",
-      "roundId": "group-r1"
+      "playedOn": "2024-06-17T16:00:00Z",
+      "roundId": "group-r1",
+      "venueId": "waldstadion",
+      "attendance": 45181
     },
     {
       "kind": "group",
@@ -177,8 +193,10 @@
       "homeTeamId": "ROU",
       "awayTeamId": "UKR",
       "id": 9,
-      "playedOn": "2016-06-13T18:00:00Z",
-      "roundId": "group-r1"
+      "playedOn": "2024-06-17T13:00:00Z",
+      "roundId": "group-r1",
+      "venueId": "allianz-arena",
+      "attendance": 61591
     },
     {
       "kind": "group",
@@ -186,17 +204,21 @@
       "homeTeamId": "AUT",
       "awayTeamId": "FRA",
       "id": 10,
-      "playedOn": "2016-06-13T21:00:00Z",
-      "roundId": "group-r1"
+      "playedOn": "2024-06-17T19:00:00Z",
+      "roundId": "group-r1",
+      "venueId": "merkur-spiel-arena",
+      "attendance": 46425
     },
     {
       "kind": "group",
       "groupLetter": "F",
       "homeTeamId": "TUR",
-      "awayTeamId": "GRE",
+      "awayTeamId": "GEO",
       "id": 11,
-      "playedOn": "2016-06-14T18:00:00Z",
-      "roundId": "group-r1"
+      "playedOn": "2024-06-18T16:00:00Z",
+      "roundId": "group-r1",
+      "venueId": "westfalenstadion",
+      "attendance": 59127
     },
     {
       "kind": "group",
@@ -204,8 +226,10 @@
       "homeTeamId": "POR",
       "awayTeamId": "CZE",
       "id": 12,
-      "playedOn": "2016-06-14T21:00:00Z",
-      "roundId": "group-r1"
+      "playedOn": "2024-06-18T19:00:00Z",
+      "roundId": "group-r1",
+      "venueId": "red-bull-arena",
+      "attendance": 38421
     },
     {
       "kind": "group",
@@ -213,8 +237,10 @@
       "homeTeamId": "CRO",
       "awayTeamId": "ALB",
       "id": 13,
-      "playedOn": "2016-06-15T15:00:00Z",
-      "roundId": "group-r2"
+      "playedOn": "2024-06-19T13:00:00Z",
+      "roundId": "group-r2",
+      "venueId": "volksparkstadion",
+      "attendance": 46784
     },
     {
       "kind": "group",
@@ -222,8 +248,10 @@
       "homeTeamId": "GER",
       "awayTeamId": "HUN",
       "id": 14,
-      "playedOn": "2016-06-15T18:00:00Z",
-      "roundId": "group-r2"
+      "playedOn": "2024-06-19T16:00:00Z",
+      "roundId": "group-r2",
+      "venueId": "mhparena",
+      "attendance": 54000
     },
     {
       "kind": "group",
@@ -231,8 +259,10 @@
       "homeTeamId": "SCO",
       "awayTeamId": "SUI",
       "id": 15,
-      "playedOn": "2016-06-15T21:00:00Z",
-      "roundId": "group-r2"
+      "playedOn": "2024-06-19T19:00:00Z",
+      "roundId": "group-r2",
+      "venueId": "rheinenergie-stadion",
+      "attendance": 42711
     },
     {
       "kind": "group",
@@ -240,8 +270,10 @@
       "homeTeamId": "SVN",
       "awayTeamId": "SRB",
       "id": 16,
-      "playedOn": "2016-06-16T15:00:00Z",
-      "roundId": "group-r2"
+      "playedOn": "2024-06-20T13:00:00Z",
+      "roundId": "group-r2",
+      "venueId": "allianz-arena",
+      "attendance": 63028
     },
     {
       "kind": "group",
@@ -249,8 +281,10 @@
       "homeTeamId": "DEN",
       "awayTeamId": "ENG",
       "id": 17,
-      "playedOn": "2016-06-16T18:00:00Z",
-      "roundId": "group-r2"
+      "playedOn": "2024-06-20T16:00:00Z",
+      "roundId": "group-r2",
+      "venueId": "waldstadion",
+      "attendance": 46177
     },
     {
       "kind": "group",
@@ -258,8 +292,10 @@
       "homeTeamId": "ESP",
       "awayTeamId": "ITA",
       "id": 18,
-      "playedOn": "2016-06-16T21:00:00Z",
-      "roundId": "group-r2"
+      "playedOn": "2024-06-20T19:00:00Z",
+      "roundId": "group-r2",
+      "venueId": "arena-aufschalke",
+      "attendance": 49528
     },
     {
       "kind": "group",
@@ -267,8 +303,10 @@
       "homeTeamId": "SVK",
       "awayTeamId": "UKR",
       "id": 19,
-      "playedOn": "2016-06-17T15:00:00Z",
-      "roundId": "group-r2"
+      "playedOn": "2024-06-21T13:00:00Z",
+      "roundId": "group-r2",
+      "venueId": "merkur-spiel-arena",
+      "attendance": 43910
     },
     {
       "kind": "group",
@@ -276,8 +314,10 @@
       "homeTeamId": "POL",
       "awayTeamId": "AUT",
       "id": 20,
-      "playedOn": "2016-06-17T18:00:00Z",
-      "roundId": "group-r2"
+      "playedOn": "2024-06-21T16:00:00Z",
+      "roundId": "group-r2",
+      "venueId": "olympiastadion-berlin",
+      "attendance": 69455
     },
     {
       "kind": "group",
@@ -285,17 +325,21 @@
       "homeTeamId": "NED",
       "awayTeamId": "FRA",
       "id": 21,
-      "playedOn": "2016-06-17T21:00:00Z",
-      "roundId": "group-r2"
+      "playedOn": "2024-06-21T19:00:00Z",
+      "roundId": "group-r2",
+      "venueId": "red-bull-arena",
+      "attendance": 38531
     },
     {
       "kind": "group",
       "groupLetter": "F",
-      "homeTeamId": "GRE",
+      "homeTeamId": "GEO",
       "awayTeamId": "CZE",
       "id": 22,
-      "playedOn": "2016-06-18T15:00:00Z",
-      "roundId": "group-r2"
+      "playedOn": "2024-06-22T13:00:00Z",
+      "roundId": "group-r2",
+      "venueId": "volksparkstadion",
+      "attendance": 46524
     },
     {
       "kind": "group",
@@ -303,8 +347,10 @@
       "homeTeamId": "TUR",
       "awayTeamId": "POR",
       "id": 23,
-      "playedOn": "2016-06-18T18:00:00Z",
-      "roundId": "group-r2"
+      "playedOn": "2024-06-22T16:00:00Z",
+      "roundId": "group-r2",
+      "venueId": "westfalenstadion",
+      "attendance": 61047
     },
     {
       "kind": "group",
@@ -312,8 +358,10 @@
       "homeTeamId": "BEL",
       "awayTeamId": "ROU",
       "id": 24,
-      "playedOn": "2016-06-18T21:00:00Z",
-      "roundId": "group-r2"
+      "playedOn": "2024-06-22T19:00:00Z",
+      "roundId": "group-r2",
+      "venueId": "rheinenergie-stadion",
+      "attendance": 42535
     },
     {
       "kind": "group",
@@ -321,8 +369,10 @@
       "homeTeamId": "SUI",
       "awayTeamId": "GER",
       "id": 25,
-      "playedOn": "2016-06-19T21:00:00Z",
-      "roundId": "group-r3"
+      "playedOn": "2024-06-23T19:00:00Z",
+      "roundId": "group-r3",
+      "venueId": "waldstadion",
+      "attendance": 46685
     },
     {
       "kind": "group",
@@ -330,8 +380,10 @@
       "homeTeamId": "SCO",
       "awayTeamId": "HUN",
       "id": 26,
-      "playedOn": "2016-06-19T21:00:00Z",
-      "roundId": "group-r3"
+      "playedOn": "2024-06-23T19:00:00Z",
+      "roundId": "group-r3",
+      "venueId": "mhparena",
+      "attendance": 54000
     },
     {
       "kind": "group",
@@ -339,8 +391,10 @@
       "homeTeamId": "ALB",
       "awayTeamId": "ESP",
       "id": 27,
-      "playedOn": "2016-06-20T21:00:00Z",
-      "roundId": "group-r3"
+      "playedOn": "2024-06-24T19:00:00Z",
+      "roundId": "group-r3",
+      "venueId": "merkur-spiel-arena",
+      "attendance": 46586
     },
     {
       "kind": "group",
@@ -348,8 +402,10 @@
       "homeTeamId": "CRO",
       "awayTeamId": "ITA",
       "id": 28,
-      "playedOn": "2016-06-20T21:00:00Z",
-      "roundId": "group-r3"
+      "playedOn": "2024-06-24T19:00:00Z",
+      "roundId": "group-r3",
+      "venueId": "red-bull-arena",
+      "attendance": 38322
     },
     {
       "kind": "group",
@@ -357,8 +413,10 @@
       "homeTeamId": "FRA",
       "awayTeamId": "POL",
       "id": 29,
-      "playedOn": "2016-06-21T18:00:00Z",
-      "roundId": "group-r3"
+      "playedOn": "2024-06-25T16:00:00Z",
+      "roundId": "group-r3",
+      "venueId": "westfalenstadion",
+      "attendance": 59728
     },
     {
       "kind": "group",
@@ -366,8 +424,10 @@
       "homeTeamId": "NED",
       "awayTeamId": "AUT",
       "id": 30,
-      "playedOn": "2016-06-21T18:00:00Z",
-      "roundId": "group-r3"
+      "playedOn": "2024-06-25T16:00:00Z",
+      "roundId": "group-r3",
+      "venueId": "olympiastadion-berlin",
+      "attendance": 68363
     },
     {
       "kind": "group",
@@ -375,8 +435,10 @@
       "homeTeamId": "ENG",
       "awayTeamId": "SVN",
       "id": 31,
-      "playedOn": "2016-06-21T21:00:00Z",
-      "roundId": "group-r3"
+      "playedOn": "2024-06-25T19:00:00Z",
+      "roundId": "group-r3",
+      "venueId": "rheinenergie-stadion",
+      "attendance": 41536
     },
     {
       "kind": "group",
@@ -384,8 +446,10 @@
       "homeTeamId": "DEN",
       "awayTeamId": "SRB",
       "id": 32,
-      "playedOn": "2016-06-21T21:00:00Z",
-      "roundId": "group-r3"
+      "playedOn": "2024-06-25T19:00:00Z",
+      "roundId": "group-r3",
+      "venueId": "allianz-arena",
+      "attendance": 64288
     },
     {
       "kind": "group",
@@ -393,8 +457,10 @@
       "homeTeamId": "UKR",
       "awayTeamId": "BEL",
       "id": 33,
-      "playedOn": "2016-06-22T18:00:00Z",
-      "roundId": "group-r3"
+      "playedOn": "2024-06-26T16:00:00Z",
+      "roundId": "group-r3",
+      "venueId": "mhparena",
+      "attendance": 54000
     },
     {
       "kind": "group",
@@ -402,8 +468,10 @@
       "homeTeamId": "SVK",
       "awayTeamId": "ROU",
       "id": 34,
-      "playedOn": "2016-06-22T18:00:00Z",
-      "roundId": "group-r3"
+      "playedOn": "2024-06-26T16:00:00Z",
+      "roundId": "group-r3",
+      "venueId": "waldstadion",
+      "attendance": 45033
     },
     {
       "kind": "group",
@@ -411,137 +479,171 @@
       "homeTeamId": "CZE",
       "awayTeamId": "TUR",
       "id": 35,
-      "playedOn": "2016-06-22T21:00:00Z",
-      "roundId": "group-r3"
+      "playedOn": "2024-06-26T19:00:00Z",
+      "roundId": "group-r3",
+      "venueId": "volksparkstadion",
+      "attendance": 47683
     },
     {
       "kind": "group",
       "groupLetter": "F",
-      "homeTeamId": "GRE",
+      "homeTeamId": "GEO",
       "awayTeamId": "POR",
       "id": 36,
-      "playedOn": "2016-06-22T21:00:00Z",
-      "roundId": "group-r3"
+      "playedOn": "2024-06-26T19:00:00Z",
+      "roundId": "group-r3",
+      "venueId": "arena-aufschalke",
+      "attendance": 49616
     },
     {
       "kind": "ko",
       "homeQual": "A2",
       "awayQual": "B2",
       "id": 37,
-      "playedOn": "2020-06-26T18:00:00Z",
-      "roundId": "r16"
+      "playedOn": "2024-06-29T16:00:00Z",
+      "roundId": "r16",
+      "venueId": "olympiastadion-berlin",
+      "attendance": 68172
     },
     {
       "kind": "ko",
       "homeQual": "A1",
       "awayQual": "C2",
       "id": 38,
-      "playedOn": "2020-06-26T21:00:00Z",
-      "roundId": "r16"
+      "playedOn": "2024-06-29T19:00:00Z",
+      "roundId": "r16",
+      "venueId": "westfalenstadion",
+      "attendance": 61612
     },
     {
       "kind": "ko",
       "homeQual": "C1",
       "awayQual": "D/E/F3",
       "id": 39,
-      "playedOn": "2020-06-27T18:00:00Z",
-      "roundId": "r16"
+      "playedOn": "2024-06-30T16:00:00Z",
+      "roundId": "r16",
+      "venueId": "arena-aufschalke",
+      "attendance": 47244
     },
     {
       "kind": "ko",
       "homeQual": "B1",
       "awayQual": "A/D/E/F3",
       "id": 40,
-      "playedOn": "2020-06-27T21:00:00Z",
-      "roundId": "r16"
+      "playedOn": "2024-06-30T19:00:00Z",
+      "roundId": "r16",
+      "venueId": "rheinenergie-stadion",
+      "attendance": 42233
     },
     {
       "kind": "ko",
       "homeQual": "D2",
       "awayQual": "E2",
       "id": 41,
-      "playedOn": "2020-06-28T18:00:00Z",
-      "roundId": "r16"
+      "playedOn": "2024-07-01T16:00:00Z",
+      "roundId": "r16",
+      "venueId": "merkur-spiel-arena",
+      "attendance": 46810
     },
     {
       "kind": "ko",
       "homeQual": "F1",
       "awayQual": "A/B/C3",
       "id": 42,
-      "playedOn": "2020-06-28T21:00:00Z",
-      "roundId": "r16"
+      "playedOn": "2024-07-01T19:00:00Z",
+      "roundId": "r16",
+      "venueId": "waldstadion",
+      "attendance": 46576
     },
     {
       "kind": "ko",
       "homeQual": "D1",
       "awayQual": "F2",
       "id": 43,
-      "playedOn": "2020-06-29T18:00:00Z",
-      "roundId": "r16"
+      "playedOn": "2024-07-02T16:00:00Z",
+      "roundId": "r16",
+      "venueId": "allianz-arena",
+      "attendance": 65012
     },
     {
       "kind": "ko",
       "homeQual": "E1",
       "awayQual": "A/B/C/D3",
       "id": 44,
-      "playedOn": "2020-06-29T21:00:00Z",
-      "roundId": "r16"
+      "playedOn": "2024-07-02T19:00:00Z",
+      "roundId": "r16",
+      "venueId": "red-bull-arena",
+      "attendance": 38305
     },
     {
       "kind": "ko",
       "homeQual": "W-41",
       "awayQual": "W-42",
       "id": 45,
-      "playedOn": "2020-07-02T18:00:00Z",
-      "roundId": "qf"
+      "playedOn": "2024-07-05T16:00:00Z",
+      "roundId": "qf",
+      "venueId": "mhparena",
+      "attendance": 54000
     },
     {
       "kind": "ko",
       "homeQual": "W-39",
       "awayQual": "W-37",
       "id": 46,
-      "playedOn": "2020-07-02T21:00:00Z",
-      "roundId": "qf"
+      "playedOn": "2024-07-05T19:00:00Z",
+      "roundId": "qf",
+      "venueId": "volksparkstadion",
+      "attendance": 47789
     },
     {
       "kind": "ko",
       "homeQual": "W-40",
       "awayQual": "W-38",
       "id": 47,
-      "playedOn": "2020-07-03T18:00:00Z",
-      "roundId": "qf"
+      "playedOn": "2024-07-06T16:00:00Z",
+      "roundId": "qf",
+      "venueId": "merkur-spiel-arena",
+      "attendance": 46907
     },
     {
       "kind": "ko",
       "homeQual": "W-43",
       "awayQual": "W-44",
       "id": 48,
-      "playedOn": "2020-07-03T21:00:00Z",
-      "roundId": "qf"
+      "playedOn": "2024-07-06T19:00:00Z",
+      "roundId": "qf",
+      "venueId": "olympiastadion-berlin",
+      "attendance": 70091
     },
     {
       "kind": "ko",
       "homeQual": "W-46",
       "awayQual": "W-45",
       "id": 49,
-      "playedOn": "2020-07-06T21:00:00Z",
-      "roundId": "sf"
+      "playedOn": "2024-07-09T19:00:00Z",
+      "roundId": "sf",
+      "venueId": "allianz-arena",
+      "attendance": 62042
     },
     {
       "kind": "ko",
       "homeQual": "W-48",
       "awayQual": "W-47",
       "id": 50,
-      "playedOn": "2020-07-07T21:00:00Z",
-      "roundId": "sf"
+      "playedOn": "2024-07-10T19:00:00Z",
+      "roundId": "sf",
+      "venueId": "westfalenstadion",
+      "attendance": 60926
     },
     {
       "kind": "ko",
       "homeQual": "W-49",
       "awayQual": "W-50",
       "id": 51,
-      "playedOn": "2020-07-11T21:00:00Z",
-      "roundId": "final"
+      "playedOn": "2024-07-14T19:00:00Z",
+      "roundId": "final",
+      "venueId": "olympiastadion-berlin",
+      "attendance": 65600
     }
   ]
 }

--- a/src/FantasyFootball.Core/Definitions/wm-2022.json
+++ b/src/FantasyFootball.Core/Definitions/wm-2022.json
@@ -123,8 +123,10 @@
       "homeTeamId": "QAT",
       "awayTeamId": "ECU",
       "id": 1,
-      "playedOn": "2022-11-20T17:00:00Z",
-      "roundId": "group-r1"
+      "playedOn": "2022-11-20T16:00:00Z",
+      "roundId": "group-r1",
+      "venueId": "al-bayt-stadium",
+      "attendance": 67372
     },
     {
       "kind": "group",
@@ -132,8 +134,10 @@
       "homeTeamId": "ENG",
       "awayTeamId": "IRN",
       "id": 2,
-      "playedOn": "2022-11-21T14:00:00Z",
-      "roundId": "group-r1"
+      "playedOn": "2022-11-21T13:00:00Z",
+      "roundId": "group-r1",
+      "venueId": "khalifa-international-stadium",
+      "attendance": 45334
     },
     {
       "kind": "group",
@@ -141,8 +145,10 @@
       "homeTeamId": "SEN",
       "awayTeamId": "NED",
       "id": 3,
-      "playedOn": "2022-11-21T17:00:00Z",
-      "roundId": "group-r1"
+      "playedOn": "2022-11-21T16:00:00Z",
+      "roundId": "group-r1",
+      "venueId": "al-thumama-stadium",
+      "attendance": 41721
     },
     {
       "kind": "group",
@@ -150,8 +156,10 @@
       "homeTeamId": "USA",
       "awayTeamId": "WAL",
       "id": 4,
-      "playedOn": "2022-11-21T20:00:00Z",
-      "roundId": "group-r1"
+      "playedOn": "2022-11-21T19:00:00Z",
+      "roundId": "group-r1",
+      "venueId": "ahmad-bin-ali-stadium",
+      "attendance": 43418
     },
     {
       "kind": "group",
@@ -159,8 +167,10 @@
       "homeTeamId": "ARG",
       "awayTeamId": "KSA",
       "id": 5,
-      "playedOn": "2022-11-22T11:00:00Z",
-      "roundId": "group-r1"
+      "playedOn": "2022-11-22T10:00:00Z",
+      "roundId": "group-r1",
+      "venueId": "lusail-stadium",
+      "attendance": 88012
     },
     {
       "kind": "group",
@@ -168,8 +178,10 @@
       "homeTeamId": "DEN",
       "awayTeamId": "TUN",
       "id": 6,
-      "playedOn": "2022-11-22T14:00:00Z",
-      "roundId": "group-r1"
+      "playedOn": "2022-11-22T13:00:00Z",
+      "roundId": "group-r1",
+      "venueId": "education-city-stadium",
+      "attendance": 42925
     },
     {
       "kind": "group",
@@ -177,8 +189,10 @@
       "homeTeamId": "MEX",
       "awayTeamId": "POL",
       "id": 7,
-      "playedOn": "2022-11-22T17:00:00Z",
-      "roundId": "group-r1"
+      "playedOn": "2022-11-22T16:00:00Z",
+      "roundId": "group-r1",
+      "venueId": "stadium-974",
+      "attendance": 39369
     },
     {
       "kind": "group",
@@ -186,8 +200,10 @@
       "homeTeamId": "FRA",
       "awayTeamId": "AUS",
       "id": 8,
-      "playedOn": "2022-11-22T20:00:00Z",
-      "roundId": "group-r1"
+      "playedOn": "2022-11-22T19:00:00Z",
+      "roundId": "group-r1",
+      "venueId": "al-janoub-stadium",
+      "attendance": 40875
     },
     {
       "kind": "group",
@@ -195,8 +211,10 @@
       "homeTeamId": "MAR",
       "awayTeamId": "CRO",
       "id": 9,
-      "playedOn": "2022-11-23T11:00:00Z",
-      "roundId": "group-r1"
+      "playedOn": "2022-11-23T10:00:00Z",
+      "roundId": "group-r1",
+      "venueId": "al-bayt-stadium",
+      "attendance": 59407
     },
     {
       "kind": "group",
@@ -204,8 +222,10 @@
       "homeTeamId": "GER",
       "awayTeamId": "JPN",
       "id": 10,
-      "playedOn": "2022-11-23T14:00:00Z",
-      "roundId": "group-r1"
+      "playedOn": "2022-11-23T13:00:00Z",
+      "roundId": "group-r1",
+      "venueId": "khalifa-international-stadium",
+      "attendance": 42608
     },
     {
       "kind": "group",
@@ -213,8 +233,10 @@
       "homeTeamId": "ESP",
       "awayTeamId": "CRC",
       "id": 11,
-      "playedOn": "2022-11-23T17:00:00Z",
-      "roundId": "group-r1"
+      "playedOn": "2022-11-23T16:00:00Z",
+      "roundId": "group-r1",
+      "venueId": "al-thumama-stadium",
+      "attendance": 40013
     },
     {
       "kind": "group",
@@ -222,8 +244,10 @@
       "homeTeamId": "BEL",
       "awayTeamId": "CAN",
       "id": 12,
-      "playedOn": "2022-11-23T20:00:00Z",
-      "roundId": "group-r1"
+      "playedOn": "2022-11-23T19:00:00Z",
+      "roundId": "group-r1",
+      "venueId": "ahmad-bin-ali-stadium",
+      "attendance": 40432
     },
     {
       "kind": "group",
@@ -231,8 +255,10 @@
       "homeTeamId": "SUI",
       "awayTeamId": "CMR",
       "id": 13,
-      "playedOn": "2022-11-24T11:00:00Z",
-      "roundId": "group-r1"
+      "playedOn": "2022-11-24T10:00:00Z",
+      "roundId": "group-r1",
+      "venueId": "al-janoub-stadium",
+      "attendance": 39089
     },
     {
       "kind": "group",
@@ -240,8 +266,10 @@
       "homeTeamId": "URU",
       "awayTeamId": "KOR",
       "id": 14,
-      "playedOn": "2022-11-24T14:00:00Z",
-      "roundId": "group-r1"
+      "playedOn": "2022-11-24T13:00:00Z",
+      "roundId": "group-r1",
+      "venueId": "education-city-stadium",
+      "attendance": 41663
     },
     {
       "kind": "group",
@@ -249,8 +277,10 @@
       "homeTeamId": "POR",
       "awayTeamId": "GHA",
       "id": 15,
-      "playedOn": "2022-11-24T17:00:00Z",
-      "roundId": "group-r1"
+      "playedOn": "2022-11-24T16:00:00Z",
+      "roundId": "group-r1",
+      "venueId": "stadium-974",
+      "attendance": 42662
     },
     {
       "kind": "group",
@@ -258,8 +288,10 @@
       "homeTeamId": "BRA",
       "awayTeamId": "SRB",
       "id": 16,
-      "playedOn": "2022-11-24T20:00:00Z",
-      "roundId": "group-r1"
+      "playedOn": "2022-11-24T19:00:00Z",
+      "roundId": "group-r1",
+      "venueId": "lusail-stadium",
+      "attendance": 88103
     },
     {
       "kind": "group",
@@ -267,8 +299,10 @@
       "homeTeamId": "WAL",
       "awayTeamId": "IRN",
       "id": 17,
-      "playedOn": "2022-11-25T11:00:00Z",
-      "roundId": "group-r2"
+      "playedOn": "2022-11-25T10:00:00Z",
+      "roundId": "group-r2",
+      "venueId": "ahmad-bin-ali-stadium",
+      "attendance": 40875
     },
     {
       "kind": "group",
@@ -276,8 +310,10 @@
       "homeTeamId": "QAT",
       "awayTeamId": "SEN",
       "id": 18,
-      "playedOn": "2022-11-25T14:00:00Z",
-      "roundId": "group-r2"
+      "playedOn": "2022-11-25T13:00:00Z",
+      "roundId": "group-r2",
+      "venueId": "al-thumama-stadium",
+      "attendance": 41797
     },
     {
       "kind": "group",
@@ -285,8 +321,10 @@
       "homeTeamId": "NED",
       "awayTeamId": "ECU",
       "id": 19,
-      "playedOn": "2022-11-25T17:00:00Z",
-      "roundId": "group-r2"
+      "playedOn": "2022-11-25T16:00:00Z",
+      "roundId": "group-r2",
+      "venueId": "khalifa-international-stadium",
+      "attendance": 44833
     },
     {
       "kind": "group",
@@ -294,8 +332,10 @@
       "homeTeamId": "ENG",
       "awayTeamId": "USA",
       "id": 20,
-      "playedOn": "2022-11-25T20:00:00Z",
-      "roundId": "group-r2"
+      "playedOn": "2022-11-25T19:00:00Z",
+      "roundId": "group-r2",
+      "venueId": "al-bayt-stadium",
+      "attendance": 68463
     },
     {
       "kind": "group",
@@ -303,8 +343,10 @@
       "homeTeamId": "TUN",
       "awayTeamId": "AUS",
       "id": 21,
-      "playedOn": "2022-11-26T11:00:00Z",
-      "roundId": "group-r2"
+      "playedOn": "2022-11-26T10:00:00Z",
+      "roundId": "group-r2",
+      "venueId": "al-janoub-stadium",
+      "attendance": 41823
     },
     {
       "kind": "group",
@@ -312,8 +354,10 @@
       "homeTeamId": "POL",
       "awayTeamId": "KSA",
       "id": 22,
-      "playedOn": "2022-11-26T14:00:00Z",
-      "roundId": "group-r2"
+      "playedOn": "2022-11-26T13:00:00Z",
+      "roundId": "group-r2",
+      "venueId": "education-city-stadium",
+      "attendance": 44259
     },
     {
       "kind": "group",
@@ -321,8 +365,10 @@
       "homeTeamId": "FRA",
       "awayTeamId": "DEN",
       "id": 23,
-      "playedOn": "2022-11-26T17:00:00Z",
-      "roundId": "group-r2"
+      "playedOn": "2022-11-26T16:00:00Z",
+      "roundId": "group-r2",
+      "venueId": "stadium-974",
+      "attendance": 42860
     },
     {
       "kind": "group",
@@ -330,8 +376,10 @@
       "homeTeamId": "ARG",
       "awayTeamId": "MEX",
       "id": 24,
-      "playedOn": "2022-11-26T20:00:00Z",
-      "roundId": "group-r2"
+      "playedOn": "2022-11-26T19:00:00Z",
+      "roundId": "group-r2",
+      "venueId": "lusail-stadium",
+      "attendance": 88966
     },
     {
       "kind": "group",
@@ -339,8 +387,10 @@
       "homeTeamId": "JPN",
       "awayTeamId": "CRC",
       "id": 25,
-      "playedOn": "2022-11-27T11:00:00Z",
-      "roundId": "group-r2"
+      "playedOn": "2022-11-27T10:00:00Z",
+      "roundId": "group-r2",
+      "venueId": "ahmad-bin-ali-stadium",
+      "attendance": 41479
     },
     {
       "kind": "group",
@@ -348,8 +398,10 @@
       "homeTeamId": "BEL",
       "awayTeamId": "MAR",
       "id": 26,
-      "playedOn": "2022-11-27T14:00:00Z",
-      "roundId": "group-r2"
+      "playedOn": "2022-11-27T13:00:00Z",
+      "roundId": "group-r2",
+      "venueId": "al-thumama-stadium",
+      "attendance": 43738
     },
     {
       "kind": "group",
@@ -357,8 +409,10 @@
       "homeTeamId": "CRO",
       "awayTeamId": "CAN",
       "id": 27,
-      "playedOn": "2022-11-27T17:00:00Z",
-      "roundId": "group-r2"
+      "playedOn": "2022-11-27T16:00:00Z",
+      "roundId": "group-r2",
+      "venueId": "khalifa-international-stadium",
+      "attendance": 44374
     },
     {
       "kind": "group",
@@ -366,8 +420,10 @@
       "homeTeamId": "ESP",
       "awayTeamId": "GER",
       "id": 28,
-      "playedOn": "2022-11-27T20:00:00Z",
-      "roundId": "group-r2"
+      "playedOn": "2022-11-27T19:00:00Z",
+      "roundId": "group-r2",
+      "venueId": "al-bayt-stadium",
+      "attendance": 68895
     },
     {
       "kind": "group",
@@ -375,8 +431,10 @@
       "homeTeamId": "CMR",
       "awayTeamId": "SRB",
       "id": 29,
-      "playedOn": "2022-11-28T11:00:00Z",
-      "roundId": "group-r2"
+      "playedOn": "2022-11-28T10:00:00Z",
+      "roundId": "group-r2",
+      "venueId": "al-janoub-stadium",
+      "attendance": 39789
     },
     {
       "kind": "group",
@@ -384,8 +442,10 @@
       "homeTeamId": "KOR",
       "awayTeamId": "GHA",
       "id": 30,
-      "playedOn": "2022-11-28T14:00:00Z",
-      "roundId": "group-r2"
+      "playedOn": "2022-11-28T13:00:00Z",
+      "roundId": "group-r2",
+      "venueId": "education-city-stadium",
+      "attendance": 43983
     },
     {
       "kind": "group",
@@ -393,8 +453,10 @@
       "homeTeamId": "BRA",
       "awayTeamId": "SUI",
       "id": 31,
-      "playedOn": "2022-11-28T17:00:00Z",
-      "roundId": "group-r2"
+      "playedOn": "2022-11-28T16:00:00Z",
+      "roundId": "group-r2",
+      "venueId": "stadium-974",
+      "attendance": 43649
     },
     {
       "kind": "group",
@@ -402,8 +464,10 @@
       "homeTeamId": "POR",
       "awayTeamId": "URU",
       "id": 32,
-      "playedOn": "2022-11-28T20:00:00Z",
-      "roundId": "group-r2"
+      "playedOn": "2022-11-28T19:00:00Z",
+      "roundId": "group-r2",
+      "venueId": "lusail-stadium",
+      "attendance": 88668
     },
     {
       "kind": "group",
@@ -411,8 +475,10 @@
       "homeTeamId": "NED",
       "awayTeamId": "QAT",
       "id": 33,
-      "playedOn": "2022-11-29T16:00:00Z",
-      "roundId": "group-r3"
+      "playedOn": "2022-11-29T15:00:00Z",
+      "roundId": "group-r3",
+      "venueId": "al-bayt-stadium",
+      "attendance": 66784
     },
     {
       "kind": "group",
@@ -420,8 +486,10 @@
       "homeTeamId": "ECU",
       "awayTeamId": "SEN",
       "id": 34,
-      "playedOn": "2022-11-29T16:00:00Z",
-      "roundId": "group-r3"
+      "playedOn": "2022-11-29T15:00:00Z",
+      "roundId": "group-r3",
+      "venueId": "khalifa-international-stadium",
+      "attendance": 44569
     },
     {
       "kind": "group",
@@ -429,8 +497,10 @@
       "homeTeamId": "IRN",
       "awayTeamId": "USA",
       "id": 35,
-      "playedOn": "2022-11-29T20:00:00Z",
-      "roundId": "group-r3"
+      "playedOn": "2022-11-29T19:00:00Z",
+      "roundId": "group-r3",
+      "venueId": "al-thumama-stadium",
+      "attendance": 42127
     },
     {
       "kind": "group",
@@ -438,8 +508,10 @@
       "homeTeamId": "WAL",
       "awayTeamId": "ENG",
       "id": 36,
-      "playedOn": "2022-11-29T20:00:00Z",
-      "roundId": "group-r3"
+      "playedOn": "2022-11-29T19:00:00Z",
+      "roundId": "group-r3",
+      "venueId": "ahmad-bin-ali-stadium",
+      "attendance": 44297
     },
     {
       "kind": "group",
@@ -447,8 +519,10 @@
       "homeTeamId": "TUN",
       "awayTeamId": "FRA",
       "id": 37,
-      "playedOn": "2022-11-30T16:00:00Z",
-      "roundId": "group-r3"
+      "playedOn": "2022-11-30T15:00:00Z",
+      "roundId": "group-r3",
+      "venueId": "education-city-stadium",
+      "attendance": 43627
     },
     {
       "kind": "group",
@@ -456,8 +530,10 @@
       "homeTeamId": "AUS",
       "awayTeamId": "DEN",
       "id": 38,
-      "playedOn": "2022-11-30T16:00:00Z",
-      "roundId": "group-r3"
+      "playedOn": "2022-11-30T15:00:00Z",
+      "roundId": "group-r3",
+      "venueId": "al-janoub-stadium",
+      "attendance": 41232
     },
     {
       "kind": "group",
@@ -465,8 +541,10 @@
       "homeTeamId": "KSA",
       "awayTeamId": "MEX",
       "id": 39,
-      "playedOn": "2022-11-30T20:00:00Z",
-      "roundId": "group-r3"
+      "playedOn": "2022-11-30T19:00:00Z",
+      "roundId": "group-r3",
+      "venueId": "lusail-stadium",
+      "attendance": 84985
     },
     {
       "kind": "group",
@@ -474,8 +552,10 @@
       "homeTeamId": "POL",
       "awayTeamId": "ARG",
       "id": 40,
-      "playedOn": "2022-11-30T20:00:00Z",
-      "roundId": "group-r3"
+      "playedOn": "2022-11-30T19:00:00Z",
+      "roundId": "group-r3",
+      "venueId": "stadium-974",
+      "attendance": 44089
     },
     {
       "kind": "group",
@@ -483,8 +563,10 @@
       "homeTeamId": "CAN",
       "awayTeamId": "MAR",
       "id": 41,
-      "playedOn": "2022-12-01T16:00:00Z",
-      "roundId": "group-r3"
+      "playedOn": "2022-12-01T15:00:00Z",
+      "roundId": "group-r3",
+      "venueId": "al-thumama-stadium",
+      "attendance": 43102
     },
     {
       "kind": "group",
@@ -492,8 +574,10 @@
       "homeTeamId": "CRO",
       "awayTeamId": "BEL",
       "id": 42,
-      "playedOn": "2022-12-01T16:00:00Z",
-      "roundId": "group-r3"
+      "playedOn": "2022-12-01T15:00:00Z",
+      "roundId": "group-r3",
+      "venueId": "ahmad-bin-ali-stadium",
+      "attendance": 43984
     },
     {
       "kind": "group",
@@ -501,8 +585,10 @@
       "homeTeamId": "CRC",
       "awayTeamId": "GER",
       "id": 43,
-      "playedOn": "2022-12-01T20:00:00Z",
-      "roundId": "group-r3"
+      "playedOn": "2022-12-01T19:00:00Z",
+      "roundId": "group-r3",
+      "venueId": "al-bayt-stadium",
+      "attendance": 67054
     },
     {
       "kind": "group",
@@ -510,8 +596,10 @@
       "homeTeamId": "JPN",
       "awayTeamId": "ESP",
       "id": 44,
-      "playedOn": "2022-12-01T20:00:00Z",
-      "roundId": "group-r3"
+      "playedOn": "2022-12-01T19:00:00Z",
+      "roundId": "group-r3",
+      "venueId": "khalifa-international-stadium",
+      "attendance": 44851
     },
     {
       "kind": "group",
@@ -519,8 +607,10 @@
       "homeTeamId": "GHA",
       "awayTeamId": "URU",
       "id": 45,
-      "playedOn": "2022-12-02T16:00:00Z",
-      "roundId": "group-r3"
+      "playedOn": "2022-12-02T15:00:00Z",
+      "roundId": "group-r3",
+      "venueId": "al-janoub-stadium",
+      "attendance": 43443
     },
     {
       "kind": "group",
@@ -528,8 +618,10 @@
       "homeTeamId": "KOR",
       "awayTeamId": "POR",
       "id": 46,
-      "playedOn": "2022-12-02T16:00:00Z",
-      "roundId": "group-r3"
+      "playedOn": "2022-12-02T15:00:00Z",
+      "roundId": "group-r3",
+      "venueId": "education-city-stadium",
+      "attendance": 44097
     },
     {
       "kind": "group",
@@ -537,8 +629,10 @@
       "homeTeamId": "SRB",
       "awayTeamId": "SUI",
       "id": 47,
-      "playedOn": "2022-12-02T20:00:00Z",
-      "roundId": "group-r3"
+      "playedOn": "2022-12-02T19:00:00Z",
+      "roundId": "group-r3",
+      "venueId": "stadium-974",
+      "attendance": 41378
     },
     {
       "kind": "group",
@@ -546,136 +640,170 @@
       "homeTeamId": "CMR",
       "awayTeamId": "BRA",
       "id": 48,
-      "playedOn": "2022-12-02T20:00:00Z",
-      "roundId": "group-r3"
+      "playedOn": "2022-12-02T19:00:00Z",
+      "roundId": "group-r3",
+      "venueId": "lusail-stadium",
+      "attendance": 85986
     },
     {
       "kind": "ko",
       "homeQual": "A1",
       "awayQual": "B2",
       "id": 49,
-      "playedOn": "2022-12-03T16:00:00Z",
-      "roundId": "r16"
+      "playedOn": "2022-12-03T15:00:00Z",
+      "roundId": "r16",
+      "venueId": "khalifa-international-stadium",
+      "attendance": 44846
     },
     {
       "kind": "ko",
       "homeQual": "C1",
       "awayQual": "D2",
       "id": 50,
-      "playedOn": "2022-12-03T20:00:00Z",
-      "roundId": "r16"
+      "playedOn": "2022-12-03T19:00:00Z",
+      "roundId": "r16",
+      "venueId": "ahmad-bin-ali-stadium",
+      "attendance": 45032
     },
     {
       "kind": "ko",
       "homeQual": "D1",
       "awayQual": "C2",
       "id": 51,
-      "playedOn": "2022-12-04T16:00:00Z",
-      "roundId": "r16"
+      "playedOn": "2022-12-04T15:00:00Z",
+      "roundId": "r16",
+      "venueId": "al-thumama-stadium",
+      "attendance": 40989
     },
     {
       "kind": "ko",
       "homeQual": "B1",
       "awayQual": "A2",
       "id": 52,
-      "playedOn": "2022-12-04T20:00:00Z",
-      "roundId": "r16"
+      "playedOn": "2022-12-04T19:00:00Z",
+      "roundId": "r16",
+      "venueId": "al-bayt-stadium",
+      "attendance": 65985
     },
     {
       "kind": "ko",
       "homeQual": "E1",
       "awayQual": "F2",
       "id": 53,
-      "playedOn": "2022-12-05T16:00:00Z",
-      "roundId": "r16"
+      "playedOn": "2022-12-05T15:00:00Z",
+      "roundId": "r16",
+      "venueId": "al-janoub-stadium",
+      "attendance": 42523
     },
     {
       "kind": "ko",
       "homeQual": "G1",
       "awayQual": "H2",
       "id": 54,
-      "playedOn": "2022-12-05T20:00:00Z",
-      "roundId": "r16"
+      "playedOn": "2022-12-05T19:00:00Z",
+      "roundId": "r16",
+      "venueId": "stadium-974",
+      "attendance": 43847
     },
     {
       "kind": "ko",
       "homeQual": "F1",
       "awayQual": "E2",
       "id": 55,
-      "playedOn": "2022-12-06T16:00:00Z",
-      "roundId": "r16"
+      "playedOn": "2022-12-06T15:00:00Z",
+      "roundId": "r16",
+      "venueId": "education-city-stadium",
+      "attendance": 44667
     },
     {
       "kind": "ko",
       "homeQual": "H1",
       "awayQual": "G2",
       "id": 56,
-      "playedOn": "2022-12-06T20:00:00Z",
-      "roundId": "r16"
+      "playedOn": "2022-12-06T19:00:00Z",
+      "roundId": "r16",
+      "venueId": "lusail-stadium",
+      "attendance": 83720
     },
     {
       "kind": "ko",
       "homeQual": "W-53",
       "awayQual": "W-54",
       "id": 57,
-      "playedOn": "2022-12-09T16:00:00Z",
-      "roundId": "qf"
+      "playedOn": "2022-12-09T15:00:00Z",
+      "roundId": "qf",
+      "venueId": "education-city-stadium",
+      "attendance": 43893
     },
     {
       "kind": "ko",
       "homeQual": "W-49",
       "awayQual": "W-50",
       "id": 58,
-      "playedOn": "2022-12-09T20:00:00Z",
-      "roundId": "qf"
+      "playedOn": "2022-12-09T19:00:00Z",
+      "roundId": "qf",
+      "venueId": "lusail-stadium",
+      "attendance": 88235
     },
     {
       "kind": "ko",
       "homeQual": "W-55",
       "awayQual": "W-56",
       "id": 59,
-      "playedOn": "2022-12-10T16:00:00Z",
-      "roundId": "qf"
+      "playedOn": "2022-12-10T15:00:00Z",
+      "roundId": "qf",
+      "venueId": "al-thumama-stadium",
+      "attendance": 44198
     },
     {
       "kind": "ko",
       "homeQual": "W-51",
       "awayQual": "W-52",
       "id": 60,
-      "playedOn": "2022-12-10T20:00:00Z",
-      "roundId": "qf"
+      "playedOn": "2022-12-10T19:00:00Z",
+      "roundId": "qf",
+      "venueId": "al-bayt-stadium",
+      "attendance": 68895
     },
     {
       "kind": "ko",
       "homeQual": "W-57",
       "awayQual": "W-58",
       "id": 61,
-      "playedOn": "2022-12-13T16:00:00Z",
-      "roundId": "sf"
+      "playedOn": "2022-12-13T19:00:00Z",
+      "roundId": "sf",
+      "venueId": "lusail-stadium",
+      "attendance": 88966
     },
     {
       "kind": "ko",
       "homeQual": "W-59",
       "awayQual": "W-60",
       "id": 62,
-      "playedOn": "2022-12-14T16:00:00Z",
-      "roundId": "sf"
+      "playedOn": "2022-12-14T19:00:00Z",
+      "roundId": "sf",
+      "venueId": "al-bayt-stadium",
+      "attendance": 68294
     },
     {
       "kind": "ko",
       "homeQual": "L-61",
       "awayQual": "L-62",
       "id": 63,
-      "playedOn": "2022-12-17T16:00:00Z",
-      "roundId": "third"
+      "playedOn": "2022-12-17T15:00:00Z",
+      "roundId": "third",
+      "venueId": "khalifa-international-stadium",
+      "attendance": 44137
     },
     {
       "kind": "ko",
       "homeQual": "W-61",
       "awayQual": "W-62",
       "id": 64,
-      "playedOn": "2022-12-18T16:00:00Z",
-      "roundId": "final"
+      "playedOn": "2022-12-18T15:00:00Z",
+      "roundId": "final",
+      "venueId": "lusail-stadium",
+      "attendance": 88966
     }
   ]
 }

--- a/src/FantasyFootball.Core/Definitions/wm-2026.json
+++ b/src/FantasyFootball.Core/Definitions/wm-2026.json
@@ -154,7 +154,8 @@
       "awayTeamId": "RSA",
       "id": 1,
       "playedOn": "2026-06-11T15:00:00Z",
-      "roundId": "group-r1"
+      "roundId": "group-r1",
+      "venueId": "banorte-stadium"
     },
     {
       "kind": "group",
@@ -163,7 +164,8 @@
       "awayTeamId": "CZE",
       "id": 2,
       "playedOn": "2026-06-11T22:00:00Z",
-      "roundId": "group-r1"
+      "roundId": "group-r1",
+      "venueId": "estadio-akron"
     },
     {
       "kind": "group",
@@ -172,7 +174,8 @@
       "awayTeamId": "BIH",
       "id": 3,
       "playedOn": "2026-06-12T15:00:00Z",
-      "roundId": "group-r1"
+      "roundId": "group-r1",
+      "venueId": "bmo-field"
     },
     {
       "kind": "group",
@@ -181,7 +184,8 @@
       "awayTeamId": "PAR",
       "id": 4,
       "playedOn": "2026-06-12T21:00:00Z",
-      "roundId": "group-r1"
+      "roundId": "group-r1",
+      "venueId": "sofi-stadium"
     },
     {
       "kind": "group",
@@ -190,7 +194,8 @@
       "awayTeamId": "SUI",
       "id": 5,
       "playedOn": "2026-06-13T15:00:00Z",
-      "roundId": "group-r1"
+      "roundId": "group-r1",
+      "venueId": "levi-s-stadium"
     },
     {
       "kind": "group",
@@ -199,7 +204,8 @@
       "awayTeamId": "MAR",
       "id": 6,
       "playedOn": "2026-06-13T18:00:00Z",
-      "roundId": "group-r1"
+      "roundId": "group-r1",
+      "venueId": "metlife-stadium"
     },
     {
       "kind": "group",
@@ -208,7 +214,8 @@
       "awayTeamId": "SCO",
       "id": 7,
       "playedOn": "2026-06-13T21:00:00Z",
-      "roundId": "group-r1"
+      "roundId": "group-r1",
+      "venueId": "gillette-stadium"
     },
     {
       "kind": "group",
@@ -217,7 +224,8 @@
       "awayTeamId": "TUR",
       "id": 8,
       "playedOn": "2026-06-14T00:00:00Z",
-      "roundId": "group-r1"
+      "roundId": "group-r1",
+      "venueId": "bc-place"
     },
     {
       "kind": "group",
@@ -226,7 +234,8 @@
       "awayTeamId": "CUW",
       "id": 9,
       "playedOn": "2026-06-14T13:00:00Z",
-      "roundId": "group-r1"
+      "roundId": "group-r1",
+      "venueId": "nrg-stadium"
     },
     {
       "kind": "group",
@@ -235,7 +244,8 @@
       "awayTeamId": "JPN",
       "id": 10,
       "playedOn": "2026-06-14T16:00:00Z",
-      "roundId": "group-r1"
+      "roundId": "group-r1",
+      "venueId": "at-t-stadium"
     },
     {
       "kind": "group",
@@ -244,7 +254,8 @@
       "awayTeamId": "ECU",
       "id": 11,
       "playedOn": "2026-06-14T19:00:00Z",
-      "roundId": "group-r1"
+      "roundId": "group-r1",
+      "venueId": "lincoln-financial-field"
     },
     {
       "kind": "group",
@@ -253,7 +264,8 @@
       "awayTeamId": "TUN",
       "id": 12,
       "playedOn": "2026-06-14T22:00:00Z",
-      "roundId": "group-r1"
+      "roundId": "group-r1",
+      "venueId": "estadio-monterrey"
     },
     {
       "kind": "group",
@@ -262,7 +274,8 @@
       "awayTeamId": "CPV",
       "id": 13,
       "playedOn": "2026-06-15T12:00:00Z",
-      "roundId": "group-r1"
+      "roundId": "group-r1",
+      "venueId": "mercedes-benz-stadium"
     },
     {
       "kind": "group",
@@ -271,7 +284,8 @@
       "awayTeamId": "EGY",
       "id": 14,
       "playedOn": "2026-06-15T15:00:00Z",
-      "roundId": "group-r1"
+      "roundId": "group-r1",
+      "venueId": "lumen-field"
     },
     {
       "kind": "group",
@@ -280,7 +294,8 @@
       "awayTeamId": "URU",
       "id": 15,
       "playedOn": "2026-06-15T18:00:00Z",
-      "roundId": "group-r1"
+      "roundId": "group-r1",
+      "venueId": "hard-rock-stadium"
     },
     {
       "kind": "group",
@@ -289,7 +304,8 @@
       "awayTeamId": "NZL",
       "id": 16,
       "playedOn": "2026-06-15T21:00:00Z",
-      "roundId": "group-r1"
+      "roundId": "group-r1",
+      "venueId": "sofi-stadium"
     },
     {
       "kind": "group",
@@ -298,7 +314,8 @@
       "awayTeamId": "SEN",
       "id": 17,
       "playedOn": "2026-06-16T15:00:00Z",
-      "roundId": "group-r1"
+      "roundId": "group-r1",
+      "venueId": "metlife-stadium"
     },
     {
       "kind": "group",
@@ -307,7 +324,8 @@
       "awayTeamId": "NOR",
       "id": 18,
       "playedOn": "2026-06-16T18:00:00Z",
-      "roundId": "group-r1"
+      "roundId": "group-r1",
+      "venueId": "gillette-stadium"
     },
     {
       "kind": "group",
@@ -316,7 +334,8 @@
       "awayTeamId": "ALG",
       "id": 19,
       "playedOn": "2026-06-16T21:00:00Z",
-      "roundId": "group-r1"
+      "roundId": "group-r1",
+      "venueId": "arrowhead-stadium"
     },
     {
       "kind": "group",
@@ -325,7 +344,8 @@
       "awayTeamId": "JOR",
       "id": 20,
       "playedOn": "2026-06-17T00:00:00Z",
-      "roundId": "group-r1"
+      "roundId": "group-r1",
+      "venueId": "levi-s-stadium"
     },
     {
       "kind": "group",
@@ -334,7 +354,8 @@
       "awayTeamId": "COD",
       "id": 21,
       "playedOn": "2026-06-17T13:00:00Z",
-      "roundId": "group-r1"
+      "roundId": "group-r1",
+      "venueId": "nrg-stadium"
     },
     {
       "kind": "group",
@@ -343,7 +364,8 @@
       "awayTeamId": "CRO",
       "id": 22,
       "playedOn": "2026-06-17T16:00:00Z",
-      "roundId": "group-r1"
+      "roundId": "group-r1",
+      "venueId": "at-t-stadium"
     },
     {
       "kind": "group",
@@ -352,7 +374,8 @@
       "awayTeamId": "PAN",
       "id": 23,
       "playedOn": "2026-06-17T19:00:00Z",
-      "roundId": "group-r1"
+      "roundId": "group-r1",
+      "venueId": "bmo-field"
     },
     {
       "kind": "group",
@@ -361,7 +384,8 @@
       "awayTeamId": "COL",
       "id": 24,
       "playedOn": "2026-06-17T22:00:00Z",
-      "roundId": "group-r1"
+      "roundId": "group-r1",
+      "venueId": "banorte-stadium"
     },
     {
       "kind": "group",
@@ -370,7 +394,8 @@
       "awayTeamId": "RSA",
       "id": 25,
       "playedOn": "2026-06-18T12:00:00Z",
-      "roundId": "group-r2"
+      "roundId": "group-r2",
+      "venueId": "mercedes-benz-stadium"
     },
     {
       "kind": "group",
@@ -379,7 +404,8 @@
       "awayTeamId": "BIH",
       "id": 26,
       "playedOn": "2026-06-18T15:00:00Z",
-      "roundId": "group-r2"
+      "roundId": "group-r2",
+      "venueId": "sofi-stadium"
     },
     {
       "kind": "group",
@@ -388,7 +414,8 @@
       "awayTeamId": "QAT",
       "id": 27,
       "playedOn": "2026-06-18T18:00:00Z",
-      "roundId": "group-r2"
+      "roundId": "group-r2",
+      "venueId": "bc-place"
     },
     {
       "kind": "group",
@@ -397,7 +424,8 @@
       "awayTeamId": "KOR",
       "id": 28,
       "playedOn": "2026-06-18T21:00:00Z",
-      "roundId": "group-r2"
+      "roundId": "group-r2",
+      "venueId": "estadio-akron"
     },
     {
       "kind": "group",
@@ -406,7 +434,8 @@
       "awayTeamId": "AUS",
       "id": 29,
       "playedOn": "2026-06-19T15:00:00Z",
-      "roundId": "group-r2"
+      "roundId": "group-r2",
+      "venueId": "lumen-field"
     },
     {
       "kind": "group",
@@ -415,7 +444,8 @@
       "awayTeamId": "MAR",
       "id": 30,
       "playedOn": "2026-06-19T18:00:00Z",
-      "roundId": "group-r2"
+      "roundId": "group-r2",
+      "venueId": "gillette-stadium"
     },
     {
       "kind": "group",
@@ -424,7 +454,8 @@
       "awayTeamId": "HAI",
       "id": 31,
       "playedOn": "2026-06-19T20:30:00Z",
-      "roundId": "group-r2"
+      "roundId": "group-r2",
+      "venueId": "lincoln-financial-field"
     },
     {
       "kind": "group",
@@ -433,7 +464,8 @@
       "awayTeamId": "PAR",
       "id": 32,
       "playedOn": "2026-06-19T23:00:00Z",
-      "roundId": "group-r2"
+      "roundId": "group-r2",
+      "venueId": "levi-s-stadium"
     },
     {
       "kind": "group",
@@ -442,7 +474,8 @@
       "awayTeamId": "SWE",
       "id": 33,
       "playedOn": "2026-06-20T13:00:00Z",
-      "roundId": "group-r2"
+      "roundId": "group-r2",
+      "venueId": "nrg-stadium"
     },
     {
       "kind": "group",
@@ -451,7 +484,8 @@
       "awayTeamId": "CIV",
       "id": 34,
       "playedOn": "2026-06-20T16:00:00Z",
-      "roundId": "group-r2"
+      "roundId": "group-r2",
+      "venueId": "bmo-field"
     },
     {
       "kind": "group",
@@ -460,7 +494,8 @@
       "awayTeamId": "CUW",
       "id": 35,
       "playedOn": "2026-06-20T20:00:00Z",
-      "roundId": "group-r2"
+      "roundId": "group-r2",
+      "venueId": "arrowhead-stadium"
     },
     {
       "kind": "group",
@@ -469,7 +504,8 @@
       "awayTeamId": "JPN",
       "id": 36,
       "playedOn": "2026-06-21T00:00:00Z",
-      "roundId": "group-r2"
+      "roundId": "group-r2",
+      "venueId": "estadio-monterrey"
     },
     {
       "kind": "group",
@@ -478,7 +514,8 @@
       "awayTeamId": "KSA",
       "id": 37,
       "playedOn": "2026-06-21T12:00:00Z",
-      "roundId": "group-r2"
+      "roundId": "group-r2",
+      "venueId": "mercedes-benz-stadium"
     },
     {
       "kind": "group",
@@ -487,7 +524,8 @@
       "awayTeamId": "IRN",
       "id": 38,
       "playedOn": "2026-06-21T15:00:00Z",
-      "roundId": "group-r2"
+      "roundId": "group-r2",
+      "venueId": "sofi-stadium"
     },
     {
       "kind": "group",
@@ -496,7 +534,8 @@
       "awayTeamId": "CPV",
       "id": 39,
       "playedOn": "2026-06-21T18:00:00Z",
-      "roundId": "group-r2"
+      "roundId": "group-r2",
+      "venueId": "hard-rock-stadium"
     },
     {
       "kind": "group",
@@ -505,7 +544,8 @@
       "awayTeamId": "EGY",
       "id": 40,
       "playedOn": "2026-06-21T21:00:00Z",
-      "roundId": "group-r2"
+      "roundId": "group-r2",
+      "venueId": "bc-place"
     },
     {
       "kind": "group",
@@ -514,7 +554,8 @@
       "awayTeamId": "AUT",
       "id": 41,
       "playedOn": "2026-06-22T13:00:00Z",
-      "roundId": "group-r2"
+      "roundId": "group-r2",
+      "venueId": "at-t-stadium"
     },
     {
       "kind": "group",
@@ -523,7 +564,8 @@
       "awayTeamId": "IRQ",
       "id": 42,
       "playedOn": "2026-06-22T17:00:00Z",
-      "roundId": "group-r2"
+      "roundId": "group-r2",
+      "venueId": "lincoln-financial-field"
     },
     {
       "kind": "group",
@@ -532,7 +574,8 @@
       "awayTeamId": "SEN",
       "id": 43,
       "playedOn": "2026-06-22T20:00:00Z",
-      "roundId": "group-r2"
+      "roundId": "group-r2",
+      "venueId": "metlife-stadium"
     },
     {
       "kind": "group",
@@ -541,7 +584,8 @@
       "awayTeamId": "ALG",
       "id": 44,
       "playedOn": "2026-06-22T23:00:00Z",
-      "roundId": "group-r2"
+      "roundId": "group-r2",
+      "venueId": "levi-s-stadium"
     },
     {
       "kind": "group",
@@ -550,7 +594,8 @@
       "awayTeamId": "UZB",
       "id": 45,
       "playedOn": "2026-06-23T13:00:00Z",
-      "roundId": "group-r2"
+      "roundId": "group-r2",
+      "venueId": "nrg-stadium"
     },
     {
       "kind": "group",
@@ -559,7 +604,8 @@
       "awayTeamId": "GHA",
       "id": 46,
       "playedOn": "2026-06-23T16:00:00Z",
-      "roundId": "group-r2"
+      "roundId": "group-r2",
+      "venueId": "gillette-stadium"
     },
     {
       "kind": "group",
@@ -568,7 +614,8 @@
       "awayTeamId": "CRO",
       "id": 47,
       "playedOn": "2026-06-23T19:00:00Z",
-      "roundId": "group-r2"
+      "roundId": "group-r2",
+      "venueId": "bmo-field"
     },
     {
       "kind": "group",
@@ -577,7 +624,8 @@
       "awayTeamId": "COD",
       "id": 48,
       "playedOn": "2026-06-23T22:00:00Z",
-      "roundId": "group-r2"
+      "roundId": "group-r2",
+      "venueId": "estadio-akron"
     },
     {
       "kind": "group",
@@ -586,7 +634,8 @@
       "awayTeamId": "CAN",
       "id": 49,
       "playedOn": "2026-06-24T15:00:00Z",
-      "roundId": "group-r3"
+      "roundId": "group-r3",
+      "venueId": "bc-place"
     },
     {
       "kind": "group",
@@ -595,7 +644,8 @@
       "awayTeamId": "QAT",
       "id": 50,
       "playedOn": "2026-06-24T15:00:00Z",
-      "roundId": "group-r3"
+      "roundId": "group-r3",
+      "venueId": "lumen-field"
     },
     {
       "kind": "group",
@@ -604,7 +654,8 @@
       "awayTeamId": "HAI",
       "id": 51,
       "playedOn": "2026-06-24T18:00:00Z",
-      "roundId": "group-r3"
+      "roundId": "group-r3",
+      "venueId": "hard-rock-stadium"
     },
     {
       "kind": "group",
@@ -613,7 +664,8 @@
       "awayTeamId": "BRA",
       "id": 52,
       "playedOn": "2026-06-24T18:00:00Z",
-      "roundId": "group-r3"
+      "roundId": "group-r3",
+      "venueId": "mercedes-benz-stadium"
     },
     {
       "kind": "group",
@@ -622,7 +674,8 @@
       "awayTeamId": "KOR",
       "id": 53,
       "playedOn": "2026-06-24T21:00:00Z",
-      "roundId": "group-r3"
+      "roundId": "group-r3",
+      "venueId": "banorte-stadium"
     },
     {
       "kind": "group",
@@ -631,7 +684,8 @@
       "awayTeamId": "MEX",
       "id": 54,
       "playedOn": "2026-06-24T21:00:00Z",
-      "roundId": "group-r3"
+      "roundId": "group-r3",
+      "venueId": "estadio-monterrey"
     },
     {
       "kind": "group",
@@ -640,7 +694,8 @@
       "awayTeamId": "CIV",
       "id": 55,
       "playedOn": "2026-06-25T16:00:00Z",
-      "roundId": "group-r3"
+      "roundId": "group-r3",
+      "venueId": "lincoln-financial-field"
     },
     {
       "kind": "group",
@@ -649,7 +704,8 @@
       "awayTeamId": "GER",
       "id": 56,
       "playedOn": "2026-06-25T16:00:00Z",
-      "roundId": "group-r3"
+      "roundId": "group-r3",
+      "venueId": "metlife-stadium"
     },
     {
       "kind": "group",
@@ -658,7 +714,8 @@
       "awayTeamId": "NED",
       "id": 57,
       "playedOn": "2026-06-25T19:00:00Z",
-      "roundId": "group-r3"
+      "roundId": "group-r3",
+      "venueId": "at-t-stadium"
     },
     {
       "kind": "group",
@@ -667,7 +724,8 @@
       "awayTeamId": "SWE",
       "id": 58,
       "playedOn": "2026-06-25T19:00:00Z",
-      "roundId": "group-r3"
+      "roundId": "group-r3",
+      "venueId": "arrowhead-stadium"
     },
     {
       "kind": "group",
@@ -676,7 +734,8 @@
       "awayTeamId": "USA",
       "id": 59,
       "playedOn": "2026-06-25T22:00:00Z",
-      "roundId": "group-r3"
+      "roundId": "group-r3",
+      "venueId": "sofi-stadium"
     },
     {
       "kind": "group",
@@ -685,7 +744,8 @@
       "awayTeamId": "AUS",
       "id": 60,
       "playedOn": "2026-06-25T22:00:00Z",
-      "roundId": "group-r3"
+      "roundId": "group-r3",
+      "venueId": "levi-s-stadium"
     },
     {
       "kind": "group",
@@ -694,7 +754,8 @@
       "awayTeamId": "FRA",
       "id": 61,
       "playedOn": "2026-06-26T15:00:00Z",
-      "roundId": "group-r3"
+      "roundId": "group-r3",
+      "venueId": "gillette-stadium"
     },
     {
       "kind": "group",
@@ -703,7 +764,8 @@
       "awayTeamId": "IRQ",
       "id": 62,
       "playedOn": "2026-06-26T15:00:00Z",
-      "roundId": "group-r3"
+      "roundId": "group-r3",
+      "venueId": "bmo-field"
     },
     {
       "kind": "group",
@@ -712,7 +774,8 @@
       "awayTeamId": "KSA",
       "id": 63,
       "playedOn": "2026-06-26T20:00:00Z",
-      "roundId": "group-r3"
+      "roundId": "group-r3",
+      "venueId": "nrg-stadium"
     },
     {
       "kind": "group",
@@ -721,7 +784,8 @@
       "awayTeamId": "ESP",
       "id": 64,
       "playedOn": "2026-06-26T20:00:00Z",
-      "roundId": "group-r3"
+      "roundId": "group-r3",
+      "venueId": "estadio-akron"
     },
     {
       "kind": "group",
@@ -730,7 +794,8 @@
       "awayTeamId": "BEL",
       "id": 65,
       "playedOn": "2026-06-26T23:00:00Z",
-      "roundId": "group-r3"
+      "roundId": "group-r3",
+      "venueId": "lumen-field"
     },
     {
       "kind": "group",
@@ -739,7 +804,8 @@
       "awayTeamId": "IRN",
       "id": 66,
       "playedOn": "2026-06-26T23:00:00Z",
-      "roundId": "group-r3"
+      "roundId": "group-r3",
+      "venueId": "bc-place"
     },
     {
       "kind": "group",
@@ -748,7 +814,8 @@
       "awayTeamId": "ENG",
       "id": 67,
       "playedOn": "2026-06-27T17:00:00Z",
-      "roundId": "group-r3"
+      "roundId": "group-r3",
+      "venueId": "metlife-stadium"
     },
     {
       "kind": "group",
@@ -757,7 +824,8 @@
       "awayTeamId": "GHA",
       "id": 68,
       "playedOn": "2026-06-27T17:00:00Z",
-      "roundId": "group-r3"
+      "roundId": "group-r3",
+      "venueId": "lincoln-financial-field"
     },
     {
       "kind": "group",
@@ -766,7 +834,8 @@
       "awayTeamId": "POR",
       "id": 69,
       "playedOn": "2026-06-27T19:30:00Z",
-      "roundId": "group-r3"
+      "roundId": "group-r3",
+      "venueId": "hard-rock-stadium"
     },
     {
       "kind": "group",
@@ -775,7 +844,8 @@
       "awayTeamId": "UZB",
       "id": 70,
       "playedOn": "2026-06-27T19:30:00Z",
-      "roundId": "group-r3"
+      "roundId": "group-r3",
+      "venueId": "mercedes-benz-stadium"
     },
     {
       "kind": "group",
@@ -784,7 +854,8 @@
       "awayTeamId": "AUT",
       "id": 71,
       "playedOn": "2026-06-27T22:00:00Z",
-      "roundId": "group-r3"
+      "roundId": "group-r3",
+      "venueId": "arrowhead-stadium"
     },
     {
       "kind": "group",
@@ -793,7 +864,8 @@
       "awayTeamId": "ARG",
       "id": 72,
       "playedOn": "2026-06-27T22:00:00Z",
-      "roundId": "group-r3"
+      "roundId": "group-r3",
+      "venueId": "at-t-stadium"
     },
     {
       "kind": "ko",
@@ -801,7 +873,8 @@
       "awayQual": "B2",
       "id": 73,
       "playedOn": "2026-06-28T15:00:00Z",
-      "roundId": "r32"
+      "roundId": "r32",
+      "venueId": "sofi-stadium"
     },
     {
       "kind": "ko",
@@ -809,7 +882,8 @@
       "awayQual": "F2",
       "id": 74,
       "playedOn": "2026-06-29T13:00:00Z",
-      "roundId": "r32"
+      "roundId": "r32",
+      "venueId": "nrg-stadium"
     },
     {
       "kind": "ko",
@@ -817,7 +891,8 @@
       "awayQual": "A/B/C/D/F3",
       "id": 75,
       "playedOn": "2026-06-29T16:30:00Z",
-      "roundId": "r32"
+      "roundId": "r32",
+      "venueId": "gillette-stadium"
     },
     {
       "kind": "ko",
@@ -825,7 +900,8 @@
       "awayQual": "C2",
       "id": 76,
       "playedOn": "2026-06-29T21:00:00Z",
-      "roundId": "r32"
+      "roundId": "r32",
+      "venueId": "estadio-monterrey"
     },
     {
       "kind": "ko",
@@ -833,7 +909,8 @@
       "awayQual": "I2",
       "id": 77,
       "playedOn": "2026-06-30T13:00:00Z",
-      "roundId": "r32"
+      "roundId": "r32",
+      "venueId": "at-t-stadium"
     },
     {
       "kind": "ko",
@@ -841,7 +918,8 @@
       "awayQual": "C/D/F/G/H3",
       "id": 78,
       "playedOn": "2026-06-30T17:00:00Z",
-      "roundId": "r32"
+      "roundId": "r32",
+      "venueId": "metlife-stadium"
     },
     {
       "kind": "ko",
@@ -849,7 +927,8 @@
       "awayQual": "C/E/F/H/I3",
       "id": 79,
       "playedOn": "2026-06-30T21:00:00Z",
-      "roundId": "r32"
+      "roundId": "r32",
+      "venueId": "banorte-stadium"
     },
     {
       "kind": "ko",
@@ -857,7 +936,8 @@
       "awayQual": "E/H/I/J/K3",
       "id": 80,
       "playedOn": "2026-07-01T12:00:00Z",
-      "roundId": "r32"
+      "roundId": "r32",
+      "venueId": "mercedes-benz-stadium"
     },
     {
       "kind": "ko",
@@ -865,7 +945,8 @@
       "awayQual": "A/E/H/I/J3",
       "id": 81,
       "playedOn": "2026-07-01T16:00:00Z",
-      "roundId": "r32"
+      "roundId": "r32",
+      "venueId": "lumen-field"
     },
     {
       "kind": "ko",
@@ -873,7 +954,8 @@
       "awayQual": "B/E/F/I/J3",
       "id": 82,
       "playedOn": "2026-07-01T20:00:00Z",
-      "roundId": "r32"
+      "roundId": "r32",
+      "venueId": "levi-s-stadium"
     },
     {
       "kind": "ko",
@@ -881,7 +963,8 @@
       "awayQual": "J2",
       "id": 83,
       "playedOn": "2026-07-02T15:00:00Z",
-      "roundId": "r32"
+      "roundId": "r32",
+      "venueId": "sofi-stadium"
     },
     {
       "kind": "ko",
@@ -889,7 +972,8 @@
       "awayQual": "L2",
       "id": 84,
       "playedOn": "2026-07-02T19:00:00Z",
-      "roundId": "r32"
+      "roundId": "r32",
+      "venueId": "bmo-field"
     },
     {
       "kind": "ko",
@@ -897,7 +981,8 @@
       "awayQual": "E/F/G/I/J3",
       "id": 85,
       "playedOn": "2026-07-02T23:00:00Z",
-      "roundId": "r32"
+      "roundId": "r32",
+      "venueId": "bc-place"
     },
     {
       "kind": "ko",
@@ -905,7 +990,8 @@
       "awayQual": "G2",
       "id": 86,
       "playedOn": "2026-07-03T14:00:00Z",
-      "roundId": "r32"
+      "roundId": "r32",
+      "venueId": "at-t-stadium"
     },
     {
       "kind": "ko",
@@ -913,7 +999,8 @@
       "awayQual": "H2",
       "id": 87,
       "playedOn": "2026-07-03T18:00:00Z",
-      "roundId": "r32"
+      "roundId": "r32",
+      "venueId": "hard-rock-stadium"
     },
     {
       "kind": "ko",
@@ -921,7 +1008,8 @@
       "awayQual": "D/E/I/J/L3",
       "id": 88,
       "playedOn": "2026-07-03T21:30:00Z",
-      "roundId": "r32"
+      "roundId": "r32",
+      "venueId": "arrowhead-stadium"
     },
     {
       "kind": "ko",
@@ -929,7 +1017,8 @@
       "awayQual": "W-75",
       "id": 89,
       "playedOn": "2026-07-04T13:00:00Z",
-      "roundId": "r16"
+      "roundId": "r16",
+      "venueId": "nrg-stadium"
     },
     {
       "kind": "ko",
@@ -937,7 +1026,8 @@
       "awayQual": "W-77",
       "id": 90,
       "playedOn": "2026-07-04T17:00:00Z",
-      "roundId": "r16"
+      "roundId": "r16",
+      "venueId": "lincoln-financial-field"
     },
     {
       "kind": "ko",
@@ -945,7 +1035,8 @@
       "awayQual": "W-78",
       "id": 91,
       "playedOn": "2026-07-05T16:00:00Z",
-      "roundId": "r16"
+      "roundId": "r16",
+      "venueId": "metlife-stadium"
     },
     {
       "kind": "ko",
@@ -953,7 +1044,8 @@
       "awayQual": "W-80",
       "id": 92,
       "playedOn": "2026-07-05T20:00:00Z",
-      "roundId": "r16"
+      "roundId": "r16",
+      "venueId": "banorte-stadium"
     },
     {
       "kind": "ko",
@@ -961,7 +1053,8 @@
       "awayQual": "W-84",
       "id": 93,
       "playedOn": "2026-07-06T15:00:00Z",
-      "roundId": "r16"
+      "roundId": "r16",
+      "venueId": "at-t-stadium"
     },
     {
       "kind": "ko",
@@ -969,7 +1062,8 @@
       "awayQual": "W-82",
       "id": 94,
       "playedOn": "2026-07-06T20:00:00Z",
-      "roundId": "r16"
+      "roundId": "r16",
+      "venueId": "lumen-field"
     },
     {
       "kind": "ko",
@@ -977,7 +1071,8 @@
       "awayQual": "W-88",
       "id": 95,
       "playedOn": "2026-07-07T12:00:00Z",
-      "roundId": "r16"
+      "roundId": "r16",
+      "venueId": "mercedes-benz-stadium"
     },
     {
       "kind": "ko",
@@ -985,7 +1080,8 @@
       "awayQual": "W-87",
       "id": 96,
       "playedOn": "2026-07-07T16:00:00Z",
-      "roundId": "r16"
+      "roundId": "r16",
+      "venueId": "bc-place"
     },
     {
       "kind": "ko",
@@ -993,7 +1089,8 @@
       "awayQual": "W-90",
       "id": 97,
       "playedOn": "2026-07-09T16:00:00Z",
-      "roundId": "qf"
+      "roundId": "qf",
+      "venueId": "gillette-stadium"
     },
     {
       "kind": "ko",
@@ -1001,7 +1098,8 @@
       "awayQual": "W-94",
       "id": 98,
       "playedOn": "2026-07-10T15:00:00Z",
-      "roundId": "qf"
+      "roundId": "qf",
+      "venueId": "sofi-stadium"
     },
     {
       "kind": "ko",
@@ -1009,7 +1107,8 @@
       "awayQual": "W-92",
       "id": 99,
       "playedOn": "2026-07-11T17:00:00Z",
-      "roundId": "qf"
+      "roundId": "qf",
+      "venueId": "hard-rock-stadium"
     },
     {
       "kind": "ko",
@@ -1017,7 +1116,8 @@
       "awayQual": "W-96",
       "id": 100,
       "playedOn": "2026-07-11T21:00:00Z",
-      "roundId": "qf"
+      "roundId": "qf",
+      "venueId": "arrowhead-stadium"
     },
     {
       "kind": "ko",
@@ -1025,7 +1125,8 @@
       "awayQual": "W-98",
       "id": 101,
       "playedOn": "2026-07-14T15:00:00Z",
-      "roundId": "sf"
+      "roundId": "sf",
+      "venueId": "at-t-stadium"
     },
     {
       "kind": "ko",
@@ -1033,7 +1134,8 @@
       "awayQual": "W-100",
       "id": 102,
       "playedOn": "2026-07-15T15:00:00Z",
-      "roundId": "sf"
+      "roundId": "sf",
+      "venueId": "mercedes-benz-stadium"
     },
     {
       "kind": "ko",
@@ -1041,7 +1143,8 @@
       "awayQual": "L-102",
       "id": 103,
       "playedOn": "2026-07-18T17:00:00Z",
-      "roundId": "third"
+      "roundId": "third",
+      "venueId": "hard-rock-stadium"
     },
     {
       "kind": "ko",
@@ -1049,7 +1152,8 @@
       "awayQual": "W-102",
       "id": 104,
       "playedOn": "2026-07-19T15:00:00Z",
-      "roundId": "final"
+      "roundId": "final",
+      "venueId": "metlife-stadium"
     }
   ]
 }

--- a/src/FantasyFootball.Core/FantasyFootball.Core.csproj
+++ b/src/FantasyFootball.Core/FantasyFootball.Core.csproj
@@ -21,11 +21,13 @@
 
   <ItemGroup>
     <None Remove="Resources\Data\fifa_elo_new.csv" />
+    <None Remove="Resources\Data\venues.json" />
     <None Remove="Definitions\*.json" />
   </ItemGroup>
 
   <ItemGroup>
     <EmbeddedResource Include="Resources\Data\fifa_elo_new.csv" />
+    <EmbeddedResource Include="Resources\Data\venues.json" />
     <!-- Competition definition JSON files. Manifest names are derived from
          RootNamespace (FantasyFootball), so `Definitions/wm-2022.json` is
          loadable as `FantasyFootball.Definitions.wm-2022.json` via

--- a/src/FantasyFootball.Core/Models/Game.cs
+++ b/src/FantasyFootball.Core/Models/Game.cs
@@ -33,6 +33,9 @@ public abstract record class Game
 	/// <summary>FK into the global Venue registry. Optional.</summary>
 	public string? VenueId { get; init; }
 
+	/// <summary>Official spectator count for completed real-world games. Null for simulated or unplayed matches.</summary>
+	public int? Attendance { get; init; }
+
 	/// <summary>
 	/// null = scheduled (not yet played). Non-null = played.
 	/// </summary>

--- a/src/FantasyFootball.Core/Models/Venue.cs
+++ b/src/FantasyFootball.Core/Models/Venue.cs
@@ -1,19 +1,20 @@
 namespace FantasyFootball.Models;
 
 /// <summary>
-/// A stadium / venue entry. Lives in a global registry (planned
-/// <c>venues.json</c>, sibling to <c>teams.json</c>) and is referenced
-/// by ID from <see cref="Game.VenueId"/>. Independent of any one
-/// competition so the same Estadio Azteca can host games across
-/// multiple tournaments without duplication.
-///
-/// Currently unpopulated — every <c>VenueId</c> on the committed
-/// definition files is null. The type lives in the model so consumers
-/// can be wired against it before the registry data exists.
+/// A stadium / venue entry. Lives in a global registry
+/// (<c>venues.json</c>, embedded as a resource alongside <c>fifa_elo_new.csv</c>)
+/// and is referenced by ID from <see cref="Game.VenueId"/>. Independent of any
+/// one competition so the same Estadio Azteca can host games across multiple
+/// tournaments without duplication.
 /// </summary>
-public sealed record class Venue(
-	string Id,
-	string Name,
-	string City,
-	string Country,
-	int? Capacity);
+public sealed record class Venue
+{
+	public required string Id { get; init; }
+	public required string Name { get; init; }
+	public string? City { get; init; }
+	/// <summary>ISO 3166-1 alpha-3 code (matches <c>Country.Code3</c>). Nullable when the source has no country claim for the venue.</summary>
+	public string? CountryCode { get; init; }
+	public required int Capacity { get; init; }
+	/// <summary>Slugs of clubs that play their home matches here. Populated for club home grounds, empty for neutral / tournament-host venues.</summary>
+	public string[] TenantClubs { get; init; } = [];
+}

--- a/src/FantasyFootball.Core/Resources/Data/venues.json
+++ b/src/FantasyFootball.Core/Resources/Data/venues.json
@@ -1,0 +1,17489 @@
+[
+  {
+    "id": "narendra-modi-stadium",
+    "name": "Narendra Modi Stadium",
+    "city": "Ahmedabad",
+    "countryCode": "IND",
+    "capacity": 132000,
+    "tenantClubs": [
+      "gujarat-titans"
+    ]
+  },
+  {
+    "id": "estadio-do-morumbi",
+    "name": "Estádio do Morumbi",
+    "city": "São Paulo",
+    "countryCode": "BRA",
+    "capacity": 120000,
+    "tenantClubs": [
+      "sao-paulo-fc"
+    ]
+  },
+  {
+    "id": "banorte-stadium",
+    "name": "Banorte Stadium",
+    "city": "Mexico City",
+    "countryCode": "MEX",
+    "capacity": 115000,
+    "tenantClubs": [
+      "club-america",
+      "cruz-azul",
+      "mexico-men-s-national-football-team"
+    ]
+  },
+  {
+    "id": "hassan-ii-stadium",
+    "name": "Hassan II Stadium",
+    "city": null,
+    "countryCode": "MAR",
+    "capacity": 115000,
+    "tenantClubs": []
+  },
+  {
+    "id": "michigan-stadium",
+    "name": "Michigan Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 107601,
+    "tenantClubs": [
+      "michigan-wolverines",
+      "michigan-wolverines-football"
+    ]
+  },
+  {
+    "id": "beaver-stadium",
+    "name": "Beaver Stadium",
+    "city": "Pennsylvania State University",
+    "countryCode": "USA",
+    "capacity": 106572,
+    "tenantClubs": [
+      "penn-state-nittany-lions",
+      "penn-state-nittany-lions-football"
+    ]
+  },
+  {
+    "id": "camp-nou",
+    "name": "Camp Nou",
+    "city": null,
+    "countryCode": "ESP",
+    "capacity": 105000,
+    "tenantClubs": [
+      "futbol-club-barcelona"
+    ]
+  },
+  {
+    "id": "at-t-stadium",
+    "name": "AT&T Stadium",
+    "city": "Arlington",
+    "countryCode": "USA",
+    "capacity": 105000,
+    "tenantClubs": [
+      "dallas-cowboys"
+    ]
+  },
+  {
+    "id": "ohio-stadium",
+    "name": "Ohio Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 102780,
+    "tenantClubs": [
+      "columbus-crew",
+      "ohio-state-buckeyes",
+      "ohio-state-buckeyes-football"
+    ]
+  },
+  {
+    "id": "kyle-field",
+    "name": "Kyle Field",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 102733,
+    "tenantClubs": [
+      "texas-a-m-aggies",
+      "texas-a-m-aggies-football"
+    ]
+  },
+  {
+    "id": "neyland-stadium",
+    "name": "Neyland Stadium",
+    "city": "Knoxville",
+    "countryCode": "USA",
+    "capacity": 102455,
+    "tenantClubs": [
+      "tennessee-volunteers"
+    ]
+  },
+  {
+    "id": "tiger-stadium",
+    "name": "Tiger Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 102321,
+    "tenantClubs": [
+      "lsu-tigers",
+      "lsu-tigers-football"
+    ]
+  },
+  {
+    "id": "bryant-denny-stadium",
+    "name": "Bryant–Denny Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 101821,
+    "tenantClubs": [
+      "alabama-crimson-tide",
+      "alabama-crimson-tide-football"
+    ]
+  },
+  {
+    "id": "cairo-international-stadium",
+    "name": "Cairo International Stadium",
+    "city": "Nasr City",
+    "countryCode": "EGY",
+    "capacity": 100500,
+    "tenantClubs": [
+      "al-ahly-sc",
+      "egypt-men-s-national-football-team",
+      "zamalek-sc"
+    ]
+  },
+  {
+    "id": "melbourne-cricket-ground",
+    "name": "Melbourne Cricket Ground",
+    "city": "Yarra Park",
+    "countryCode": "AUS",
+    "capacity": 100024,
+    "tenantClubs": [
+      "australia-national-cricket-team",
+      "carlton-football-club",
+      "collingwood-football-club",
+      "hawthorn-football-club",
+      "melbourne-cricket-club",
+      "melbourne-football-club",
+      "richmond-football-club",
+      "victoria-cricket-team"
+    ]
+  },
+  {
+    "id": "new-trafford",
+    "name": "New Trafford",
+    "city": "Old Trafford",
+    "countryCode": "GBR",
+    "capacity": 100000,
+    "tenantClubs": []
+  },
+  {
+    "id": "darrell-k-royal-texas-memorial-stadium",
+    "name": "Darrell K Royal–Texas Memorial Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 95594,
+    "tenantClubs": [
+      "texas-longhorns"
+    ]
+  },
+  {
+    "id": "soccer-city-stadium",
+    "name": "Soccer City Stadium",
+    "city": null,
+    "countryCode": "ZAF",
+    "capacity": 94736,
+    "tenantClubs": [
+      "kaizer-chiefs-f-c",
+      "south-africa-men-s-national-association-football-team"
+    ]
+  },
+  {
+    "id": "king-salman-international-stadium",
+    "name": "King Salman International Stadium",
+    "city": "Riyadh",
+    "countryCode": "SAU",
+    "capacity": 92760,
+    "tenantClubs": []
+  },
+  {
+    "id": "sanford-stadium",
+    "name": "Sanford Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 92746,
+    "tenantClubs": [
+      "georgia-bulldogs",
+      "georgia-bulldogs-football"
+    ]
+  },
+  {
+    "id": "cotton-bowl",
+    "name": "Cotton Bowl",
+    "city": "Dallas",
+    "countryCode": "USA",
+    "capacity": 92100,
+    "tenantClubs": [
+      "dallas-trinity-fc",
+      "kansas-city-chiefs",
+      "state-fair-classic"
+    ]
+  },
+  {
+    "id": "wembley-stadium",
+    "name": "Wembley Stadium",
+    "city": "London",
+    "countryCode": "GBR",
+    "capacity": 90000,
+    "tenantClubs": [
+      "england-men-s-national-association-football-team"
+    ]
+  },
+  {
+    "id": "education-city-stadium",
+    "name": "Education City Stadium",
+    "city": "Al Rayyan",
+    "countryCode": "QAT",
+    "capacity": 90000,
+    "tenantClubs": []
+  },
+  {
+    "id": "lusail-stadium",
+    "name": "Lusail Stadium",
+    "city": "Lusail",
+    "countryCode": "QAT",
+    "capacity": 88966,
+    "tenantClubs": [
+      "qatar-men-s-national-football-team"
+    ]
+  },
+  {
+    "id": "ben-hill-griffin-stadium",
+    "name": "Ben Hill Griffin Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 88548,
+    "tenantClubs": [
+      "florida-gators",
+      "florida-gators-football"
+    ]
+  },
+  {
+    "id": "jordan-hare-stadium",
+    "name": "Jordan–Hare Stadium",
+    "city": "Auburn",
+    "countryCode": "USA",
+    "capacity": 87451,
+    "tenantClubs": [
+      "auburn-tigers"
+    ]
+  },
+  {
+    "id": "memorial-stadium",
+    "name": "Memorial Stadium",
+    "city": "Lincoln",
+    "countryCode": "USA",
+    "capacity": 87091,
+    "tenantClubs": [
+      "nebraska-cornhuskers",
+      "nebraska-cornhuskers-football"
+    ]
+  },
+  {
+    "id": "borg-el-arab-stadium",
+    "name": "Borg El Arab Stadium",
+    "city": "Second Amreya district",
+    "countryCode": "EGY",
+    "capacity": 86000,
+    "tenantClubs": [
+      "egyptian-football-association"
+    ]
+  },
+  {
+    "id": "national-stadium-bukit-jalil",
+    "name": "National Stadium, Bukit Jalil",
+    "city": "Kuala Lumpur",
+    "countryCode": "MYS",
+    "capacity": 85000,
+    "tenantClubs": [
+      "malaysia-men-s-national-football-team"
+    ]
+  },
+  {
+    "id": "centennial-olympic-stadium",
+    "name": "Centennial Olympic Stadium",
+    "city": "Atlanta",
+    "countryCode": "USA",
+    "capacity": 85000,
+    "tenantClubs": [
+      "1996-summer-olympics"
+    ]
+  },
+  {
+    "id": "mas-monumental-stadium",
+    "name": "Mas Monumental Stadium",
+    "city": "Belgrano",
+    "countryCode": "ARG",
+    "capacity": 84567,
+    "tenantClubs": [
+      "argentina-men-s-national-association-football-team",
+      "club-atletico-river-plate",
+      "club-atletico-river-plate-women",
+      "q65484512"
+    ]
+  },
+  {
+    "id": "azadi-stadium",
+    "name": "Azadi Stadium",
+    "city": null,
+    "countryCode": "IRN",
+    "capacity": 84412,
+    "tenantClubs": [
+      "esteghlal-f-c",
+      "persepolis-f-c"
+    ]
+  },
+  {
+    "id": "bernabeu",
+    "name": "Bernabéu",
+    "city": null,
+    "countryCode": "ESP",
+    "capacity": 83186,
+    "tenantClubs": [
+      "real-madrid-club-de-futbol"
+    ]
+  },
+  {
+    "id": "metlife-stadium",
+    "name": "MetLife Stadium",
+    "city": "East Rutherford",
+    "countryCode": "USA",
+    "capacity": 82500,
+    "tenantClubs": [
+      "new-york-jets"
+    ]
+  },
+  {
+    "id": "croke-park",
+    "name": "Croke Park",
+    "city": null,
+    "countryCode": "IRL",
+    "capacity": 82300,
+    "tenantClubs": [
+      "ireland-men-s-national-rugby-union-team"
+    ]
+  },
+  {
+    "id": "gaylord-family-oklahoma-memorial-stadium",
+    "name": "Gaylord Family Oklahoma Memorial Stadium",
+    "city": "Norman",
+    "countryCode": "USA",
+    "capacity": 82112,
+    "tenantClubs": [
+      "oklahoma-sooners",
+      "oklahoma-sooners-football"
+    ]
+  },
+  {
+    "id": "twickenham-stadium",
+    "name": "Twickenham Stadium",
+    "city": null,
+    "countryCode": "GBR",
+    "capacity": 82000,
+    "tenantClubs": [
+      "england-men-s-national-rugby-union-team"
+    ]
+  },
+  {
+    "id": "jakarta-international-stadium",
+    "name": "Jakarta International Stadium",
+    "city": "Tanjung Priok",
+    "countryCode": "IDN",
+    "capacity": 82000,
+    "tenantClubs": [
+      "indonesia-men-s-national-football-team",
+      "persija-jakarta"
+    ]
+  },
+  {
+    "id": "memorial-stadium-clemson",
+    "name": "Memorial Stadium, Clemson",
+    "city": "Clemson",
+    "countryCode": "USA",
+    "capacity": 81500,
+    "tenantClubs": [
+      "clemson-tigers",
+      "clemson-tigers-football"
+    ]
+  },
+  {
+    "id": "westfalenstadion",
+    "name": "Westfalenstadion",
+    "city": "Dortmund",
+    "countryCode": "DEU",
+    "capacity": 81359,
+    "tenantClubs": [
+      "borussia-dortmund"
+    ]
+  },
+  {
+    "id": "stade-de-france",
+    "name": "Stade de France",
+    "city": null,
+    "countryCode": "FRA",
+    "capacity": 81338,
+    "tenantClubs": [
+      "france-men-s-national-association-football-team",
+      "france-national-rugby-union-team",
+      "team-vitality"
+    ]
+  },
+  {
+    "id": "notre-dame-stadium",
+    "name": "Notre Dame Stadium",
+    "city": "Notre Dame",
+    "countryCode": "USA",
+    "capacity": 80795,
+    "tenantClubs": [
+      "notre-dame-fighting-irish",
+      "notre-dame-fighting-irish-football"
+    ]
+  },
+  {
+    "id": "lambeau-field",
+    "name": "Lambeau Field",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 80750,
+    "tenantClubs": [
+      "green-bay-packers"
+    ]
+  },
+  {
+    "id": "ataturk-olympic-stadium",
+    "name": "Atatürk Olympic Stadium",
+    "city": "Ziya Gökalp",
+    "countryCode": "TUR",
+    "capacity": 80597,
+    "tenantClubs": [
+      "istanbul-basaksehir-f-k"
+    ]
+  },
+  {
+    "id": "shah-alam-stadium",
+    "name": "Shah Alam Stadium",
+    "city": "Shah Alam",
+    "countryCode": "MYS",
+    "capacity": 80372,
+    "tenantClubs": [
+      "selangor-f-c"
+    ]
+  },
+  {
+    "id": "camp-randall-stadium",
+    "name": "Camp Randall Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 80321,
+    "tenantClubs": [
+      "wisconsin-badgers"
+    ]
+  },
+  {
+    "id": "williams-brice-stadium",
+    "name": "Williams-Brice Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 80250,
+    "tenantClubs": [
+      "south-carolina-gamecocks"
+    ]
+  },
+  {
+    "id": "estadio-monumental-u",
+    "name": "Estadio Monumental U",
+    "city": "Ate",
+    "countryCode": "PER",
+    "capacity": 80093,
+    "tenantClubs": [
+      "club-universitario-de-deportes"
+    ]
+  },
+  {
+    "id": "guangdong-olympic-center",
+    "name": "Guangdong Olympic Center",
+    "city": "Guangzhou",
+    "countryCode": "CHN",
+    "capacity": 80012,
+    "tenantClubs": [
+      "2010-asian-games"
+    ]
+  },
+  {
+    "id": "gazprom-arena",
+    "name": "Gazprom Arena",
+    "city": null,
+    "countryCode": "RUS",
+    "capacity": 80000,
+    "tenantClubs": [
+      "fc-zenit-saint-petersburg"
+    ]
+  },
+  {
+    "id": "martyrs-stadium",
+    "name": "martyrs' stadium",
+    "city": null,
+    "countryCode": "COD",
+    "capacity": 80000,
+    "tenantClubs": [
+      "dr-congo-men-s-national-football-team"
+    ]
+  },
+  {
+    "id": "shanghai-stadium",
+    "name": "Shanghai Stadium",
+    "city": "Xuhui District",
+    "countryCode": "CHN",
+    "capacity": 80000,
+    "tenantClubs": [
+      "shanghai-shenhua-f-c"
+    ]
+  },
+  {
+    "id": "beijing-national-stadium",
+    "name": "Beijing National Stadium",
+    "city": null,
+    "countryCode": "CHN",
+    "capacity": 80000,
+    "tenantClubs": [
+      "china-men-s-national-football-team"
+    ]
+  },
+  {
+    "id": "panathenaic-stadium",
+    "name": "Panathenaic Stadium",
+    "city": "Athens",
+    "countryCode": "GRC",
+    "capacity": 80000,
+    "tenantClubs": [
+      "hellenic-olympic-committee"
+    ]
+  },
+  {
+    "id": "dalian-sports-center",
+    "name": "Dalian Sports Center",
+    "city": null,
+    "countryCode": "CHN",
+    "capacity": 80000,
+    "tenantClubs": [
+      "dalian-shide-f-c"
+    ]
+  },
+  {
+    "id": "doak-campbell-stadium",
+    "name": "Doak Campbell Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 79560,
+    "tenantClubs": [
+      "florida-state-seminoles"
+    ]
+  },
+  {
+    "id": "maracana-stadium",
+    "name": "Maracanã Stadium",
+    "city": null,
+    "countryCode": "BRA",
+    "capacity": 78838,
+    "tenantClubs": [
+      "clube-de-regatas-do-flamengo",
+      "fluminense-f-c"
+    ]
+  },
+  {
+    "id": "luzhniki-stadium",
+    "name": "Luzhniki Stadium",
+    "city": "Moscow",
+    "countryCode": "RUS",
+    "capacity": 78360,
+    "tenantClubs": [
+      "russia-men-s-national-football-team",
+      "soviet-union-national-association-football-team"
+    ]
+  },
+  {
+    "id": "los-angeles-memorial-coliseum",
+    "name": "Los Angeles Memorial Coliseum",
+    "city": "Los Angeles",
+    "countryCode": "USA",
+    "capacity": 77500,
+    "tenantClubs": [
+      "1984-summer-olympics",
+      "cook-out-clash-at-bowman-gray-stadium",
+      "las-vegas-raiders",
+      "los-angeles-chargers",
+      "los-angeles-rams",
+      "ucla-bruins-football",
+      "usc-trojans",
+      "usc-trojans-football"
+    ]
+  },
+  {
+    "id": "gelora-bung-karno-stadium",
+    "name": "Gelora Bung Karno Stadium",
+    "city": null,
+    "countryCode": "IDN",
+    "capacity": 77193,
+    "tenantClubs": [
+      "indonesia-men-s-national-football-team",
+      "persija-jakarta"
+    ]
+  },
+  {
+    "id": "arrowhead-stadium",
+    "name": "Arrowhead Stadium",
+    "city": "Kansas City",
+    "countryCode": "USA",
+    "capacity": 76416,
+    "tenantClubs": [
+      "kansas-city-chiefs",
+      "kansas-jayhawks-football",
+      "sporting-kansas-city"
+    ]
+  },
+  {
+    "id": "stade-5-juillet-1962",
+    "name": "Stade 5 Juillet 1962",
+    "city": null,
+    "countryCode": "DZA",
+    "capacity": 76200,
+    "tenantClubs": [
+      "usm-alger"
+    ]
+  },
+  {
+    "id": "empower-field-at-mile-high",
+    "name": "Empower Field at Mile High",
+    "city": "Denver",
+    "countryCode": "USA",
+    "capacity": 76125,
+    "tenantClubs": [
+      "denver-broncos"
+    ]
+  },
+  {
+    "id": "old-trafford",
+    "name": "Old Trafford",
+    "city": "Old Trafford",
+    "countryCode": "GBR",
+    "capacity": 75731,
+    "tenantClubs": [
+      "manchester-united-f-c"
+    ]
+  },
+  {
+    "id": "caesars-superdome",
+    "name": "Caesars Superdome",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 75167,
+    "tenantClubs": [
+      "new-orleans-night",
+      "new-orleans-pelicans",
+      "new-orleans-saints",
+      "new-orleans-voodoo",
+      "portland-breakers",
+      "tulane-green-wave-football",
+      "utah-jazz"
+    ]
+  },
+  {
+    "id": "allianz-arena",
+    "name": "Allianz Arena",
+    "city": "Munich",
+    "countryCode": "DEU",
+    "capacity": 75024,
+    "tenantClubs": [
+      "fc-bayern-munich"
+    ]
+  },
+  {
+    "id": "spartan-stadium",
+    "name": "Spartan Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 75005,
+    "tenantClubs": [
+      "michigan-state-spartans",
+      "michigan-state-spartans-football"
+    ]
+  },
+  {
+    "id": "tangier-grand-stadium",
+    "name": "Tangier Grand Stadium",
+    "city": null,
+    "countryCode": "MAR",
+    "capacity": 75000,
+    "tenantClubs": [
+      "ir-tanger"
+    ]
+  },
+  {
+    "id": "estadio-gasometro",
+    "name": "Estadio Gasómetro",
+    "city": "Boedo",
+    "countryCode": "ARG",
+    "capacity": 75000,
+    "tenantClubs": [
+      "san-lorenzo-de-almagro"
+    ]
+  },
+  {
+    "id": "aleppo-international-stadium",
+    "name": "Aleppo International Stadium",
+    "city": "Aleppo",
+    "countryCode": "SYR",
+    "capacity": 75000,
+    "tenantClubs": [
+      "ahli-of-aleppo-sc"
+    ]
+  },
+  {
+    "id": "olympiastadion-berlin",
+    "name": "Olympiastadion",
+    "city": "Berlin",
+    "countryCode": "DEU",
+    "capacity": 74475,
+    "tenantClubs": [
+      "hertha-bsc"
+    ]
+  },
+  {
+    "id": "millennium-stadium",
+    "name": "Millennium Stadium",
+    "city": null,
+    "countryCode": "GBR",
+    "capacity": 73931,
+    "tenantClubs": [
+      "wales-national-rugby-union-team",
+      "welsh-rugby-union"
+    ]
+  },
+  {
+    "id": "bank-of-america-stadium",
+    "name": "Bank of America Stadium",
+    "city": "Charlotte",
+    "countryCode": "USA",
+    "capacity": 73778,
+    "tenantClubs": [
+      "carolina-panthers",
+      "charlotte-fc"
+    ]
+  },
+  {
+    "id": "stanley-park-stadium",
+    "name": "Stanley Park Stadium",
+    "city": "Stanley Park",
+    "countryCode": "GBR",
+    "capacity": 73000,
+    "tenantClubs": [
+      "liverpool-f-c"
+    ]
+  },
+  {
+    "id": "international-stadium-yokohama",
+    "name": "International Stadium Yokohama",
+    "city": null,
+    "countryCode": "JPN",
+    "capacity": 72327,
+    "tenantClubs": [
+      "2020-summer-olympics",
+      "yokohama-f-marinos"
+    ]
+  },
+  {
+    "id": "donald-w-reynolds-razorback-stadium",
+    "name": "Donald W. Reynolds Razorback Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 72000,
+    "tenantClubs": [
+      "arkansas-razorbacks"
+    ]
+  },
+  {
+    "id": "highmark-stadium",
+    "name": "Highmark Stadium",
+    "city": "Orchard Park",
+    "countryCode": "USA",
+    "capacity": 71608,
+    "tenantClubs": [
+      "buffalo-bills"
+    ]
+  },
+  {
+    "id": "legion-field",
+    "name": "Legion Field",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 71594,
+    "tenantClubs": [
+      "alabama-crimson-tide-football",
+      "birmingham-iron",
+      "uab-blazers",
+      "uab-blazers-football"
+    ]
+  },
+  {
+    "id": "huntington-bank-field",
+    "name": "Huntington Bank Field",
+    "city": "North Coast Harbor",
+    "countryCode": "USA",
+    "capacity": 71516,
+    "tenantClubs": [
+      "cleveland-browns"
+    ]
+  },
+  {
+    "id": "nrg-stadium",
+    "name": "NRG Stadium",
+    "city": "Houston",
+    "countryCode": "USA",
+    "capacity": 71054,
+    "tenantClubs": [
+      "houston-cougars-football",
+      "houston-texans",
+      "national-football-league"
+    ]
+  },
+  {
+    "id": "m-t-bank-stadium",
+    "name": "M&T Bank Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 71008,
+    "tenantClubs": [
+      "baltimore-ravens"
+    ]
+  },
+  {
+    "id": "mercedes-benz-stadium",
+    "name": "Mercedes-Benz Stadium",
+    "city": "Atlanta",
+    "countryCode": "USA",
+    "capacity": 71000,
+    "tenantClubs": [
+      "atlanta-falcons",
+      "atlanta-united-fc"
+    ]
+  },
+  {
+    "id": "stadio-olimpico",
+    "name": "Stadio Olimpico",
+    "city": "Rome",
+    "countryCode": "ITA",
+    "capacity": 70634,
+    "tenantClubs": [
+      "as-roma",
+      "italian-rugby-federation",
+      "ss-lazio"
+    ]
+  },
+  {
+    "id": "sofi-stadium",
+    "name": "SoFi Stadium",
+    "city": "Inglewood",
+    "countryCode": "USA",
+    "capacity": 70240,
+    "tenantClubs": [
+      "los-angeles-chargers",
+      "los-angeles-rams"
+    ]
+  },
+  {
+    "id": "king-fahd-sports-city",
+    "name": "King Fahd Sports City",
+    "city": "Riyadh",
+    "countryCode": "SAU",
+    "capacity": 70200,
+    "tenantClubs": [
+      "al-hilal-sfc",
+      "al-nassr",
+      "al-shabab-football-club",
+      "saudi-arabia-men-s-national-football-team"
+    ]
+  },
+  {
+    "id": "husky-stadium",
+    "name": "Husky Stadium",
+    "city": "University of Washington",
+    "countryCode": "USA",
+    "capacity": 70083,
+    "tenantClubs": [
+      "seattle-seahawks",
+      "washington-huskies"
+    ]
+  },
+  {
+    "id": "nou-mestalla",
+    "name": "Nou Mestalla",
+    "city": null,
+    "countryCode": "ESP",
+    "capacity": 70044,
+    "tenantClubs": [
+      "valencia-cf"
+    ]
+  },
+  {
+    "id": "ford-field",
+    "name": "Ford Field",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 70000,
+    "tenantClubs": [
+      "detroit-lions"
+    ]
+  },
+  {
+    "id": "estadio-de-la-cartuja",
+    "name": "Estadio de La Cartuja",
+    "city": null,
+    "countryCode": "ESP",
+    "capacity": 70000,
+    "tenantClubs": [
+      "spain-men-s-national-football-team"
+    ]
+  },
+  {
+    "id": "u-s-bank-stadium",
+    "name": "U.S. Bank Stadium",
+    "city": "Minneapolis",
+    "countryCode": "USA",
+    "capacity": 70000,
+    "tenantClubs": [
+      "minnesota-vikings"
+    ]
+  },
+  {
+    "id": "franklin-field",
+    "name": "Franklin Field",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 70000,
+    "tenantClubs": [
+      "penn-quakers-football",
+      "penn-relays"
+    ]
+  },
+  {
+    "id": "burnden-park",
+    "name": "Burnden Park",
+    "city": "Burnden",
+    "countryCode": "GBR",
+    "capacity": 70000,
+    "tenantClubs": [
+      "bolton-wanderers-f-c"
+    ]
+  },
+  {
+    "id": "new-lusaka-stadium",
+    "name": "New Lusaka Stadium",
+    "city": null,
+    "countryCode": "ZMB",
+    "capacity": 70000,
+    "tenantClubs": []
+  },
+  {
+    "id": "kim-il-sung-stadium",
+    "name": "Kim Il-sung Stadium",
+    "city": null,
+    "countryCode": "PRK",
+    "capacity": 70000,
+    "tenantClubs": [
+      "north-korea-men-s-national-football-team",
+      "pyongyang-city-sports-club"
+    ]
+  },
+  {
+    "id": "new-commanders-stadium",
+    "name": "New Commanders Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 70000,
+    "tenantClubs": [
+      "washington-commanders"
+    ]
+  },
+  {
+    "id": "q11836159",
+    "name": "Q11836159",
+    "city": null,
+    "countryCode": "BEL",
+    "capacity": 70000,
+    "tenantClubs": []
+  },
+  {
+    "id": "izmir-ataturk-stadium",
+    "name": "İzmir Atatürk Stadium",
+    "city": "Atatürk Sport Complex",
+    "countryCode": "TUR",
+    "capacity": 70000,
+    "tenantClubs": [
+      "goztepe-s-k"
+    ]
+  },
+  {
+    "id": "estadio-nacional-de-brasilia",
+    "name": "Estádio Nacional de Brasília",
+    "city": null,
+    "countryCode": "BRA",
+    "capacity": 69910,
+    "tenantClubs": [
+      "brasilia-futebol-clube",
+      "legiao-fc"
+    ]
+  },
+  {
+    "id": "prince-moulay-abdellah-stadium",
+    "name": "Prince Moulay Abdellah Stadium",
+    "city": null,
+    "countryCode": "MAR",
+    "capacity": 69500,
+    "tenantClubs": [
+      "far-rabat",
+      "morocco-men-s-national-football-team"
+    ]
+  },
+  {
+    "id": "kinnick-stadium",
+    "name": "Kinnick Stadium",
+    "city": "Iowa City",
+    "countryCode": "USA",
+    "capacity": 69250,
+    "tenantClubs": [
+      "iowa-hawkeyes",
+      "iowa-hawkeyes-football"
+    ]
+  },
+  {
+    "id": "al-bayt-stadium",
+    "name": "Al Bayt Stadium",
+    "city": "Al Khor",
+    "countryCode": "QAT",
+    "capacity": 68895,
+    "tenantClubs": [
+      "qatar-men-s-national-football-team"
+    ]
+  },
+  {
+    "id": "gillette-stadium",
+    "name": "Gillette Stadium",
+    "city": "Foxborough",
+    "countryCode": "USA",
+    "capacity": 68756,
+    "tenantClubs": [
+      "new-england-patriots",
+      "new-england-revolution",
+      "new-england-revolution-ii"
+    ]
+  },
+  {
+    "id": "lincoln-financial-field",
+    "name": "Lincoln Financial Field",
+    "city": "Philadelphia",
+    "countryCode": "USA",
+    "capacity": 68532,
+    "tenantClubs": [
+      "philadelphia-eagles",
+      "temple-owls-football"
+    ]
+  },
+  {
+    "id": "levi-s-stadium",
+    "name": "Levi's Stadium",
+    "city": "Santa Clara",
+    "countryCode": "USA",
+    "capacity": 68500,
+    "tenantClubs": [
+      "san-francisco-49ers"
+    ]
+  },
+  {
+    "id": "estadio-da-luz",
+    "name": "Estádio da Luz",
+    "city": "Lisbon",
+    "countryCode": "PRT",
+    "capacity": 68100,
+    "tenantClubs": [
+      "s-l-benfica",
+      "s-l-benfica-b"
+    ]
+  },
+  {
+    "id": "daegu-stadium",
+    "name": "Daegu Stadium",
+    "city": null,
+    "countryCode": "KOR",
+    "capacity": 68014,
+    "tenantClubs": [
+      "south-korea-men-s-national-football-team"
+    ]
+  },
+  {
+    "id": "salt-lake-stadium",
+    "name": "Salt Lake Stadium",
+    "city": "JB Block",
+    "countryCode": "IND",
+    "capacity": 68000,
+    "tenantClubs": [
+      "west-bengal-football-team"
+    ]
+  },
+  {
+    "id": "nissan-stadium",
+    "name": "Nissan Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 67700,
+    "tenantClubs": [
+      "nashville-sc",
+      "national-collegiate-athletic-association",
+      "national-football-league",
+      "tennessee-titans"
+    ]
+  },
+  {
+    "id": "estadio-universidad-san-marcos",
+    "name": "Estadio Universidad San Marcos",
+    "city": null,
+    "countryCode": "PER",
+    "capacity": 67469,
+    "tenantClubs": [
+      "national-university-of-san-marcos"
+    ]
+  },
+  {
+    "id": "stade-velodrome",
+    "name": "Stade Vélodrome",
+    "city": null,
+    "countryCode": "FRA",
+    "capacity": 67394,
+    "tenantClubs": [
+      "olympique-de-marseille"
+    ]
+  },
+  {
+    "id": "everbank-field",
+    "name": "EverBank Field",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 67246,
+    "tenantClubs": [
+      "jacksonville-jaguars"
+    ]
+  },
+  {
+    "id": "puskas-arena",
+    "name": "Puskás Aréna",
+    "city": "Istvánmező",
+    "countryCode": "HUN",
+    "capacity": 67215,
+    "tenantClubs": [
+      "hungary-men-s-national-football-team"
+    ]
+  },
+  {
+    "id": "murrayfield-stadium",
+    "name": "Murrayfield Stadium",
+    "city": "Edinburgh",
+    "countryCode": "GBR",
+    "capacity": 67144,
+    "tenantClubs": [
+      "scottish-rugby-union"
+    ]
+  },
+  {
+    "id": "stadium-salto-international",
+    "name": "Stadium Salto International",
+    "city": null,
+    "countryCode": "LBY",
+    "capacity": 67000,
+    "tenantClubs": [
+      "libya-men-s-national-football-team"
+    ]
+  },
+  {
+    "id": "lumen-field",
+    "name": "Lumen Field",
+    "city": "Seattle",
+    "countryCode": "USA",
+    "capacity": 67000,
+    "tenantClubs": [
+      "seattle-reign-fc",
+      "seattle-sea-dragons",
+      "seattle-seahawks",
+      "seattle-sounders",
+      "seattle-sounders-fc",
+      "washington-huskies-football"
+    ]
+  },
+  {
+    "id": "mohammed-v-stadium",
+    "name": "Mohammed V Stadium",
+    "city": null,
+    "countryCode": "MAR",
+    "capacity": 67000,
+    "tenantClubs": [
+      "raja-club-athletic",
+      "wydad-athletic-club"
+    ]
+  },
+  {
+    "id": "yadegar-e-emam-stadium",
+    "name": "Yadegar-e Emam Stadium",
+    "city": null,
+    "countryCode": "IRN",
+    "capacity": 66833,
+    "tenantClubs": [
+      "tractor-f-c"
+    ]
+  },
+  {
+    "id": "seoul-world-cup-stadium",
+    "name": "Seoul World Cup Stadium",
+    "city": null,
+    "countryCode": "KOR",
+    "capacity": 66806,
+    "tenantClubs": [
+      "fc-seoul",
+      "south-korea-men-s-national-football-team"
+    ]
+  },
+  {
+    "id": "mineirao",
+    "name": "Mineirão",
+    "city": null,
+    "countryCode": "BRA",
+    "capacity": 66658,
+    "tenantClubs": [
+      "clube-atletico-mineiro"
+    ]
+  },
+  {
+    "id": "merkur-spiel-arena",
+    "name": "Merkur Spiel-Arena",
+    "city": "Düsseldorf",
+    "countryCode": "DEU",
+    "capacity": 66500,
+    "tenantClubs": [
+      "fortuna-dusseldorf"
+    ]
+  },
+  {
+    "id": "the-dome-at-america-s-center",
+    "name": "The Dome at America's Center",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 66000,
+    "tenantClubs": [
+      "los-angeles-rams",
+      "st-louis-battlehawks"
+    ]
+  },
+  {
+    "id": "raymond-james-stadium",
+    "name": "Raymond James Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 65890,
+    "tenantClubs": [
+      "south-florida-bulls-football",
+      "tampa-bay-buccaneers",
+      "tampa-bay-vipers"
+    ]
+  },
+  {
+    "id": "texas-stadium",
+    "name": "Texas Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 65675,
+    "tenantClubs": [
+      "dallas-cowboys"
+    ]
+  },
+  {
+    "id": "lane-stadium",
+    "name": "Lane Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 65632,
+    "tenantClubs": [
+      "virginia-tech-hokies"
+    ]
+  },
+  {
+    "id": "paycor-stadium",
+    "name": "Paycor Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 65515,
+    "tenantClubs": [
+      "cincinnati-bengals"
+    ]
+  },
+  {
+    "id": "acrisure-stadium",
+    "name": "Acrisure Stadium",
+    "city": "North Shore",
+    "countryCode": "USA",
+    "capacity": 65500,
+    "tenantClubs": [
+      "pittsburgh-panthers-football",
+      "pittsburgh-steelers"
+    ]
+  },
+  {
+    "id": "camping-world-stadium",
+    "name": "Camping World Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 65438,
+    "tenantClubs": [
+      "citrus-bowl",
+      "orlando-city-sc",
+      "orlando-guardians",
+      "orlando-pride",
+      "ucf-knights-football"
+    ]
+  },
+  {
+    "id": "hard-rock-stadium",
+    "name": "Hard Rock Stadium",
+    "city": "Miami Gardens",
+    "countryCode": "USA",
+    "capacity": 65326,
+    "tenantClubs": [
+      "florida-atlantic-owls-football",
+      "miami-dolphins",
+      "miami-hurricanes",
+      "miami-hurricanes-football",
+      "miami-marlins",
+      "miami-open"
+    ]
+  },
+  {
+    "id": "jaber-al-ahmad-international-stadium",
+    "name": "Jaber Al-Ahmad International Stadium",
+    "city": "Kuwait City",
+    "countryCode": "KWT",
+    "capacity": 65000,
+    "tenantClubs": [
+      "kuwait-national-football-team"
+    ]
+  },
+  {
+    "id": "palaran-stadium",
+    "name": "Palaran Stadium",
+    "city": null,
+    "countryCode": "IDN",
+    "capacity": 65000,
+    "tenantClubs": [
+      "bali-united-f-c"
+    ]
+  },
+  {
+    "id": "allegiant-stadium",
+    "name": "Allegiant Stadium",
+    "city": "Paradise",
+    "countryCode": "USA",
+    "capacity": 65000,
+    "tenantClubs": [
+      "2024-las-vegas-raiders-season",
+      "2025-las-vegas-raiders-season",
+      "2026-las-vegas-raiders-season",
+      "las-vegas-bowl",
+      "las-vegas-raiders",
+      "unlv-rebels-football"
+    ]
+  },
+  {
+    "id": "alamodome",
+    "name": "Alamodome",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 65000,
+    "tenantClubs": [
+      "alamo-bowl",
+      "san-antonio-brahmas",
+      "san-antonio-commanders",
+      "san-antonio-spurs",
+      "utsa-roadrunners",
+      "utsa-roadrunners-football"
+    ]
+  },
+  {
+    "id": "q16531664",
+    "name": "Q16531664",
+    "city": null,
+    "countryCode": "IRQ",
+    "capacity": 65000,
+    "tenantClubs": [
+      "iraq-men-s-national-football-team"
+    ]
+  },
+  {
+    "id": "colosseum",
+    "name": "Colosseum",
+    "city": null,
+    "countryCode": "ITA",
+    "capacity": 65000,
+    "tenantClubs": []
+  },
+  {
+    "id": "olympic-stadium-of-rades",
+    "name": "Olympic Stadium of Radès",
+    "city": null,
+    "countryCode": "TUN",
+    "capacity": 65000,
+    "tenantClubs": [
+      "club-africain",
+      "esperance-sportive-de-tunis"
+    ]
+  },
+  {
+    "id": "jidhe-alnakhla-stadium",
+    "name": "Jidhe Alnakhla Stadium",
+    "city": null,
+    "countryCode": "IRQ",
+    "capacity": 65000,
+    "tenantClubs": [
+      "iraq-men-s-national-football-team"
+    ]
+  },
+  {
+    "id": "mountain-america-stadium",
+    "name": "Mountain America Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 64248,
+    "tenantClubs": [
+      "arizona-cardinals",
+      "arizona-hotshots",
+      "arizona-state-sun-devils",
+      "arizona-state-sun-devils-football"
+    ]
+  },
+  {
+    "id": "vaught-hemingway-stadium",
+    "name": "Vaught–Hemingway Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 64038,
+    "tenantClubs": [
+      "ole-miss-rebels",
+      "ole-miss-rebels-football"
+    ]
+  },
+  {
+    "id": "northwest-stadium",
+    "name": "Northwest Stadium",
+    "city": "Landover",
+    "countryCode": "USA",
+    "capacity": 64000,
+    "tenantClubs": [
+      "washington-commanders"
+    ]
+  },
+  {
+    "id": "saitama-stadium-2002",
+    "name": "Saitama Stadium 2002",
+    "city": "Saitama Stadium 2002 Park",
+    "countryCode": "JPN",
+    "capacity": 63700,
+    "tenantClubs": [
+      "2020-summer-olympics",
+      "urawa-red-diamonds"
+    ]
+  },
+  {
+    "id": "dalian-suoyuwan-football-stadium",
+    "name": "Dalian Suoyuwan Football Stadium",
+    "city": null,
+    "countryCode": "CHN",
+    "capacity": 63667,
+    "tenantClubs": [
+      "dalian-yingbo-f-c"
+    ]
+  },
+  {
+    "id": "soldier-field",
+    "name": "Soldier Field",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 63500,
+    "tenantClubs": [
+      "arizona-cardinals",
+      "chicago-bears",
+      "chicago-fire-fc",
+      "chicago-rockets",
+      "chicago-winds"
+    ]
+  },
+  {
+    "id": "lavell-edwards-stadium",
+    "name": "LaVell Edwards Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 63470,
+    "tenantClubs": [
+      "byu-cougars",
+      "byu-cougars-football"
+    ]
+  },
+  {
+    "id": "state-farm-stadium",
+    "name": "State Farm Stadium",
+    "city": "Glendale",
+    "countryCode": "USA",
+    "capacity": 63400,
+    "tenantClubs": [
+      "arizona-cardinals"
+    ]
+  },
+  {
+    "id": "jalisco-stadium",
+    "name": "Jalisco Stadium",
+    "city": null,
+    "countryCode": "MEX",
+    "capacity": 63200,
+    "tenantClubs": [
+      "atlas-f-c"
+    ]
+  },
+  {
+    "id": "munich-olympic-stadium",
+    "name": "Munich Olympic Stadium",
+    "city": "Am Riesenfeld",
+    "countryCode": "DEU",
+    "capacity": 63118,
+    "tenantClubs": [
+      "1972-summer-olympics",
+      "fc-bayern-munich",
+      "tsv-1860-munchen"
+    ]
+  },
+  {
+    "id": "q2337131",
+    "name": "Q2337131",
+    "city": null,
+    "countryCode": null,
+    "capacity": 63000,
+    "tenantClubs": []
+  },
+  {
+    "id": "tottenham-hotspur-stadium",
+    "name": "Tottenham Hotspur Stadium",
+    "city": "Tottenham",
+    "countryCode": "GBR",
+    "capacity": 62850,
+    "tenantClubs": [
+      "tottenham-hotspur-f-c"
+    ]
+  },
+  {
+    "id": "moses-mabhida-stadium",
+    "name": "Moses Mabhida Stadium",
+    "city": null,
+    "countryCode": "ZAF",
+    "capacity": 62760,
+    "tenantClubs": [
+      "amazulu-f-c"
+    ]
+  },
+  {
+    "id": "ellis-park-stadium",
+    "name": "Ellis Park Stadium",
+    "city": "Johannesburg",
+    "countryCode": "ZAF",
+    "capacity": 62567,
+    "tenantClubs": [
+      "lions"
+    ]
+  },
+  {
+    "id": "london-stadium",
+    "name": "London Stadium",
+    "city": "London",
+    "countryCode": "GBR",
+    "capacity": 62500,
+    "tenantClubs": [
+      "uk-athletics",
+      "west-ham-united-f-c"
+    ]
+  },
+  {
+    "id": "ross-ade-stadium",
+    "name": "Ross–Ade Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 62500,
+    "tenantClubs": [
+      "purdue-boilermakers"
+    ]
+  },
+  {
+    "id": "california-memorial-stadium",
+    "name": "California Memorial Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 62467,
+    "tenantClubs": [
+      "california-golden-bears",
+      "california-golden-bears-football"
+    ]
+  },
+  {
+    "id": "astrodome",
+    "name": "Astrodome",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 62439,
+    "tenantClubs": [
+      "houston-astros"
+    ]
+  },
+  {
+    "id": "lucas-oil-stadium",
+    "name": "Lucas Oil Stadium",
+    "city": "Indianapolis",
+    "countryCode": "USA",
+    "capacity": 62421,
+    "tenantClubs": [
+      "indianapolis-colts"
+    ]
+  },
+  {
+    "id": "arena-aufschalke",
+    "name": "Arena AufSchalke",
+    "city": "Gelsenkirchen",
+    "countryCode": "DEU",
+    "capacity": 62271,
+    "tenantClubs": [
+      "schalke-04"
+    ]
+  },
+  {
+    "id": "parkstadion",
+    "name": "Parkstadion",
+    "city": "Gelsenkirchen",
+    "countryCode": "DEU",
+    "capacity": 62008,
+    "tenantClubs": [
+      "schalke-04"
+    ]
+  },
+  {
+    "id": "shanxi-sports-centre-stadium",
+    "name": "Shanxi Sports Centre Stadium",
+    "city": null,
+    "countryCode": "CHN",
+    "capacity": 62000,
+    "tenantClubs": []
+  },
+  {
+    "id": "faurot-field",
+    "name": "Faurot Field",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 61620,
+    "tenantClubs": [
+      "missouri-tigers"
+    ]
+  },
+  {
+    "id": "scott-stadium",
+    "name": "Scott Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 61500,
+    "tenantClubs": [
+      "virginia-cavaliers",
+      "virginia-cavaliers-football"
+    ]
+  },
+  {
+    "id": "yale-bowl",
+    "name": "Yale Bowl",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 61446,
+    "tenantClubs": [
+      "yale-bulldogs"
+    ]
+  },
+  {
+    "id": "davis-wade-stadium",
+    "name": "Davis Wade Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 61337,
+    "tenantClubs": [
+      "mississippi-state-bulldogs-football"
+    ]
+  },
+  {
+    "id": "anfield",
+    "name": "Anfield",
+    "city": "Liverpool",
+    "countryCode": "GBR",
+    "capacity": 61276,
+    "tenantClubs": [
+      "everton-f-c",
+      "liverpool-f-c"
+    ]
+  },
+  {
+    "id": "kroger-field",
+    "name": "Kroger Field",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 61000,
+    "tenantClubs": [
+      "kentucky-wildcats-football"
+    ]
+  },
+  {
+    "id": "estadio-benito-villamarin",
+    "name": "Estadio Benito Villamarín",
+    "city": null,
+    "countryCode": "ESP",
+    "capacity": 60721,
+    "tenantClubs": [
+      "real-betis-balompie"
+    ]
+  },
+  {
+    "id": "arena-do-gremio",
+    "name": "Arena do Grêmio",
+    "city": "Porto Alegre",
+    "countryCode": "BRA",
+    "capacity": 60540,
+    "tenantClubs": [
+      "gremio-fbpa"
+    ]
+  },
+  {
+    "id": "mississippi-veterans-memorial-stadium",
+    "name": "Mississippi Veterans Memorial Stadium",
+    "city": "Jackson",
+    "countryCode": "USA",
+    "capacity": 60492,
+    "tenantClubs": [
+      "magnolia-gridiron-all-star-classic"
+    ]
+  },
+  {
+    "id": "abuja-stadium",
+    "name": "Abuja Stadium",
+    "city": null,
+    "countryCode": "NGA",
+    "capacity": 60491,
+    "tenantClubs": [
+      "nigeria-men-s-national-football-team"
+    ]
+  },
+  {
+    "id": "jones-at-t-stadium",
+    "name": "Jones AT&T Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 60454,
+    "tenantClubs": [
+      "texas-tech-red-raiders",
+      "texas-tech-red-raiders-football"
+    ]
+  },
+  {
+    "id": "celtic-park",
+    "name": "Celtic Park",
+    "city": "Parkhead",
+    "countryCode": "GBR",
+    "capacity": 60355,
+    "tenantClubs": [
+      "celtic-f-c"
+    ]
+  },
+  {
+    "id": "emirates-stadium",
+    "name": "Emirates Stadium",
+    "city": "Holloway",
+    "countryCode": "GBR",
+    "capacity": 60338,
+    "tenantClubs": [
+      "arsenal-f-c",
+      "arsenal-w-f-c"
+    ]
+  },
+  {
+    "id": "shenzhen-universiade-sports-centre",
+    "name": "Shenzhen Universiade Sports Centre",
+    "city": null,
+    "countryCode": "CHN",
+    "capacity": 60334,
+    "tenantClubs": [
+      "2011-summer-universiade"
+    ]
+  },
+  {
+    "id": "guangxi-sports-center",
+    "name": "Guangxi Sports Center",
+    "city": null,
+    "countryCode": "CHN",
+    "capacity": 60274,
+    "tenantClubs": []
+  },
+  {
+    "id": "jawaharlal-nehru-stadium",
+    "name": "Jawaharlal Nehru Stadium",
+    "city": "New Delhi",
+    "countryCode": "IND",
+    "capacity": 60254,
+    "tenantClubs": [
+      "2010-commonwealth-games"
+    ]
+  },
+  {
+    "id": "estadio-centenario",
+    "name": "Estadio Centenario",
+    "city": null,
+    "countryCode": "URY",
+    "capacity": 60235,
+    "tenantClubs": [
+      "uruguayan-football-association"
+    ]
+  },
+  {
+    "id": "boone-pickens-stadium",
+    "name": "Boone Pickens Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 60218,
+    "tenantClubs": [
+      "oklahoma-state-cowboys-and-cowgirls",
+      "oklahoma-state-cowboys-football"
+    ]
+  },
+  {
+    "id": "mhparena",
+    "name": "MHPArena",
+    "city": "Stuttgart",
+    "countryCode": "DEU",
+    "capacity": 60058,
+    "tenantClubs": [
+      "vfb-stuttgart"
+    ]
+  },
+  {
+    "id": "estadio-do-arruda",
+    "name": "Estádio do Arruda",
+    "city": null,
+    "countryCode": "BRA",
+    "capacity": 60044,
+    "tenantClubs": [
+      "santa-cruz-futebol-clube"
+    ]
+  },
+  {
+    "id": "jawaharlal-nehru-international-stadium",
+    "name": "Jawaharlal Nehru International Stadium",
+    "city": "Kaloor",
+    "countryCode": "IND",
+    "capacity": 60000,
+    "tenantClubs": [
+      "kerala-blasters-fc"
+    ]
+  },
+  {
+    "id": "sportforum-chemnitz",
+    "name": "Sportforum Chemnitz",
+    "city": "Bernsdorf",
+    "countryCode": "DEU",
+    "capacity": 60000,
+    "tenantClubs": []
+  },
+  {
+    "id": "xi-an-international-football-center",
+    "name": "Xi'an International Football Center",
+    "city": null,
+    "countryCode": "CHN",
+    "capacity": 60000,
+    "tenantClubs": [
+      "shaanxi-union-f-c"
+    ]
+  },
+  {
+    "id": "edmund-szyc-stadium",
+    "name": "Edmund Szyc Stadium",
+    "city": null,
+    "countryCode": "POL",
+    "capacity": 60000,
+    "tenantClubs": [
+      "warta-poznan"
+    ]
+  },
+  {
+    "id": "mogadishu-stadium",
+    "name": "Mogadishu Stadium",
+    "city": "Mogadishu",
+    "countryCode": "SOM",
+    "capacity": 60000,
+    "tenantClubs": [
+      "somali-first-division",
+      "somalia-men-s-national-football-team"
+    ]
+  },
+  {
+    "id": "haixia-olympic-center-stadium",
+    "name": "Haixia Olympic Center Stadium",
+    "city": null,
+    "countryCode": "CHN",
+    "capacity": 60000,
+    "tenantClubs": [
+      "2017-china-open-badminton-championships"
+    ]
+  },
+  {
+    "id": "gaddafi-stadium",
+    "name": "Gaddafi Stadium",
+    "city": null,
+    "countryCode": "PAK",
+    "capacity": 60000,
+    "tenantClubs": []
+  },
+  {
+    "id": "benjamin-mkapa-national-stadium",
+    "name": "Benjamin Mkapa National Stadium",
+    "city": null,
+    "countryCode": "TZA",
+    "capacity": 60000,
+    "tenantClubs": [
+      "tanzania-men-s-national-football-team",
+      "young-africans-s-c"
+    ]
+  },
+  {
+    "id": "tianjin-olympic-center-stadium",
+    "name": "Tianjin Olympic Center Stadium",
+    "city": "Tianjin",
+    "countryCode": "CHN",
+    "capacity": 60000,
+    "tenantClubs": [
+      "tianjin-jinmen-tiger-f-c"
+    ]
+  },
+  {
+    "id": "mountaineer-field-at-milan-puskar-stadium",
+    "name": "Mountaineer Field at Milan Puskar Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 60000,
+    "tenantClubs": [
+      "west-virginia-mountaineers-football"
+    ]
+  },
+  {
+    "id": "mario-alberto-kempes-stadium",
+    "name": "Mario Alberto Kempes Stadium",
+    "city": "Córdoba",
+    "countryCode": "ARG",
+    "capacity": 60000,
+    "tenantClubs": [
+      "talleres-de-cordoba"
+    ]
+  },
+  {
+    "id": "alassane-ouattara-stadium",
+    "name": "Alassane Ouattara Stadium",
+    "city": null,
+    "countryCode": "CIV",
+    "capacity": 60000,
+    "tenantClubs": [
+      "ivory-coast-men-s-national-football-team"
+    ]
+  },
+  {
+    "id": "hefei-olympic-sports-center-stadium",
+    "name": "Hefei Olympic Sports Center Stadium",
+    "city": "Hefei",
+    "countryCode": "CHN",
+    "capacity": 60000,
+    "tenantClubs": [
+      "anhui-jiufang-f-c"
+    ]
+  },
+  {
+    "id": "national-sports-stadium",
+    "name": "National Sports Stadium",
+    "city": null,
+    "countryCode": "ZWE",
+    "capacity": 60000,
+    "tenantClubs": [
+      "zimbabwe-men-s-national-football-team"
+    ]
+  },
+  {
+    "id": "shenyang-olympic-sports-center-stadium",
+    "name": "Shenyang Olympic Sports Center Stadium",
+    "city": null,
+    "countryCode": "CHN",
+    "capacity": 60000,
+    "tenantClubs": [
+      "shenyang-dongjin-f-c"
+    ]
+  },
+  {
+    "id": "national-heroes-stadium",
+    "name": "National Heroes Stadium",
+    "city": null,
+    "countryCode": "ZMB",
+    "capacity": 60000,
+    "tenantClubs": [
+      "zambia-men-s-national-football-team"
+    ]
+  },
+  {
+    "id": "stade-leopold-sedar-senghor",
+    "name": "Stade Léopold Sédar Senghor",
+    "city": null,
+    "countryCode": "SEN",
+    "capacity": 60000,
+    "tenantClubs": [
+      "senegal-men-s-national-association-football-team"
+    ]
+  },
+  {
+    "id": "guangxi-sports-centre-stadium",
+    "name": "Guangxi Sports Centre Stadium",
+    "city": null,
+    "countryCode": "CHN",
+    "capacity": 60000,
+    "tenantClubs": []
+  },
+  {
+    "id": "jinan-olympic-sports-center-stadium",
+    "name": "Jinan Olympic Sports Center Stadium",
+    "city": "Jinan Olympic Sports Center",
+    "countryCode": "CHN",
+    "capacity": 60000,
+    "tenantClubs": [
+      "shandong-taishan-f-c"
+    ]
+  },
+  {
+    "id": "perth-stadium",
+    "name": "Perth Stadium",
+    "city": "Burswood",
+    "countryCode": "AUS",
+    "capacity": 60000,
+    "tenantClubs": [
+      "fremantle-football-club",
+      "perth-scorchers",
+      "west-coast-eagles"
+    ]
+  },
+  {
+    "id": "wuhu-olympic-stadium",
+    "name": "Wuhu Olympic Stadium",
+    "city": null,
+    "countryCode": "CHN",
+    "capacity": 60000,
+    "tenantClubs": []
+  },
+  {
+    "id": "moi-international-sports-centre",
+    "name": "Moi International Sports Centre",
+    "city": "Kasarani",
+    "countryCode": "KEN",
+    "capacity": 60000,
+    "tenantClubs": [
+      "kenya-men-s-national-football-team"
+    ]
+  },
+  {
+    "id": "bahir-dar-stadium",
+    "name": "Bahir Dar Stadium",
+    "city": "Bahir Dar",
+    "countryCode": "ETH",
+    "capacity": 60000,
+    "tenantClubs": [
+      "ethiopia-men-s-national-football-team"
+    ]
+  },
+  {
+    "id": "tajiat-olympic-stadium",
+    "name": "Tajiat Olympic Stadium",
+    "city": null,
+    "countryCode": "IRQ",
+    "capacity": 60000,
+    "tenantClubs": []
+  },
+  {
+    "id": "al-ahly-sc-stadium",
+    "name": "Al Ahly SC Stadium",
+    "city": null,
+    "countryCode": "EGY",
+    "capacity": 60000,
+    "tenantClubs": [
+      "al-ahly-sc"
+    ]
+  },
+  {
+    "id": "damanhour-stadium",
+    "name": "Damanhour Stadium",
+    "city": null,
+    "countryCode": "EGY",
+    "capacity": 60000,
+    "tenantClubs": []
+  },
+  {
+    "id": "dsc-multi-purpose-stadium",
+    "name": "DSC Multi-Purpose Stadium",
+    "city": "Dubai",
+    "countryCode": "ARE",
+    "capacity": 60000,
+    "tenantClubs": []
+  },
+  {
+    "id": "stadion-maksimir",
+    "name": "Stadion Maksimir",
+    "city": "Maksimirska naselja",
+    "countryCode": "HRV",
+    "capacity": 60000,
+    "tenantClubs": [
+      "croatia-men-s-national-football-team",
+      "gnk-dinamo-zagreb",
+      "hask",
+      "nk-lokomotiva"
+    ]
+  },
+  {
+    "id": "rufaro-stadium",
+    "name": "Rufaro Stadium",
+    "city": "Harare",
+    "countryCode": "ZWE",
+    "capacity": 60000,
+    "tenantClubs": []
+  },
+  {
+    "id": "borussia-park",
+    "name": "Borussia-Park",
+    "city": null,
+    "countryCode": "DEU",
+    "capacity": 59749,
+    "tenantClubs": [
+      "borussia-monchengladbach"
+    ]
+  },
+  {
+    "id": "parc-olympique-lyonnais",
+    "name": "Parc Olympique Lyonnais",
+    "city": "Décines-Charpieu",
+    "countryCode": "FRA",
+    "capacity": 59286,
+    "tenantClubs": [
+      "olympique-lyonnais"
+    ]
+  },
+  {
+    "id": "el-inodoro",
+    "name": "El inodoro",
+    "city": "La Boca",
+    "countryCode": "ARG",
+    "capacity": 58840,
+    "tenantClubs": [
+      "argentina-men-s-national-association-football-team",
+      "boca-juniors",
+      "passion-for-boca-juniors-museum"
+    ]
+  },
+  {
+    "id": "tianhe-stadium",
+    "name": "Tianhe Stadium",
+    "city": "Tianhe District",
+    "countryCode": "CHN",
+    "capacity": 58500,
+    "tenantClubs": [
+      "guangzhou-f-c"
+    ]
+  },
+  {
+    "id": "cape-town-stadium",
+    "name": "Cape Town Stadium",
+    "city": "Cape Town",
+    "countryCode": "ZAF",
+    "capacity": 58309,
+    "tenantClubs": [
+      "cape-town-city-f-c",
+      "stormers"
+    ]
+  },
+  {
+    "id": "kazimierz-gorski-national-stadium",
+    "name": "Kazimierz Górski National Stadium",
+    "city": null,
+    "countryCode": "POL",
+    "capacity": 58274,
+    "tenantClubs": [
+      "poland-men-s-national-football-team"
+    ]
+  },
+  {
+    "id": "stadio-san-nicola",
+    "name": "Stadio San Nicola",
+    "city": null,
+    "countryCode": "ITA",
+    "capacity": 58270,
+    "tenantClubs": [
+      "ssc-bari"
+    ]
+  },
+  {
+    "id": "castelao",
+    "name": "Castelão",
+    "city": "Fortaleza",
+    "countryCode": "BRA",
+    "capacity": 57876,
+    "tenantClubs": [
+      "ceara-sporting-club",
+      "fortaleza-e-c"
+    ]
+  },
+  {
+    "id": "carter-finley-stadium",
+    "name": "Carter–Finley Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 57583,
+    "tenantClubs": [
+      "nc-state-wolfpack",
+      "nc-state-wolfpack-football"
+    ]
+  },
+  {
+    "id": "volksparkstadion",
+    "name": "Volksparkstadion",
+    "city": "Hamburg",
+    "countryCode": "DEU",
+    "capacity": 57000,
+    "tenantClubs": [
+      "hamburger-sv"
+    ]
+  },
+  {
+    "id": "commonwealth-stadium",
+    "name": "Commonwealth Stadium",
+    "city": null,
+    "countryCode": "CAN",
+    "capacity": 56302,
+    "tenantClubs": [
+      "edmonton-drillers",
+      "edmonton-elks"
+    ]
+  },
+  {
+    "id": "arizona-stadium",
+    "name": "Arizona Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 56037,
+    "tenantClubs": [
+      "arizona-wildcats"
+    ]
+  },
+  {
+    "id": "dodger-stadium",
+    "name": "Dodger Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 56000,
+    "tenantClubs": [
+      "los-angeles-angels",
+      "los-angeles-dodgers"
+    ]
+  },
+  {
+    "id": "great-strahov-stadium",
+    "name": "Great Strahov Stadium",
+    "city": null,
+    "countryCode": "CZE",
+    "capacity": 56000,
+    "tenantClubs": [
+      "ac-sparta-prague",
+      "ac-sparta-prague-b"
+    ]
+  },
+  {
+    "id": "el-cilindro",
+    "name": "El Cilindro",
+    "city": "Avellaneda",
+    "countryCode": "ARG",
+    "capacity": 55880,
+    "tenantClubs": [
+      "racing-club",
+      "racing-club-women-s"
+    ]
+  },
+  {
+    "id": "rajko-mitic-stadium",
+    "name": "Rajko Mitić Stadium",
+    "city": "Autokomanda",
+    "countryCode": "SRB",
+    "capacity": 55538,
+    "tenantClubs": [
+      "fk-crvena-zvezda"
+    ]
+  },
+  {
+    "id": "gies-memorial-stadium",
+    "name": "Gies Memorial Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 55524,
+    "tenantClubs": [
+      "chicago-bears",
+      "illinois-fighting-illini-football"
+    ]
+  },
+  {
+    "id": "etihad-stadium",
+    "name": "Etihad Stadium",
+    "city": "Manchester",
+    "countryCode": "GBR",
+    "capacity": 55017,
+    "tenantClubs": [
+      "manchester-city-f-c"
+    ]
+  },
+  {
+    "id": "helong-stadium",
+    "name": "Helong Stadium",
+    "city": null,
+    "countryCode": "CHN",
+    "capacity": 55000,
+    "tenantClubs": [
+      "hunan-billows-f-c"
+    ]
+  },
+  {
+    "id": "national-stadium",
+    "name": "National Stadium",
+    "city": "Zuoying District",
+    "countryCode": "TWN",
+    "capacity": 55000,
+    "tenantClubs": [
+      "world-games-2009"
+    ]
+  },
+  {
+    "id": "plovdiv-stadium",
+    "name": "Plovdiv Stadium",
+    "city": null,
+    "countryCode": "BGR",
+    "capacity": 55000,
+    "tenantClubs": [
+      "botev-plovdiv"
+    ]
+  },
+  {
+    "id": "bobby-dodd-stadium",
+    "name": "Bobby Dodd Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 55000,
+    "tenantClubs": [
+      "atlanta-united-fc",
+      "georgia-tech-yellow-jackets",
+      "georgia-tech-yellow-jackets-football"
+    ]
+  },
+  {
+    "id": "national-stadium-sgp",
+    "name": "National Stadium",
+    "city": "Kallang",
+    "countryCode": "SGP",
+    "capacity": 55000,
+    "tenantClubs": [
+      "singapore-men-s-national-football-team"
+    ]
+  },
+  {
+    "id": "kings-park-stadium",
+    "name": "Kings Park Stadium",
+    "city": "Durban",
+    "countryCode": "ZAF",
+    "capacity": 55000,
+    "tenantClubs": [
+      "sharks"
+    ]
+  },
+  {
+    "id": "l-n-federal-credit-union-stadium",
+    "name": "L&N Federal Credit Union Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 55000,
+    "tenantClubs": [
+      "louisville-cardinals",
+      "louisville-cardinals-football"
+    ]
+  },
+  {
+    "id": "lagos-national-stadium",
+    "name": "Lagos National Stadium",
+    "city": null,
+    "countryCode": "NGA",
+    "capacity": 55000,
+    "tenantClubs": []
+  },
+  {
+    "id": "tokyo-dome",
+    "name": "Tokyo Dome",
+    "city": "Tokyo Dome City",
+    "countryCode": "JPN",
+    "capacity": 55000,
+    "tenantClubs": [
+      "hokkaido-nippon-ham-fighters",
+      "yomiuri-giants"
+    ]
+  },
+  {
+    "id": "estadio-latinoamericano",
+    "name": "Estadio Latinoamericano",
+    "city": null,
+    "countryCode": "CUB",
+    "capacity": 55000,
+    "tenantClubs": [
+      "cuban-national-series",
+      "industriales"
+    ]
+  },
+  {
+    "id": "gelora-bung-tomo-stadium",
+    "name": "Gelora Bung Tomo Stadium",
+    "city": "Surabaya",
+    "countryCode": "IDN",
+    "capacity": 55000,
+    "tenantClubs": [
+      "persebaya-surabaya"
+    ]
+  },
+  {
+    "id": "johan-cruyff-arena",
+    "name": "Johan Cruyff Arena",
+    "city": null,
+    "countryCode": null,
+    "capacity": 54990,
+    "tenantClubs": [
+      "afc-ajax"
+    ]
+  },
+  {
+    "id": "dinamo-arena",
+    "name": "Dinamo Arena",
+    "city": null,
+    "countryCode": "GEO",
+    "capacity": 54549,
+    "tenantClubs": [
+      "georgia-men-s-national-rugby-union-team"
+    ]
+  },
+  {
+    "id": "bc-place",
+    "name": "BC Place",
+    "city": "Vancouver",
+    "countryCode": "CAN",
+    "capacity": 54500,
+    "tenantClubs": [
+      "bc-lions",
+      "vancouver-whitecaps-fc"
+    ]
+  },
+  {
+    "id": "silesian-stadium",
+    "name": "Silesian Stadium",
+    "city": "Silesian Park",
+    "countryCode": "POL",
+    "capacity": 54378,
+    "tenantClubs": [
+      "2023-european-team-championships",
+      "poland-men-s-national-football-team"
+    ]
+  },
+  {
+    "id": "wuhan-sports-center",
+    "name": "Wuhan Sports Center",
+    "city": null,
+    "countryCode": "CHN",
+    "capacity": 54357,
+    "tenantClubs": [
+      "wuhan-yangtze-river-f-c"
+    ]
+  },
+  {
+    "id": "strawberry-arena",
+    "name": "Strawberry Arena",
+    "city": null,
+    "countryCode": "SWE",
+    "capacity": 54329,
+    "tenantClubs": [
+      "aik-fotboll",
+      "sweden-men-s-national-football-team"
+    ]
+  },
+  {
+    "id": "hrazdan-stadium",
+    "name": "Hrazdan Stadium",
+    "city": "Yerevan",
+    "countryCode": "ARM",
+    "capacity": 54208,
+    "tenantClubs": [
+      "armenia-men-s-national-football-team"
+    ]
+  },
+  {
+    "id": "estadio-serra-dourada",
+    "name": "Estádio Serra Dourada",
+    "city": "Goiânia",
+    "countryCode": "BRA",
+    "capacity": 54084,
+    "tenantClubs": [
+      "goias-esporte-clube"
+    ]
+  },
+  {
+    "id": "autzen-stadium",
+    "name": "Autzen Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 53800,
+    "tenantClubs": [
+      "oregon-ducks-football"
+    ]
+  },
+  {
+    "id": "estadio-monterrey",
+    "name": "Estadio Monterrey",
+    "city": "Monterrey",
+    "countryCode": "MEX",
+    "capacity": 53500,
+    "tenantClubs": [
+      "club-de-futbol-monterrey"
+    ]
+  },
+  {
+    "id": "estadio-parque-do-sabia",
+    "name": "Estádio Parque do Sabiá",
+    "city": null,
+    "countryCode": "BRA",
+    "capacity": 53350,
+    "tenantClubs": [
+      "clube-atletico-portal",
+      "uberlandia-e-c"
+    ]
+  },
+  {
+    "id": "san-mames-stadium",
+    "name": "San Mamés Stadium",
+    "city": null,
+    "countryCode": "ESP",
+    "capacity": 53289,
+    "tenantClubs": [
+      "athletic-club"
+    ]
+  },
+  {
+    "id": "unique-diego-armando-maradona-stadium",
+    "name": "Unique Diego Armando Maradona Stadium",
+    "city": "La Plata",
+    "countryCode": "ARG",
+    "capacity": 53000,
+    "tenantClubs": [
+      "argentina-men-s-national-association-football-team",
+      "argentina-national-rugby-union-team"
+    ]
+  },
+  {
+    "id": "semple-stadium",
+    "name": "Semple Stadium",
+    "city": "Thurles",
+    "countryCode": "IRL",
+    "capacity": 53000,
+    "tenantClubs": [
+      "tipperary-gaa"
+    ]
+  },
+  {
+    "id": "ems-stadium",
+    "name": "EMS Stadium",
+    "city": null,
+    "countryCode": "IND",
+    "capacity": 53000,
+    "tenantClubs": [
+      "india-men-s-national-football-team",
+      "kerala-football-team"
+    ]
+  },
+  {
+    "id": "memorial-stadium-usa",
+    "name": "Memorial Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 52929,
+    "tenantClubs": [
+      "indiana-hoosiers"
+    ]
+  },
+  {
+    "id": "rams-park",
+    "name": "Rams Park",
+    "city": null,
+    "countryCode": "TUR",
+    "capacity": 52652,
+    "tenantClubs": [
+      "galatasaray-s-k"
+    ]
+  },
+  {
+    "id": "donbass-arena",
+    "name": "Donbass Arena",
+    "city": null,
+    "countryCode": "UKR",
+    "capacity": 52518,
+    "tenantClubs": [
+      "fc-shakhtar-donetsk"
+    ]
+  },
+  {
+    "id": "as-roma-stadium",
+    "name": "AS Roma Stadium",
+    "city": null,
+    "countryCode": "ITA",
+    "capacity": 52500,
+    "tenantClubs": [
+      "as-roma"
+    ]
+  },
+  {
+    "id": "lang-park",
+    "name": "Lang Park",
+    "city": null,
+    "countryCode": "AUS",
+    "capacity": 52500,
+    "tenantClubs": [
+      "brisbane-broncos",
+      "brisbane-broncos-women-s-rugby-league",
+      "brisbane-roar-fc",
+      "queensland-maroons",
+      "queensland-reds",
+      "south-queensland-crushers"
+    ]
+  },
+  {
+    "id": "st-james-park",
+    "name": "St James’ Park",
+    "city": "Newcastle upon Tyne",
+    "countryCode": "GBR",
+    "capacity": 52305,
+    "tenantClubs": [
+      "newcastle-united-f-c"
+    ]
+  },
+  {
+    "id": "incheon-munhak-sports-complex",
+    "name": "Incheon Munhak Sports Complex",
+    "city": null,
+    "countryCode": "KOR",
+    "capacity": 52179,
+    "tenantClubs": [
+      "incheon-united-fc"
+    ]
+  },
+  {
+    "id": "estadio-jose-alvalade",
+    "name": "Estádio José Alvalade",
+    "city": "Lisbon",
+    "countryCode": "PRT",
+    "capacity": 52095,
+    "tenantClubs": [
+      "sporting-cp"
+    ]
+  },
+  {
+    "id": "huainan-sports-stadium",
+    "name": "Huainan Sports Stadium",
+    "city": null,
+    "countryCode": "CHN",
+    "capacity": 52080,
+    "tenantClubs": []
+  },
+  {
+    "id": "estadio-monumental-de-maturin",
+    "name": "Estadio Monumental de Maturín",
+    "city": null,
+    "countryCode": "VEN",
+    "capacity": 52000,
+    "tenantClubs": [
+      "monagas-sport-club"
+    ]
+  },
+  {
+    "id": "stade-ahmadou-ahidjo",
+    "name": "Stade Ahmadou Ahidjo",
+    "city": null,
+    "countryCode": "CMR",
+    "capacity": 52000,
+    "tenantClubs": [
+      "cameroon-men-s-national-football-team",
+      "canon-yaounde",
+      "tonnerre-yaounde"
+    ]
+  },
+  {
+    "id": "guiyang-olympic-sports-center",
+    "name": "Guiyang Olympic Sports Center",
+    "city": "Guanshanhu District",
+    "countryCode": "CHN",
+    "capacity": 52000,
+    "tenantClubs": [
+      "guizhou-renhe-f-c"
+    ]
+  },
+  {
+    "id": "proposed-domed-brooklyn-dodgers-stadium",
+    "name": "Proposed domed Brooklyn Dodgers stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 52000,
+    "tenantClubs": [
+      "brooklyn-dodgers"
+    ]
+  },
+  {
+    "id": "newlands-stadium",
+    "name": "Newlands Stadium",
+    "city": "Cape Town",
+    "countryCode": "ZAF",
+    "capacity": 51900,
+    "tenantClubs": [
+      "stormers",
+      "western-province"
+    ]
+  },
+  {
+    "id": "hampden-park",
+    "name": "Hampden Park",
+    "city": "Glasgow",
+    "countryCode": "GBR",
+    "capacity": 51866,
+    "tenantClubs": [
+      "queen-s-park-f-c",
+      "scotland-women-s-national-football-team"
+    ]
+  },
+  {
+    "id": "secu-stadium",
+    "name": "SECU Stadium",
+    "city": "University of Maryland",
+    "countryCode": "USA",
+    "capacity": 51802,
+    "tenantClubs": [
+      "maryland-terrapins",
+      "maryland-terrapins-football",
+      "maryland-terrapins-men-s-lacrosse",
+      "maryland-terrapins-men-s-soccer"
+    ]
+  },
+  {
+    "id": "loftus-versfeld-stadium",
+    "name": "Loftus Versfeld Stadium",
+    "city": null,
+    "countryCode": "ZAF",
+    "capacity": 51762,
+    "tenantClubs": [
+      "blue-bulls",
+      "bulls",
+      "kaizer-chiefs-f-c",
+      "mamelodi-sundowns-f-c"
+    ]
+  },
+  {
+    "id": "aviva-stadium",
+    "name": "Aviva Stadium",
+    "city": null,
+    "countryCode": "IRL",
+    "capacity": 51700,
+    "tenantClubs": [
+      "football-association-of-ireland",
+      "irish-rugby-football-union"
+    ]
+  },
+  {
+    "id": "ibrox-stadium",
+    "name": "Ibrox Stadium",
+    "city": "Glasgow",
+    "countryCode": "GBR",
+    "capacity": 51700,
+    "tenantClubs": [
+      "rangers-f-c"
+    ]
+  },
+  {
+    "id": "de-kuip",
+    "name": "De Kuip",
+    "city": "Rotterdam",
+    "countryCode": null,
+    "capacity": 51577,
+    "tenantClubs": [
+      "feyenoord-rotterdam"
+    ]
+  },
+  {
+    "id": "sun-bowl-stadium",
+    "name": "Sun Bowl Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 51500,
+    "tenantClubs": [
+      "utep-miners",
+      "utep-miners-football"
+    ]
+  },
+  {
+    "id": "waldstadion",
+    "name": "Waldstadion",
+    "city": "Frankfurt",
+    "countryCode": "DEU",
+    "capacity": 51500,
+    "tenantClubs": [
+      "eintracht-frankfurt"
+    ]
+  },
+  {
+    "id": "shizuoka-stadium",
+    "name": "Shizuoka Stadium",
+    "city": "Fukuroi",
+    "countryCode": "JPN",
+    "capacity": 51349,
+    "tenantClubs": [
+      "jubilo-iwata"
+    ]
+  },
+  {
+    "id": "ghadir-stadium",
+    "name": "Ghadir Stadium",
+    "city": "Ahvaz",
+    "countryCode": "IRN",
+    "capacity": 51000,
+    "tenantClubs": [
+      "foolad-f-c"
+    ]
+  },
+  {
+    "id": "huanglong-sports-center",
+    "name": "Huanglong Sports Center",
+    "city": null,
+    "countryCode": "CHN",
+    "capacity": 51000,
+    "tenantClubs": [
+      "zhejiang-professional-f-c"
+    ]
+  },
+  {
+    "id": "estadio-akron",
+    "name": "Estadio Akron",
+    "city": "Guadalajara",
+    "countryCode": "MEX",
+    "capacity": 50850,
+    "tenantClubs": [
+      "c-d-guadalajara"
+    ]
+  },
+  {
+    "id": "huntington-bank-stadium",
+    "name": "Huntington Bank Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 50805,
+    "tenantClubs": [
+      "minnesota-golden-gophers",
+      "minnesota-golden-gophers-football",
+      "minnesota-united-fc",
+      "minnesota-vikings"
+    ]
+  },
+  {
+    "id": "chengdu-phoenix-hill-football-stadium",
+    "name": "Chengdu Phoenix Hill Football Stadium",
+    "city": "Chengdu",
+    "countryCode": "CHN",
+    "capacity": 50695,
+    "tenantClubs": []
+  },
+  {
+    "id": "sukru-saracoglu-stadium",
+    "name": "Şükrü Saracoğlu Stadium",
+    "city": "Kadıköy",
+    "countryCode": "TUR",
+    "capacity": 50530,
+    "tenantClubs": [
+      "fenerbahce-istanbul"
+    ]
+  },
+  {
+    "id": "khalifa-international-stadium",
+    "name": "Khalifa International Stadium",
+    "city": "Al Rayyan",
+    "countryCode": "QAT",
+    "capacity": 50500,
+    "tenantClubs": [
+      "qatar-men-s-national-football-team"
+    ]
+  },
+  {
+    "id": "coors-field",
+    "name": "Coors Field",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 50480,
+    "tenantClubs": [
+      "colorado-rockies"
+    ]
+  },
+  {
+    "id": "jose-maria-minella-stadium",
+    "name": "José María Minella Stadium",
+    "city": "Mar del Plata",
+    "countryCode": "ARG",
+    "capacity": 50180,
+    "tenantClubs": [
+      "alvarado",
+      "club-atletico-aldosivi"
+    ]
+  },
+  {
+    "id": "simmons-bank-liberty-stadium",
+    "name": "Simmons Bank Liberty Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 50160,
+    "tenantClubs": [
+      "houston-gamblers",
+      "memphis-express",
+      "memphis-rogues",
+      "memphis-tigers",
+      "memphis-tigers-football",
+      "tennessee-titans"
+    ]
+  },
+  {
+    "id": "ekana-cricket-stadium",
+    "name": "Ekana Cricket Stadium",
+    "city": "Lucknow",
+    "countryCode": "IND",
+    "capacity": 50100,
+    "tenantClubs": [
+      "afghanistan-national-cricket-team",
+      "india-national-cricket-team",
+      "india-women-s-national-cricket-team",
+      "lucknow-super-giants",
+      "up-warriorz",
+      "uttar-pradesh-cricket-team"
+    ]
+  },
+  {
+    "id": "david-booth-kansas-memorial-stadium",
+    "name": "David Booth Kansas Memorial Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 50071,
+    "tenantClubs": [
+      "kansas-jayhawks",
+      "kansas-jayhawks-football"
+    ]
+  },
+  {
+    "id": "estadio-do-dragao",
+    "name": "Estádio do Dragão",
+    "city": "Porto",
+    "countryCode": "PRT",
+    "capacity": 50033,
+    "tenantClubs": [
+      "fc-porto"
+    ]
+  },
+  {
+    "id": "king-baudouin-stadium",
+    "name": "King Baudouin Stadium",
+    "city": "Heysel - Heizel",
+    "countryCode": "BEL",
+    "capacity": 50024,
+    "tenantClubs": [
+      "belgium-men-s-national-football-team"
+    ]
+  },
+  {
+    "id": "stade-olympique-de-la-pontaise",
+    "name": "Stade Olympique de la Pontaise",
+    "city": "Lausanne",
+    "countryCode": "CHE",
+    "capacity": 50000,
+    "tenantClubs": [
+      "fc-lausanne-sport"
+    ]
+  },
+  {
+    "id": "hocine-ait-ahmed-stadium",
+    "name": "Hocine-Ait Ahmed Stadium",
+    "city": "Boukhalfa",
+    "countryCode": "DZA",
+    "capacity": 50000,
+    "tenantClubs": [
+      "js-kabylie"
+    ]
+  },
+  {
+    "id": "pars-stadium",
+    "name": "Pars Stadium",
+    "city": null,
+    "countryCode": "IRN",
+    "capacity": 50000,
+    "tenantClubs": [
+      "fajr-sepasi-f-c"
+    ]
+  },
+  {
+    "id": "max-morlock-stadion",
+    "name": "Max-Morlock-Stadion",
+    "city": null,
+    "countryCode": "DEU",
+    "capacity": 50000,
+    "tenantClubs": [
+      "1-fc-nurnberg"
+    ]
+  },
+  {
+    "id": "stade-tata-raphael",
+    "name": "Stade Tata Raphaël",
+    "city": null,
+    "countryCode": "COD",
+    "capacity": 50000,
+    "tenantClubs": [
+      "daring-club-motema-pembe"
+    ]
+  },
+  {
+    "id": "stade-du-26-mars",
+    "name": "Stade du 26 Mars",
+    "city": "Bamako",
+    "countryCode": "MLI",
+    "capacity": 50000,
+    "tenantClubs": [
+      "cercle-olympique-de-bamako",
+      "mali-men-s-national-football-team",
+      "stade-malien"
+    ]
+  },
+  {
+    "id": "aloha-stadium",
+    "name": "Aloha Stadium",
+    "city": "Halawa",
+    "countryCode": "USA",
+    "capacity": 50000,
+    "tenantClubs": [
+      "hawaii-rainbow-warriors-and-rainbow-wahine",
+      "university-of-hawai-i-system"
+    ]
+  },
+  {
+    "id": "stadium-at-olympia",
+    "name": "Stadium at Olympia",
+    "city": "Olympia",
+    "countryCode": "GRC",
+    "capacity": 50000,
+    "tenantClubs": [
+      "2004-summer-olympics"
+    ]
+  },
+  {
+    "id": "shaheed-mohtarama-benazir-bhutto-international-cricket-stadium",
+    "name": "Shaheed Mohtarama Benazir Bhutto International Cricket Stadium",
+    "city": null,
+    "countryCode": "PAK",
+    "capacity": 50000,
+    "tenantClubs": []
+  },
+  {
+    "id": "felix-houphouet-boigny-stadium",
+    "name": "Felix Houphouet Boigny Stadium",
+    "city": null,
+    "countryCode": "CIV",
+    "capacity": 50000,
+    "tenantClubs": [
+      "academie-de-sol-beni",
+      "asec-mimosas"
+    ]
+  },
+  {
+    "id": "the-sevens",
+    "name": "The Sevens",
+    "city": "Dubai",
+    "countryCode": "ARE",
+    "capacity": 50000,
+    "tenantClubs": []
+  },
+  {
+    "id": "thuwunna-stadium",
+    "name": "Thuwunna Stadium",
+    "city": "Thingangyun Township",
+    "countryCode": "MMR",
+    "capacity": 50000,
+    "tenantClubs": [
+      "myanmar-men-s-national-football-team"
+    ]
+  },
+  {
+    "id": "olympic-stadium",
+    "name": "Olympic Stadium",
+    "city": "Phnom Penh",
+    "countryCode": "KHM",
+    "capacity": 50000,
+    "tenantClubs": [
+      "cambodia-men-s-national-football-team",
+      "cambodian-premier-league"
+    ]
+  },
+  {
+    "id": "harbin-sports-city-center-stadium",
+    "name": "Harbin Sports City Center Stadium",
+    "city": null,
+    "countryCode": "CHN",
+    "capacity": 50000,
+    "tenantClubs": [
+      "harbin-yiteng-f-c"
+    ]
+  },
+  {
+    "id": "general-lansana-conte-stadium",
+    "name": "General Lansana Conté Stadium",
+    "city": null,
+    "countryCode": "GIN",
+    "capacity": 50000,
+    "tenantClubs": [
+      "guinea-men-s-national-football-team"
+    ]
+  },
+  {
+    "id": "ernst-happel-stadion",
+    "name": "Ernst-Happel-Stadion",
+    "city": null,
+    "countryCode": "AUT",
+    "capacity": 50000,
+    "tenantClubs": [
+      "austria-men-s-national-football-team"
+    ]
+  },
+  {
+    "id": "estadio-zapote",
+    "name": "Estadio Zapote",
+    "city": null,
+    "countryCode": "MEX",
+    "capacity": 50000,
+    "tenantClubs": [
+      "jaiba-brava"
+    ]
+  },
+  {
+    "id": "eden-park",
+    "name": "Eden Park",
+    "city": "Kingsland",
+    "countryCode": "NZL",
+    "capacity": 50000,
+    "tenantClubs": [
+      "auckland-rfu",
+      "auckland-rugby-union-team",
+      "blues"
+    ]
+  },
+  {
+    "id": "hiroshima-big-arch",
+    "name": "Hiroshima Big Arch",
+    "city": "Hiroshima",
+    "countryCode": "JPN",
+    "capacity": 50000,
+    "tenantClubs": [
+      "sanfrecce-hiroshima"
+    ]
+  },
+  {
+    "id": "lago-di-tesero-cross-country-ski-stadium",
+    "name": "Lago di Tesero Cross-Country Ski Stadium",
+    "city": "Lago",
+    "countryCode": "ITA",
+    "capacity": 50000,
+    "tenantClubs": []
+  },
+  {
+    "id": "stade-24-fevrier-1956",
+    "name": "Stade 24 Fevrier 1956",
+    "city": null,
+    "countryCode": "DZA",
+    "capacity": 50000,
+    "tenantClubs": [
+      "usm-bel-abbes"
+    ]
+  },
+  {
+    "id": "wadi-al-rabi-stadium",
+    "name": "Wadi Al Rabi Stadium",
+    "city": null,
+    "countryCode": "LBY",
+    "capacity": 50000,
+    "tenantClubs": []
+  },
+  {
+    "id": "cathkin-park",
+    "name": "Cathkin Park",
+    "city": "Glasgow",
+    "countryCode": "GBR",
+    "capacity": 50000,
+    "tenantClubs": [
+      "queen-s-park-f-c",
+      "third-lanark-a-c"
+    ]
+  },
+  {
+    "id": "estadio-11-de-novembro",
+    "name": "Estádio 11 de Novembro",
+    "city": "Talatona",
+    "countryCode": "AGO",
+    "capacity": 50000,
+    "tenantClubs": [
+      "clube-desportivo-primeiro-de-agosto"
+    ]
+  },
+  {
+    "id": "jiangxi-olympic-sports-center",
+    "name": "Jiangxi Olympic Sports Center",
+    "city": "Nanchang",
+    "countryCode": "CHN",
+    "capacity": 50000,
+    "tenantClubs": []
+  },
+  {
+    "id": "jose-amalfitani-stadium",
+    "name": "José Amalfitani Stadium",
+    "city": "Liniers",
+    "countryCode": "ARG",
+    "capacity": 50000,
+    "tenantClubs": [
+      "argentina-national-rugby-union-team",
+      "club-atletico-velez-sarsfield",
+      "jaguares"
+    ]
+  },
+  {
+    "id": "estadio-pedro-bidegain",
+    "name": "Estadio Pedro Bidegain",
+    "city": "Flores",
+    "countryCode": "ARG",
+    "capacity": 50000,
+    "tenantClubs": [
+      "san-lorenzo-de-almagro",
+      "san-lorenzo-de-almagro-women"
+    ]
+  },
+  {
+    "id": "wulihe-stadium",
+    "name": "Wulihe Stadium",
+    "city": null,
+    "countryCode": "CHN",
+    "capacity": 50000,
+    "tenantClubs": []
+  },
+  {
+    "id": "stadion-za-luzankami",
+    "name": "Stadion Za Lužánkami",
+    "city": "Brno",
+    "countryCode": "CZE",
+    "capacity": 50000,
+    "tenantClubs": [
+      "fc-zbrojovka-brno"
+    ]
+  },
+  {
+    "id": "bill-snyder-family-football-stadium",
+    "name": "Bill Snyder Family Football Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 50000,
+    "tenantClubs": [
+      "kansas-state-wildcats-football"
+    ]
+  },
+  {
+    "id": "sultan-mizan-zainal-abidin-stadium",
+    "name": "Sultan Mizan Zainal Abidin Stadium",
+    "city": null,
+    "countryCode": "MYS",
+    "capacity": 50000,
+    "tenantClubs": [
+      "terengganu-f-c"
+    ]
+  },
+  {
+    "id": "may-19-1956-stadium",
+    "name": "May 19, 1956 Stadium",
+    "city": null,
+    "countryCode": "DZA",
+    "capacity": 50000,
+    "tenantClubs": [
+      "usm-annaba"
+    ]
+  },
+  {
+    "id": "dowdy-ficklen-stadium",
+    "name": "Dowdy–Ficklen Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 50000,
+    "tenantClubs": [
+      "east-carolina-pirates",
+      "east-carolina-pirates-football"
+    ]
+  },
+  {
+    "id": "gaelic-grounds",
+    "name": "Gaelic Grounds",
+    "city": null,
+    "countryCode": "IRL",
+    "capacity": 49866,
+    "tenantClubs": [
+      "limerick-gaa"
+    ]
+  },
+  {
+    "id": "levy-mwanawasa-stadium",
+    "name": "Levy Mwanawasa Stadium",
+    "city": "T3 road",
+    "countryCode": "ZMB",
+    "capacity": 49800,
+    "tenantClubs": [
+      "zambia-men-s-national-football-team"
+    ]
+  },
+  {
+    "id": "fritz-walter-stadium",
+    "name": "Fritz Walter Stadium",
+    "city": null,
+    "countryCode": "DEU",
+    "capacity": 49780,
+    "tenantClubs": [
+      "1-fc-kaiserslautern"
+    ]
+  },
+  {
+    "id": "estadio-ciudad-de-lanus-nestor-diaz-perez",
+    "name": "Estadio Ciudad de Lanús Néstor Díaz Pérez",
+    "city": null,
+    "countryCode": "ARG",
+    "capacity": 49584,
+    "tenantClubs": [
+      "club-atletico-lanus",
+      "club-atletico-lanus-women"
+    ]
+  },
+  {
+    "id": "mestalla-stadium",
+    "name": "Mestalla Stadium",
+    "city": null,
+    "countryCode": "ESP",
+    "capacity": 49430,
+    "tenantClubs": [
+      "valencia-cf"
+    ]
+  },
+  {
+    "id": "independence-stadium",
+    "name": "Independence Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 49427,
+    "tenantClubs": [
+      "independence-bowl",
+      "shreveport-steamer"
+    ]
+  },
+  {
+    "id": "jma-wireless-dome",
+    "name": "JMA Wireless Dome",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 49262,
+    "tenantClubs": [
+      "syracuse-orange",
+      "syracuse-orange-football",
+      "syracuse-orange-men-s-basketball",
+      "syracuse-orange-men-s-lacrosse",
+      "syracuse-orange-women-s-basketball"
+    ]
+  },
+  {
+    "id": "q-a-stadium-miyagi",
+    "name": "Q&A Stadium Miyagi",
+    "city": "Miyagi Sports Park",
+    "countryCode": "JPN",
+    "capacity": 49133,
+    "tenantClubs": [
+      "2020-summer-olympics",
+      "vegalta-sendai"
+    ]
+  },
+  {
+    "id": "estadio-beira-rio",
+    "name": "Estádio Beira-Rio",
+    "city": null,
+    "countryCode": "BRA",
+    "capacity": 49055,
+    "tenantClubs": [
+      "s-c-internacional"
+    ]
+  },
+  {
+    "id": "niedersachsenstadion",
+    "name": "Niedersachsenstadion",
+    "city": "Hanover",
+    "countryCode": "DEU",
+    "capacity": 49000,
+    "tenantClubs": [
+      "hannover-96"
+    ]
+  },
+  {
+    "id": "marcelo-bielsa-stadium",
+    "name": "Marcelo Bielsa Stadium",
+    "city": "Rosario",
+    "countryCode": "ARG",
+    "capacity": 49000,
+    "tenantClubs": [
+      "newell-s-old-boys"
+    ]
+  },
+  {
+    "id": "oriole-park-at-camden-yards",
+    "name": "Oriole Park at Camden Yards",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 48876,
+    "tenantClubs": [
+      "baltimore-orioles"
+    ]
+  },
+  {
+    "id": "estadio-tomas-adolfo-duco",
+    "name": "Estadio Tomás Adolfo Ducó",
+    "city": null,
+    "countryCode": "ARG",
+    "capacity": 48314,
+    "tenantClubs": [
+      "club-atletico-huracan",
+      "huracan-women"
+    ]
+  },
+  {
+    "id": "choctaw-stadium",
+    "name": "Choctaw Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 48114,
+    "tenantClubs": [
+      "dallas-renegades",
+      "north-texas-sc",
+      "texas-rangers"
+    ]
+  },
+  {
+    "id": "ajinomoto-stadium",
+    "name": "Ajinomoto Stadium",
+    "city": null,
+    "countryCode": "JPN",
+    "capacity": 48013,
+    "tenantClubs": [
+      "2020-summer-olympics",
+      "fc-tokyo"
+    ]
+  },
+  {
+    "id": "estadio-modelo-alberto-spencer-herrera",
+    "name": "Estadio Modelo Alberto Spencer Herrera",
+    "city": null,
+    "countryCode": "ECU",
+    "capacity": 48000,
+    "tenantClubs": []
+  },
+  {
+    "id": "arena-fonte-nova",
+    "name": "Arena Fonte Nova",
+    "city": "Nazaré",
+    "countryCode": "BRA",
+    "capacity": 47915,
+    "tenantClubs": [
+      "brazil-men-s-national-football-team",
+      "esporte-clube-bahia"
+    ]
+  },
+  {
+    "id": "yanmar-stadium-nagai",
+    "name": "Yanmar Stadium Nagai",
+    "city": "Nagai Park",
+    "countryCode": "JPN",
+    "capacity": 47853,
+    "tenantClubs": [
+      "cerezo-osaka"
+    ]
+  },
+  {
+    "id": "t-mobile-park",
+    "name": "T-Mobile Park",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 47476,
+    "tenantClubs": [
+      "seattle-mariners"
+    ]
+  },
+  {
+    "id": "estadio-cuauhtemoc",
+    "name": "Estadio Cuauhtémoc",
+    "city": null,
+    "countryCode": "MEX",
+    "capacity": 47417,
+    "tenantClubs": [
+      "club-puebla",
+      "cruz-azul",
+      "puebla-f-c"
+    ]
+  },
+  {
+    "id": "neo-quimica-arena",
+    "name": "Neo Química Arena",
+    "city": "São Paulo",
+    "countryCode": "BRA",
+    "capacity": 47252,
+    "tenantClubs": [
+      "novonor",
+      "s-c-corinthians-paulista"
+    ]
+  },
+  {
+    "id": "protective-stadium",
+    "name": "Protective Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 47100,
+    "tenantClubs": [
+      "houston-gamblers",
+      "uab-blazers-football"
+    ]
+  },
+  {
+    "id": "south-riyadh-stadium",
+    "name": "South Riyadh Stadium",
+    "city": null,
+    "countryCode": "SAU",
+    "capacity": 47060,
+    "tenantClubs": []
+  },
+  {
+    "id": "amon-g-carter-stadium",
+    "name": "Amon G. Carter Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 47000,
+    "tenantClubs": [
+      "tcu-horned-frogs-football"
+    ]
+  },
+  {
+    "id": "estadio-monumental",
+    "name": "Estadio Monumental",
+    "city": "Macul",
+    "countryCode": "CHL",
+    "capacity": 47000,
+    "tenantClubs": [
+      "club-social-y-deportivo-colo-colo"
+    ]
+  },
+  {
+    "id": "rice-stadium",
+    "name": "Rice Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 47000,
+    "tenantClubs": [
+      "houston-cougars-football",
+      "rice-owls",
+      "rice-owls-football"
+    ]
+  },
+  {
+    "id": "prince-mohammed-bin-salman-stadium",
+    "name": "Prince Mohammed bin Salman Stadium",
+    "city": "Qiddiya",
+    "countryCode": "SAU",
+    "capacity": 46979,
+    "tenantClubs": [
+      "al-hilal-sfc",
+      "al-nassr"
+    ]
+  },
+  {
+    "id": "estadio-nilton-santos",
+    "name": "Estádio Nilton Santos",
+    "city": null,
+    "countryCode": "BRA",
+    "capacity": 46931,
+    "tenantClubs": [
+      "botafogo-f-r",
+      "fluminense-f-c"
+    ]
+  },
+  {
+    "id": "sports-city-stadium",
+    "name": "Sports City Stadium",
+    "city": null,
+    "countryCode": "QAT",
+    "capacity": 46890,
+    "tenantClubs": [
+      "2022-fifa-world-cup"
+    ]
+  },
+  {
+    "id": "estadio-metropolitano-roberto-melendez",
+    "name": "Estadio Metropolitano Roberto Meléndez",
+    "city": null,
+    "countryCode": "COL",
+    "capacity": 46692,
+    "tenantClubs": [
+      "junior-de-barranquilla"
+    ]
+  },
+  {
+    "id": "rheinenergie-stadion",
+    "name": "RheinEnergie Stadion",
+    "city": "Cologne",
+    "countryCode": "DEU",
+    "capacity": 46195,
+    "tenantClubs": [
+      "1-fc-koln"
+    ]
+  },
+  {
+    "id": "julio-martinez-pradanos-national-stadium",
+    "name": "Julio Martínez Prádanos National Stadium",
+    "city": null,
+    "countryCode": "CHL",
+    "capacity": 46190,
+    "tenantClubs": [
+      "chile-men-s-national-football-team",
+      "chile-women-s-national-association-football-team",
+      "club-universidad-de-chile"
+    ]
+  },
+  {
+    "id": "qiddiya-coast-stadium",
+    "name": "Qiddiya Coast Stadium",
+    "city": null,
+    "countryCode": "SAU",
+    "capacity": 46096,
+    "tenantClubs": []
+  },
+  {
+    "id": "aramco-stadium",
+    "name": "Aramco Stadium",
+    "city": null,
+    "countryCode": "SAU",
+    "capacity": 46096,
+    "tenantClubs": []
+  },
+  {
+    "id": "al-murabba-stadium",
+    "name": "Al-Murabba Stadium",
+    "city": "Riyadh",
+    "countryCode": "SAU",
+    "capacity": 46010,
+    "tenantClubs": []
+  },
+  {
+    "id": "neom-stadium",
+    "name": "NEOM Stadium",
+    "city": null,
+    "countryCode": "SAU",
+    "capacity": 46010,
+    "tenantClubs": []
+  },
+  {
+    "id": "atanasio-girardot-sports-complex",
+    "name": "Atanasio Girardot Sports Complex",
+    "city": "Medellín",
+    "countryCode": "COL",
+    "capacity": 46000,
+    "tenantClubs": [
+      "atletico-nacional"
+    ]
+  },
+  {
+    "id": "roshn-stadium",
+    "name": "Roshn Stadium",
+    "city": null,
+    "countryCode": "SAU",
+    "capacity": 46000,
+    "tenantClubs": []
+  },
+  {
+    "id": "gigante-de-arroyito-stadium",
+    "name": "Gigante de Arroyito Stadium",
+    "city": "Rosario",
+    "countryCode": "ARG",
+    "capacity": 46000,
+    "tenantClubs": [
+      "club-atletico-rosario-central",
+      "rosario-central-women"
+    ]
+  },
+  {
+    "id": "estadio-cuscatlan",
+    "name": "Estadio Cuscatlán",
+    "city": null,
+    "countryCode": "SLV",
+    "capacity": 45925,
+    "tenantClubs": [
+      "el-salvador-men-s-national-football-team"
+    ]
+  },
+  {
+    "id": "jeddah-central-stadium",
+    "name": "Jeddah Central Stadium",
+    "city": null,
+    "countryCode": "SAU",
+    "capacity": 45794,
+    "tenantClubs": []
+  },
+  {
+    "id": "king-abdullah-economic-city-stadium",
+    "name": "King Abdullah Economic City Stadium",
+    "city": "Rabigh governorate",
+    "countryCode": "SAU",
+    "capacity": 45700,
+    "tenantClubs": []
+  },
+  {
+    "id": "reser-stadium",
+    "name": "Reser Stadium",
+    "city": "Oregon State University",
+    "countryCode": "USA",
+    "capacity": 45674,
+    "tenantClubs": [
+      "oregon-state-beavers",
+      "oregon-state-beavers-football"
+    ]
+  },
+  {
+    "id": "polideportivo-cachamay",
+    "name": "Polideportivo Cachamay",
+    "city": "Ciudad Guayana",
+    "countryCode": "VEN",
+    "capacity": 45600,
+    "tenantClubs": [
+      "asociacion-civil-mineros-de-guayana"
+    ]
+  },
+  {
+    "id": "volgograd-arena",
+    "name": "Volgograd Arena",
+    "city": null,
+    "countryCode": "RUS",
+    "capacity": 45568,
+    "tenantClubs": [
+      "fc-rotor-volgograd"
+    ]
+  },
+  {
+    "id": "arena-cidade-da-copa",
+    "name": "Arena Cidade da Copa",
+    "city": "São Lourenço da Mata",
+    "countryCode": "BRA",
+    "capacity": 45440,
+    "tenantClubs": [
+      "2014-fifa-world-cup",
+      "clube-nautico-capibaribe"
+    ]
+  },
+  {
+    "id": "tropicana-field",
+    "name": "Tropicana Field",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 45369,
+    "tenantClubs": [
+      "tampa-bay-lightning",
+      "tampa-bay-rays"
+    ]
+  },
+  {
+    "id": "lukoil-arena",
+    "name": "Lukoil Arena",
+    "city": "Moscow",
+    "countryCode": "RUS",
+    "capacity": 45360,
+    "tenantClubs": [
+      "russia-men-s-national-football-team",
+      "spartak-moscow"
+    ]
+  },
+  {
+    "id": "al-shamal-stadium",
+    "name": "Al-Shamal Stadium",
+    "city": "Al Shamal",
+    "countryCode": "QAT",
+    "capacity": 45330,
+    "tenantClubs": [
+      "2022-fifa-world-cup"
+    ]
+  },
+  {
+    "id": "acrisure-bounce-house",
+    "name": "Acrisure Bounce House",
+    "city": "University of Central Florida",
+    "countryCode": "USA",
+    "capacity": 45323,
+    "tenantClubs": [
+      "orlando-apollos",
+      "ucf-knights",
+      "ucf-knights-football"
+    ]
+  },
+  {
+    "id": "dy-patil-stadium",
+    "name": "DY Patil Stadium",
+    "city": "Nerul",
+    "countryCode": "IND",
+    "capacity": 45300,
+    "tenantClubs": []
+  },
+  {
+    "id": "estadio-universitario",
+    "name": "Estadio Universitario",
+    "city": null,
+    "countryCode": "MEX",
+    "capacity": 45257,
+    "tenantClubs": [
+      "tigres-uanl"
+    ]
+  },
+  {
+    "id": "marrakesh-stadium",
+    "name": "Marrakesh Stadium",
+    "city": null,
+    "countryCode": "MAR",
+    "capacity": 45240,
+    "tenantClubs": [
+      "kacm"
+    ]
+  },
+  {
+    "id": "general-santander",
+    "name": "General Santander",
+    "city": null,
+    "countryCode": "COL",
+    "capacity": 45220,
+    "tenantClubs": [
+      "cucuta-deportivo"
+    ]
+  },
+  {
+    "id": "mandela-national-stadium",
+    "name": "Mandela National Stadium",
+    "city": "Bweyogerere",
+    "countryCode": "UGA",
+    "capacity": 45202,
+    "tenantClubs": [
+      "uganda-men-s-national-football-team",
+      "uganda-revenue-authority-sc",
+      "uganda-women-s-national-football-team"
+    ]
+  },
+  {
+    "id": "free-state-stadium",
+    "name": "Free State Stadium",
+    "city": null,
+    "countryCode": "ZAF",
+    "capacity": 45158,
+    "tenantClubs": [
+      "cheetahs"
+    ]
+  },
+  {
+    "id": "ak-bars-arena",
+    "name": "Ak Bars Arena",
+    "city": null,
+    "countryCode": "RUS",
+    "capacity": 45105,
+    "tenantClubs": [
+      "rubin-kazan"
+    ]
+  },
+  {
+    "id": "rice-eccles-stadium",
+    "name": "Rice–Eccles Stadium",
+    "city": "University of Utah",
+    "countryCode": "USA",
+    "capacity": 45017,
+    "tenantClubs": [
+      "salt-lake-stallions",
+      "utah-utes",
+      "utah-utes-football"
+    ]
+  },
+  {
+    "id": "rostec-arena",
+    "name": "Rostec Arena",
+    "city": null,
+    "countryCode": "RUS",
+    "capacity": 45015,
+    "tenantClubs": [
+      "fc-baltika-kaliningrad"
+    ]
+  },
+  {
+    "id": "mordovia-arena",
+    "name": "Mordovia Arena",
+    "city": null,
+    "countryCode": "RUS",
+    "capacity": 45015,
+    "tenantClubs": [
+      "fc-mordovia-saransk"
+    ]
+  },
+  {
+    "id": "estadio-estadual-jornalista-edgar-augusto-proenca",
+    "name": "Estádio Estadual Jornalista Edgar Augusto Proença",
+    "city": "Mangueirão",
+    "countryCode": "BRA",
+    "capacity": 45007,
+    "tenantClubs": [
+      "clube-do-remo"
+    ]
+  },
+  {
+    "id": "estadio-campeon-del-siglo",
+    "name": "Estadio Campeón del Siglo",
+    "city": null,
+    "countryCode": "URY",
+    "capacity": 45000,
+    "tenantClubs": [
+      "club-atletico-penarol"
+    ]
+  },
+  {
+    "id": "zibo-sports-center-stadium",
+    "name": "Zibo Sports Center Stadium",
+    "city": "Zibo",
+    "countryCode": "CHN",
+    "capacity": 45000,
+    "tenantClubs": [
+      "2010-afc-u-19-championship"
+    ]
+  },
+  {
+    "id": "harapan-bangsa-stadium",
+    "name": "Harapan Bangsa Stadium",
+    "city": null,
+    "countryCode": "IDN",
+    "capacity": 45000,
+    "tenantClubs": [
+      "persiraja-banda-aceh"
+    ]
+  },
+  {
+    "id": "weifang-sports-center-stadium",
+    "name": "Weifang Sports Center Stadium",
+    "city": "Weifang",
+    "countryCode": "CHN",
+    "capacity": 45000,
+    "tenantClubs": []
+  },
+  {
+    "id": "estadio-olimpico-monumental",
+    "name": "Estádio Olímpico Monumental",
+    "city": null,
+    "countryCode": "BRA",
+    "capacity": 45000,
+    "tenantClubs": [
+      "gremio-fbpa"
+    ]
+  },
+  {
+    "id": "naghsh-e-jahan-stadium",
+    "name": "Naghsh-e-Jahan Stadium",
+    "city": null,
+    "countryCode": "IRN",
+    "capacity": 45000,
+    "tenantClubs": [
+      "sepahan-f-c"
+    ]
+  },
+  {
+    "id": "mclane-stadium",
+    "name": "McLane Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 45000,
+    "tenantClubs": [
+      "baylor-bears",
+      "baylor-bears-football"
+    ]
+  },
+  {
+    "id": "fez-stadium",
+    "name": "Fez Stadium",
+    "city": null,
+    "countryCode": "MAR",
+    "capacity": 45000,
+    "tenantClubs": [
+      "maghreb-association-sportive-de-fes"
+    ]
+  },
+  {
+    "id": "estadio-da-machava",
+    "name": "Estádio da Machava",
+    "city": null,
+    "countryCode": "MOZ",
+    "capacity": 45000,
+    "tenantClubs": [
+      "clube-ferroviario-de-maputo"
+    ]
+  },
+  {
+    "id": "kobe-universiade-memorial-stadium",
+    "name": "Kobe Universiade Memorial Stadium",
+    "city": null,
+    "countryCode": "JPN",
+    "capacity": 45000,
+    "tenantClubs": [
+      "1985-summer-universiade",
+      "kobelco-kobe-steelers"
+    ]
+  },
+  {
+    "id": "stadium-974",
+    "name": "Stadium 974",
+    "city": "Doha",
+    "countryCode": "QAT",
+    "capacity": 45000,
+    "tenantClubs": []
+  },
+  {
+    "id": "stade-omar-bongo",
+    "name": "Stade Omar Bongo",
+    "city": null,
+    "countryCode": "GAB",
+    "capacity": 45000,
+    "tenantClubs": [
+      "fc-105-libreville"
+    ]
+  },
+  {
+    "id": "stade-el-menzah",
+    "name": "Stade El Menzah",
+    "city": null,
+    "countryCode": "TUN",
+    "capacity": 45000,
+    "tenantClubs": [
+      "esperance-sportive-de-tunis"
+    ]
+  },
+  {
+    "id": "mubarak-international-stadium",
+    "name": "Mubarak International Stadium",
+    "city": null,
+    "countryCode": "EGY",
+    "capacity": 45000,
+    "tenantClubs": []
+  },
+  {
+    "id": "qingdao-conson-stadium",
+    "name": "Qingdao Conson Stadium",
+    "city": "Qingdao",
+    "countryCode": "CHN",
+    "capacity": 45000,
+    "tenantClubs": [
+      "qingdao-f-c"
+    ]
+  },
+  {
+    "id": "morenao",
+    "name": "Morenão",
+    "city": null,
+    "countryCode": "BRA",
+    "capacity": 45000,
+    "tenantClubs": [
+      "esporte-clube-comercial"
+    ]
+  },
+  {
+    "id": "rostov-arena",
+    "name": "Rostov Arena",
+    "city": null,
+    "countryCode": "RUS",
+    "capacity": 45000,
+    "tenantClubs": [
+      "fc-rostov"
+    ]
+  },
+  {
+    "id": "arena-das-dunas",
+    "name": "Arena das Dunas",
+    "city": null,
+    "countryCode": "BRA",
+    "capacity": 45000,
+    "tenantClubs": [
+      "america-futebol-clube"
+    ]
+  },
+  {
+    "id": "national-stadium-sle",
+    "name": "National Stadium",
+    "city": null,
+    "countryCode": "SLE",
+    "capacity": 45000,
+    "tenantClubs": [
+      "sierra-leone-men-s-national-football-team"
+    ]
+  },
+  {
+    "id": "preu-enstadion",
+    "name": "Preußenstadion",
+    "city": null,
+    "countryCode": "DEU",
+    "capacity": 45000,
+    "tenantClubs": [
+      "sc-preu-en-munster"
+    ]
+  },
+  {
+    "id": "umm-salal-stadium",
+    "name": "Umm Salal Stadium",
+    "city": null,
+    "countryCode": "QAT",
+    "capacity": 45000,
+    "tenantClubs": [
+      "2022-fifa-world-cup"
+    ]
+  },
+  {
+    "id": "latakia-sports-city-stadium",
+    "name": "Latakia Sports City Stadium",
+    "city": "Latakia",
+    "countryCode": "SYR",
+    "capacity": 45000,
+    "tenantClubs": []
+  },
+  {
+    "id": "estadio-kleber-andrade",
+    "name": "Estádio Kléber Andrade",
+    "city": "Cariacica",
+    "countryCode": "BRA",
+    "capacity": 45000,
+    "tenantClubs": [
+      "rio-branco-atletico-clube"
+    ]
+  },
+  {
+    "id": "samara-arena",
+    "name": "Samara Arena",
+    "city": null,
+    "countryCode": "RUS",
+    "capacity": 44918,
+    "tenantClubs": [
+      "fc-akron-tolyatti",
+      "fc-krylia-sovetov-samara"
+    ]
+  },
+  {
+    "id": "nizhny-novgorod-stadium",
+    "name": "Nizhny Novgorod Stadium",
+    "city": null,
+    "countryCode": "RUS",
+    "capacity": 44899,
+    "tenantClubs": [
+      "fc-nizhny-novgorod",
+      "fc-volga-nizhny-novgorod"
+    ]
+  },
+  {
+    "id": "estadio-atanasio-girardot",
+    "name": "Estadio Atanasio Girardot",
+    "city": "Medellín",
+    "countryCode": "COL",
+    "capacity": 44826,
+    "tenantClubs": [
+      "atletico-nacional",
+      "deportivo-independiente-medellin"
+    ]
+  },
+  {
+    "id": "thani-bin-jassim-stadium",
+    "name": "Thani bin Jassim Stadium",
+    "city": "Al Rayyan Municipality",
+    "countryCode": "QAT",
+    "capacity": 44740,
+    "tenantClubs": [
+      "al-gharafa-sc"
+    ]
+  },
+  {
+    "id": "ahmad-bin-ali-stadium",
+    "name": "Ahmad bin Ali Stadium",
+    "city": "Al Rayyan",
+    "countryCode": "QAT",
+    "capacity": 44740,
+    "tenantClubs": [
+      "al-rayyan"
+    ]
+  },
+  {
+    "id": "alumni-stadium",
+    "name": "Alumni Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 44500,
+    "tenantClubs": [
+      "boston-college-eagles"
+    ]
+  },
+  {
+    "id": "estadio-paulo-constantino",
+    "name": "Estadio Paulo Constantino",
+    "city": null,
+    "countryCode": "BRA",
+    "capacity": 44414,
+    "tenantClubs": [
+      "esporte-clube-corinthians"
+    ]
+  },
+  {
+    "id": "can-tho-stadium",
+    "name": "Cần Thơ Stadium",
+    "city": null,
+    "countryCode": "VNM",
+    "capacity": 44400,
+    "tenantClubs": [
+      "can-tho-f-c"
+    ]
+  },
+  {
+    "id": "toyota-stadium",
+    "name": "Toyota Stadium",
+    "city": "Toyota",
+    "countryCode": "JPN",
+    "capacity": 44380,
+    "tenantClubs": [
+      "nagoya-grampus",
+      "toyota-verblitz"
+    ]
+  },
+  {
+    "id": "albertao",
+    "name": "Albertão",
+    "city": null,
+    "countryCode": "BRA",
+    "capacity": 44200,
+    "tenantClubs": [
+      "esporte-clube-flamengo"
+    ]
+  },
+  {
+    "id": "ulsan-munsu-football-stadium",
+    "name": "Ulsan Munsu Football Stadium",
+    "city": null,
+    "countryCode": "KOR",
+    "capacity": 44102,
+    "tenantClubs": [
+      "ulsan-hd-fc"
+    ]
+  },
+  {
+    "id": "jos-international-stadium",
+    "name": "Jos International Stadium",
+    "city": null,
+    "countryCode": "NGA",
+    "capacity": 44000,
+    "tenantClubs": []
+  },
+  {
+    "id": "suwon-world-cup-stadium",
+    "name": "Suwon World Cup Stadium",
+    "city": null,
+    "countryCode": "KOR",
+    "capacity": 43959,
+    "tenantClubs": [
+      "suwon-samsung-bluewings-fc"
+    ]
+  },
+  {
+    "id": "riau-main-stadium",
+    "name": "Riau Main Stadium",
+    "city": null,
+    "countryCode": "IDN",
+    "capacity": 43923,
+    "tenantClubs": [
+      "psps-riau"
+    ]
+  },
+  {
+    "id": "timsah-arena",
+    "name": "Timsah Arena",
+    "city": null,
+    "countryCode": "TUR",
+    "capacity": 43877,
+    "tenantClubs": [
+      "bursaspor"
+    ]
+  },
+  {
+    "id": "allianz-parque",
+    "name": "Allianz Parque",
+    "city": "São Paulo",
+    "countryCode": "BRA",
+    "capacity": 43713,
+    "tenantClubs": [
+      "sociedade-esportiva-palmeiras"
+    ]
+  },
+  {
+    "id": "shandong-provincial-stadium",
+    "name": "Shandong Provincial Stadium",
+    "city": null,
+    "countryCode": "CHN",
+    "capacity": 43700,
+    "tenantClubs": [
+      "shandong-taishan-f-c"
+    ]
+  },
+  {
+    "id": "sydney-cricket-ground",
+    "name": "Sydney Cricket Ground",
+    "city": "Moore Park",
+    "countryCode": "AUS",
+    "capacity": 43649,
+    "tenantClubs": [
+      "new-south-wales-cricket-team",
+      "sydney-roosters",
+      "sydney-roosters-women-s-rugby-league",
+      "sydney-sixers",
+      "sydney-swans"
+    ]
+  },
+  {
+    "id": "mbombela-stadium",
+    "name": "Mbombela Stadium",
+    "city": "Mbombela",
+    "countryCode": "ZAF",
+    "capacity": 43500,
+    "tenantClubs": []
+  },
+  {
+    "id": "qatar-university-stadium",
+    "name": "Qatar University Stadium",
+    "city": null,
+    "countryCode": "QAT",
+    "capacity": 43500,
+    "tenantClubs": []
+  },
+  {
+    "id": "libertadores-de-america-stadium",
+    "name": "Libertadores de América Stadium",
+    "city": "Avellaneda",
+    "countryCode": "ARG",
+    "capacity": 43364,
+    "tenantClubs": [
+      "club-atletico-independiente",
+      "club-atletico-independiente-women"
+    ]
+  },
+  {
+    "id": "stadio-artemio-franchi",
+    "name": "Stadio Artemio Franchi",
+    "city": null,
+    "countryCode": "ITA",
+    "capacity": 43325,
+    "tenantClubs": [
+      "acf-fiorentina"
+    ]
+  },
+  {
+    "id": "angel-stadium-of-anaheim",
+    "name": "Angel Stadium of Anaheim",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 43250,
+    "tenantClubs": [
+      "los-angeles-angels"
+    ]
+  },
+  {
+    "id": "vasil-levski-national-stadium",
+    "name": "Vasil Levski National Stadium",
+    "city": "Borisova Gradina",
+    "countryCode": "BGR",
+    "capacity": 43230,
+    "tenantClubs": [
+      "pfc-levski-sofia"
+    ]
+  },
+  {
+    "id": "fitzgerald-stadium",
+    "name": "Fitzgerald Stadium",
+    "city": "Killarney",
+    "countryCode": "IRL",
+    "capacity": 43180,
+    "tenantClubs": [
+      "kerry-gaa"
+    ]
+  },
+  {
+    "id": "new-stadium-la-romareda",
+    "name": "New Stadium La Romareda",
+    "city": "Zaragoza City",
+    "countryCode": "ESP",
+    "capacity": 43110,
+    "tenantClubs": [
+      "real-zaragoza"
+    ]
+  },
+  {
+    "id": "national-stadium-of-peru",
+    "name": "National Stadium of Peru",
+    "city": "Lima",
+    "countryCode": "PER",
+    "capacity": 43086,
+    "tenantClubs": [
+      "club-atletico-defensor-lima-1931",
+      "peru-men-s-national-football-team"
+    ]
+  },
+  {
+    "id": "ullevi",
+    "name": "Ullevi",
+    "city": "Heden",
+    "countryCode": "SWE",
+    "capacity": 43000,
+    "tenantClubs": [
+      "1975-world-sprint-speed-skating-championships",
+      "ifk-goteborg"
+    ]
+  },
+  {
+    "id": "zayed-sports-city-stadium",
+    "name": "Zayed Sports City Stadium",
+    "city": null,
+    "countryCode": "ARE",
+    "capacity": 43000,
+    "tenantClubs": [
+      "emirates-men-s-national-football-team"
+    ]
+  },
+  {
+    "id": "al-merrikh-stadium",
+    "name": "Al-Merrikh Stadium",
+    "city": "Omdurman",
+    "countryCode": "SDN",
+    "capacity": 43000,
+    "tenantClubs": [
+      "al-merrikh-sc"
+    ]
+  },
+  {
+    "id": "arena-pantaloneta",
+    "name": "Arena Pantaloneta",
+    "city": null,
+    "countryCode": "BRA",
+    "capacity": 42968,
+    "tenantClubs": [
+      "cuiaba-esporte-clube",
+      "mixto-esporte-clube"
+    ]
+  },
+  {
+    "id": "arena-amazonia",
+    "name": "Arena Amazônia",
+    "city": null,
+    "countryCode": "BRA",
+    "capacity": 42924,
+    "tenantClubs": [
+      "america-futebol-clube",
+      "nacional-futebol-clube"
+    ]
+  },
+  {
+    "id": "gwangju-world-cup-stadium",
+    "name": "Gwangju World Cup Stadium",
+    "city": "Seo District",
+    "countryCode": "KOR",
+    "capacity": 42880,
+    "tenantClubs": [
+      "gwangju-fc",
+      "gwangju-sangmu-fc"
+    ]
+  },
+  {
+    "id": "enea-stadion",
+    "name": "Enea Stadion",
+    "city": null,
+    "countryCode": "POL",
+    "capacity": 42873,
+    "tenantClubs": [
+      "lech-poznan"
+    ]
+  },
+  {
+    "id": "tarczynski-arena-wroc-aw",
+    "name": "Tarczyński Arena Wrocław",
+    "city": null,
+    "countryCode": "POL",
+    "capacity": 42771,
+    "tenantClubs": [
+      "slask-wroc-aw",
+      "uefa-euro-2012"
+    ]
+  },
+  {
+    "id": "zhuzhou-stadium",
+    "name": "Zhuzhou Stadium",
+    "city": null,
+    "countryCode": "CHN",
+    "capacity": 42740,
+    "tenantClubs": []
+  },
+  {
+    "id": "ramon-sanchez-pizjuan-stadium",
+    "name": "Ramón Sánchez Pizjuán Stadium",
+    "city": "Nervión",
+    "countryCode": "ESP",
+    "capacity": 42714,
+    "tenantClubs": [
+      "sevilla-fc"
+    ]
+  },
+  {
+    "id": "villa-park",
+    "name": "Villa Park",
+    "city": null,
+    "countryCode": "GBR",
+    "capacity": 42640,
+    "tenantClubs": [
+      "aston-villa-f-c"
+    ]
+  },
+  {
+    "id": "central-stadium-yekaterinburg",
+    "name": "Central Stadium Yekaterinburg",
+    "city": null,
+    "countryCode": "RUS",
+    "capacity": 42500,
+    "tenantClubs": [
+      "fc-ural-yekaterinburg"
+    ]
+  },
+  {
+    "id": "weserstadion",
+    "name": "Weserstadion",
+    "city": null,
+    "countryCode": "DEU",
+    "capacity": 42500,
+    "tenantClubs": [
+      "sv-werder-bremen"
+    ]
+  },
+  {
+    "id": "estadio-polideportivo-de-pueblo-nuevo",
+    "name": "Estadio Polideportivo de Pueblo Nuevo",
+    "city": "San Cristóbal",
+    "countryCode": "VEN",
+    "capacity": 42500,
+    "tenantClubs": [
+      "atletico-san-cristobal",
+      "internacional-de-bogota"
+    ]
+  },
+  {
+    "id": "jack-trice-stadium",
+    "name": "Jack Trice Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 42500,
+    "tenantClubs": [
+      "iowa-state-cyclones"
+    ]
+  },
+  {
+    "id": "nelson-mandela-bay-stadium",
+    "name": "Nelson Mandela Bay Stadium",
+    "city": null,
+    "countryCode": "ZAF",
+    "capacity": 42486,
+    "tenantClubs": [
+      "southern-kings"
+    ]
+  },
+  {
+    "id": "jeonju-world-cup-stadium",
+    "name": "Jeonju World Cup Stadium",
+    "city": null,
+    "countryCode": "KOR",
+    "capacity": 42477,
+    "tenantClubs": [
+      "jeonbuk-hyundai-motors-fc"
+    ]
+  },
+  {
+    "id": "shaanxi-province-stadium",
+    "name": "Shaanxi Province Stadium",
+    "city": null,
+    "countryCode": "CHN",
+    "capacity": 42383,
+    "tenantClubs": [
+      "guizhou-renhe-f-c",
+      "shaanxi-union-f-c"
+    ]
+  },
+  {
+    "id": "estadio-defensores-del-chaco",
+    "name": "Estadio Defensores del Chaco",
+    "city": null,
+    "countryCode": "PRY",
+    "capacity": 42354,
+    "tenantClubs": [
+      "paraguay-men-s-national-football-team"
+    ]
+  },
+  {
+    "id": "great-american-ball-park",
+    "name": "Great American Ball Park",
+    "city": "Cincinnati",
+    "countryCode": "USA",
+    "capacity": 42319,
+    "tenantClubs": [
+      "cincinnati-reds"
+    ]
+  },
+  {
+    "id": "petco-park",
+    "name": "Petco Park",
+    "city": "San Diego",
+    "countryCode": "USA",
+    "capacity": 42302,
+    "tenantClubs": [
+      "san-diego-padres"
+    ]
+  },
+  {
+    "id": "denka-big-swan-stadium",
+    "name": "Denka Big Swan Stadium",
+    "city": "Niigata",
+    "countryCode": "JPN",
+    "capacity": 42300,
+    "tenantClubs": [
+      "albirex-niigata",
+      "albirex-niigata-ladies"
+    ]
+  },
+  {
+    "id": "konya-buyuksehir-stadium",
+    "name": "Konya Büyükşehir Stadium",
+    "city": null,
+    "countryCode": "TUR",
+    "capacity": 42276,
+    "tenantClubs": [
+      "konyaspor",
+      "turkey-men-s-national-football-team"
+    ]
+  },
+  {
+    "id": "jeju-world-cup-stadium",
+    "name": "Jeju World Cup Stadium",
+    "city": null,
+    "countryCode": "KOR",
+    "capacity": 42256,
+    "tenantClubs": [
+      "jeju-sk-fc"
+    ]
+  },
+  {
+    "id": "estadio-olimpico-pascual-guerrero",
+    "name": "Estadio Olímpico Pascual Guerrero",
+    "city": null,
+    "countryCode": "COL",
+    "capacity": 42200,
+    "tenantClubs": [
+      "america-de-cali"
+    ]
+  },
+  {
+    "id": "estadio-metropolitano-de-merida",
+    "name": "Estadio Metropolitano de Mérida",
+    "city": null,
+    "countryCode": "VEN",
+    "capacity": 42200,
+    "tenantClubs": [
+      "estudiantes-de-merida"
+    ]
+  },
+  {
+    "id": "daejeon-world-cup-stadium",
+    "name": "Daejeon World Cup Stadium",
+    "city": null,
+    "countryCode": "KOR",
+    "capacity": 42176,
+    "tenantClubs": [
+      "daejeon-hana-citizen-fc"
+    ]
+  },
+  {
+    "id": "helsinki-olympic-stadium",
+    "name": "Helsinki Olympic Stadium",
+    "city": "Taka-Töölö",
+    "countryCode": "FIN",
+    "capacity": 42062,
+    "tenantClubs": [
+      "finland-men-s-national-football-team"
+    ]
+  },
+  {
+    "id": "daikin-park",
+    "name": "Daikin Park",
+    "city": "Houston",
+    "countryCode": "USA",
+    "capacity": 42060,
+    "tenantClubs": [
+      "houston-astros"
+    ]
+  },
+  {
+    "id": "mohammed-bin-zayed-stadium",
+    "name": "Mohammed Bin Zayed Stadium",
+    "city": null,
+    "countryCode": "ARE",
+    "capacity": 42056,
+    "tenantClubs": [
+      "al-jazira-club"
+    ]
+  },
+  {
+    "id": "estadio-deportivo-cali",
+    "name": "Estadio Deportivo Cali",
+    "city": "Palmira",
+    "countryCode": "COL",
+    "capacity": 42000,
+    "tenantClubs": [
+      "deportivo-cali",
+      "deportivo-cali-women-s-team",
+      "q5803206"
+    ]
+  },
+  {
+    "id": "adrar-stadium",
+    "name": "Adrar Stadium",
+    "city": "Agadir",
+    "countryCode": "MAR",
+    "capacity": 42000,
+    "tenantClubs": [
+      "hassania-agadir"
+    ]
+  },
+  {
+    "id": "stade-olympique-de-sousse",
+    "name": "Stade Olympique de Sousse",
+    "city": null,
+    "countryCode": "TUN",
+    "capacity": 42000,
+    "tenantClubs": [
+      "etoile-sportive-du-sahel"
+    ]
+  },
+  {
+    "id": "malvinas-argentinas-stadium",
+    "name": "Malvinas Argentinas Stadium",
+    "city": null,
+    "countryCode": "ARG",
+    "capacity": 42000,
+    "tenantClubs": [
+      "argentina-men-s-national-association-football-team",
+      "argentina-national-rugby-union-team",
+      "godoy-cruz-antonio-tomba",
+      "huracan-las-heras",
+      "independiente-rivadavia",
+      "san-martin-de-mendoza"
+    ]
+  },
+  {
+    "id": "red-bull-arena",
+    "name": "Red Bull Arena",
+    "city": "Leipzig",
+    "countryCode": "DEU",
+    "capacity": 42000,
+    "tenantClubs": [
+      "rb-leipzig"
+    ]
+  },
+  {
+    "id": "altonaer-stadion-hamburg",
+    "name": "Altonaer Stadion (Hamburg)",
+    "city": "Bahrenfeld",
+    "countryCode": "DEU",
+    "capacity": 42000,
+    "tenantClubs": []
+  },
+  {
+    "id": "estadio-de-monteria",
+    "name": "Estadio de Monteria",
+    "city": null,
+    "countryCode": "COL",
+    "capacity": 42000,
+    "tenantClubs": []
+  },
+  {
+    "id": "estadio-do-zimpeto",
+    "name": "Estádio do Zimpeto",
+    "city": null,
+    "countryCode": "MOZ",
+    "capacity": 42000,
+    "tenantClubs": [
+      "2011-all-africa-games"
+    ]
+  },
+  {
+    "id": "royal-bafokeng-stadium",
+    "name": "Royal Bafokeng Stadium",
+    "city": null,
+    "countryCode": "ZAF",
+    "capacity": 42000,
+    "tenantClubs": [
+      "platinum-stars-f-c"
+    ]
+  },
+  {
+    "id": "oracle-park",
+    "name": "Oracle Park",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 41915,
+    "tenantClubs": [
+      "san-francisco-giants"
+    ]
+  },
+  {
+    "id": "besiktas-stadium",
+    "name": "Beşiktaş Stadium",
+    "city": "Beşiktaş",
+    "countryCode": "TUR",
+    "capacity": 41903,
+    "tenantClubs": [
+      "2019-uefa-super-cup",
+      "besiktas-j-k"
+    ]
+  },
+  {
+    "id": "nationals-park",
+    "name": "Nationals Park",
+    "city": "Navy Yard",
+    "countryCode": "USA",
+    "capacity": 41888,
+    "tenantClubs": [
+      "washington-nationals"
+    ]
+  },
+  {
+    "id": "stamford-bridge",
+    "name": "Stamford Bridge",
+    "city": "Fulham",
+    "countryCode": "GBR",
+    "capacity": 41875,
+    "tenantClubs": [
+      "chelsea-f-c"
+    ]
+  },
+  {
+    "id": "peter-mokaba-stadium",
+    "name": "Peter Mokaba Stadium",
+    "city": null,
+    "countryCode": "ZAF",
+    "capacity": 41733,
+    "tenantClubs": [
+      "baroka-f-c",
+      "black-leopards-f-c",
+      "limpopo"
+    ]
+  },
+  {
+    "id": "new-antalya-stadium",
+    "name": "New Antalya Stadium",
+    "city": null,
+    "countryCode": "TUR",
+    "capacity": 41703,
+    "tenantClubs": [
+      "antalyaspor"
+    ]
+  },
+  {
+    "id": "juventus-stadium",
+    "name": "Juventus Stadium",
+    "city": null,
+    "countryCode": "ITA",
+    "capacity": 41689,
+    "tenantClubs": [
+      "juventus-fc"
+    ]
+  },
+  {
+    "id": "gdansk-arena",
+    "name": "Gdańsk Arena",
+    "city": null,
+    "countryCode": "POL",
+    "capacity": 41620,
+    "tenantClubs": [
+      "ks-lechia-gdansk",
+      "uefa-euro-2012"
+    ]
+  },
+  {
+    "id": "estadio-rodrigo-paz-delgado",
+    "name": "Estadio Rodrigo Paz Delgado",
+    "city": null,
+    "countryCode": "ECU",
+    "capacity": 41596,
+    "tenantClubs": [
+      "liga-deportiva-universitaria-de-quito"
+    ]
+  },
+  {
+    "id": "new-izmir-stadium",
+    "name": "New İzmir Stadium",
+    "city": null,
+    "countryCode": "TUR",
+    "capacity": 41540,
+    "tenantClubs": [
+      "altay-s-k"
+    ]
+  },
+  {
+    "id": "wuyuan-river-stadium",
+    "name": "Wuyuan River Stadium",
+    "city": null,
+    "countryCode": "CHN",
+    "capacity": 41506,
+    "tenantClubs": []
+  },
+  {
+    "id": "papara-park",
+    "name": "Papara Park",
+    "city": null,
+    "countryCode": "TUR",
+    "capacity": 41500,
+    "tenantClubs": [
+      "trabzonspor"
+    ]
+  },
+  {
+    "id": "shi-stadium",
+    "name": "SHI Stadium",
+    "city": "Piscataway",
+    "countryCode": "USA",
+    "capacity": 41500,
+    "tenantClubs": [
+      "rutgers-scarlet-knights-football",
+      "rutgers-scarlet-knights-men-s-lacrosse"
+    ]
+  },
+  {
+    "id": "nuevo-estadio-azul",
+    "name": "Nuevo Estadio Azul",
+    "city": null,
+    "countryCode": "MEX",
+    "capacity": 41418,
+    "tenantClubs": [
+      "cruz-azul"
+    ]
+  },
+  {
+    "id": "goyang-stadium",
+    "name": "Goyang Stadium",
+    "city": null,
+    "countryCode": "KOR",
+    "capacity": 41311,
+    "tenantClubs": [
+      "goyang-zaicro-fc"
+    ]
+  },
+  {
+    "id": "bingu-national-stadium",
+    "name": "Bingu National Stadium",
+    "city": null,
+    "countryCode": "MWI",
+    "capacity": 41100,
+    "tenantClubs": [
+      "malawi-men-s-national-football-team"
+    ]
+  },
+  {
+    "id": "wrigley-field",
+    "name": "Wrigley Field",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 41072,
+    "tenantClubs": [
+      "arizona-cardinals",
+      "chicago-bears",
+      "chicago-cubs",
+      "chicago-tigers",
+      "chicago-whales",
+      "hammond-pros"
+    ]
+  },
+  {
+    "id": "valley-children-s-stadium",
+    "name": "Valley Children's Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 41031,
+    "tenantClubs": [
+      "fresno-state-bulldogs"
+    ]
+  },
+  {
+    "id": "canvas-stadium",
+    "name": "Canvas Stadium",
+    "city": "Fort Collins",
+    "countryCode": "USA",
+    "capacity": 41000,
+    "tenantClubs": [
+      "colorado-state-rams",
+      "colorado-state-rams-football"
+    ]
+  },
+  {
+    "id": "gelredome",
+    "name": "GelreDome",
+    "city": null,
+    "countryCode": null,
+    "capacity": 41000,
+    "tenantClubs": [
+      "sbv-vitesse"
+    ]
+  },
+  {
+    "id": "falcon-stadium",
+    "name": "Falcon Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 40828,
+    "tenantClubs": [
+      "air-force-falcons",
+      "air-force-falcons-football"
+    ]
+  },
+  {
+    "id": "estadio-jose-pachencho-romero",
+    "name": "Estadio José Pachencho Romero",
+    "city": "Maracaibo",
+    "countryCode": "VEN",
+    "capacity": 40800,
+    "tenantClubs": [
+      "club-deportivo-italmaracaibo",
+      "union-atletico-maracaibo",
+      "zulia-fc"
+    ]
+  },
+  {
+    "id": "nelson-mandela-stadium",
+    "name": "Nelson Mandela Stadium",
+    "city": null,
+    "countryCode": "DZA",
+    "capacity": 40784,
+    "tenantClubs": []
+  },
+  {
+    "id": "kashima-soccer-stadium",
+    "name": "Kashima Soccer Stadium",
+    "city": "Kashima",
+    "countryCode": "JPN",
+    "capacity": 40728,
+    "tenantClubs": [
+      "2020-summer-olympics",
+      "kashima-antlers"
+    ]
+  },
+  {
+    "id": "rate-field",
+    "name": "Rate Field",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 40615,
+    "tenantClubs": [
+      "chicago-white-sox"
+    ]
+  },
+  {
+    "id": "firstbank-stadium",
+    "name": "FirstBank Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 40550,
+    "tenantClubs": [
+      "tennessee-titans",
+      "vanderbilt-commodores-football"
+    ]
+  },
+  {
+    "id": "rcde-stadium",
+    "name": "RCDE Stadium",
+    "city": null,
+    "countryCode": "ESP",
+    "capacity": 40500,
+    "tenantClubs": [
+      "rcd-espanyol-de-barcelona"
+    ]
+  },
+  {
+    "id": "nagoya-dome",
+    "name": "Nagoya Dome",
+    "city": null,
+    "countryCode": "JPN",
+    "capacity": 40500,
+    "tenantClubs": [
+      "chunichi-dragons"
+    ]
+  },
+  {
+    "id": "q28269730",
+    "name": "Q28269730",
+    "city": null,
+    "countryCode": "MAR",
+    "capacity": 40410,
+    "tenantClubs": []
+  },
+  {
+    "id": "skelly-field-at-h-a-chapman-stadium",
+    "name": "Skelly Field at H. A. Chapman Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 40385,
+    "tenantClubs": [
+      "tulsa-golden-hurricane-football",
+      "tulsa-roughnecks"
+    ]
+  },
+  {
+    "id": "arequipa-stadium",
+    "name": "Arequipa Stadium",
+    "city": "Arequipa",
+    "countryCode": "PER",
+    "capacity": 40370,
+    "tenantClubs": [
+      "fbc-melgar"
+    ]
+  },
+  {
+    "id": "estadio-metropolitano-de-futbol-de-lara",
+    "name": "Estadio Metropolitano de Fútbol de Lara",
+    "city": null,
+    "countryCode": "VEN",
+    "capacity": 40312,
+    "tenantClubs": [
+      "asociacion-civil-deportivo-lara"
+    ]
+  },
+  {
+    "id": "globe-life-field",
+    "name": "Globe Life Field",
+    "city": "Arlington",
+    "countryCode": "USA",
+    "capacity": 40300,
+    "tenantClubs": [
+      "texas-rangers"
+    ]
+  },
+  {
+    "id": "my-dinh-national-stadium",
+    "name": "My Dinh National Stadium",
+    "city": "Nam Từ Liêm",
+    "countryCode": "VNM",
+    "capacity": 40192,
+    "tenantClubs": [
+      "vietnam-men-s-national-football-team"
+    ]
+  },
+  {
+    "id": "goodison-park",
+    "name": "Goodison Park",
+    "city": null,
+    "countryCode": "GBR",
+    "capacity": 40157,
+    "tenantClubs": [
+      "everton-f-c",
+      "everton-f-c-women"
+    ]
+  },
+  {
+    "id": "miloud-hadefi-stadium",
+    "name": "Miloud Hadefi Stadium",
+    "city": null,
+    "countryCode": "DZA",
+    "capacity": 40143,
+    "tenantClubs": []
+  },
+  {
+    "id": "comerica-park",
+    "name": "Comerica Park",
+    "city": "Detroit",
+    "countryCode": "USA",
+    "capacity": 40120,
+    "tenantClubs": [
+      "detroit-tigers",
+      "major-league-baseball"
+    ]
+  },
+  {
+    "id": "metalist-stadium",
+    "name": "Metalist Stadium",
+    "city": null,
+    "countryCode": "UKR",
+    "capacity": 40003,
+    "tenantClubs": [
+      "fc-metalist-kharkiv"
+    ]
+  },
+  {
+    "id": "pratt-whitney-stadium",
+    "name": "Pratt & Whitney Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 40000,
+    "tenantClubs": [
+      "uconn-huskies",
+      "uconn-huskies-football"
+    ]
+  },
+  {
+    "id": "accra-sports-stadium",
+    "name": "Accra Sports Stadium",
+    "city": "Ministries",
+    "countryCode": "GHA",
+    "capacity": 40000,
+    "tenantClubs": [
+      "2023-african-games",
+      "accra-great-olympics-f-c",
+      "accra-hearts-of-oak-sc",
+      "accra-lions-fc"
+    ]
+  },
+  {
+    "id": "baba-yara-stadium",
+    "name": "Baba Yara Stadium",
+    "city": "Kumasi",
+    "countryCode": "GHA",
+    "capacity": 40000,
+    "tenantClubs": [
+      "asante-kotoko-f-c"
+    ]
+  },
+  {
+    "id": "kunming-tuodong-sports-center",
+    "name": "Kunming Tuodong Sports Center",
+    "city": null,
+    "countryCode": "CHN",
+    "capacity": 40000,
+    "tenantClubs": [
+      "yunnan-hongta-f-c"
+    ]
+  },
+  {
+    "id": "darul-makmur-stadium",
+    "name": "Darul Makmur Stadium",
+    "city": "Kuantan",
+    "countryCode": "MYS",
+    "capacity": 40000,
+    "tenantClubs": [
+      "sri-pahang-f-c"
+    ]
+  },
+  {
+    "id": "al-janoub-stadium",
+    "name": "Al Janoub Stadium",
+    "city": "Al Wakrah",
+    "countryCode": "QAT",
+    "capacity": 40000,
+    "tenantClubs": [
+      "al-wakrah-sports-club"
+    ]
+  },
+  {
+    "id": "barbourfields-stadium",
+    "name": "Barbourfields Stadium",
+    "city": "Bulawayo",
+    "countryCode": "ZWE",
+    "capacity": 40000,
+    "tenantClubs": [
+      "highlanders-f-c"
+    ]
+  },
+  {
+    "id": "sarawak-stadium",
+    "name": "Sarawak Stadium",
+    "city": "Kuching",
+    "countryCode": "MYS",
+    "capacity": 40000,
+    "tenantClubs": [
+      "sarawak-football-association"
+    ]
+  },
+  {
+    "id": "stade-des-trois-tilleuls",
+    "name": "stade des Trois Tilleuls",
+    "city": null,
+    "countryCode": "BEL",
+    "capacity": 40000,
+    "tenantClubs": [
+      "boitsfort-rugby-club",
+      "la-maison-de-l-escrime",
+      "q104537227",
+      "royal-racing-club-de-bruxelles"
+    ]
+  },
+  {
+    "id": "jahnstadion",
+    "name": "Jahnstadion",
+    "city": null,
+    "countryCode": "DEU",
+    "capacity": 40000,
+    "tenantClubs": [
+      "q869716"
+    ]
+  },
+  {
+    "id": "grugastadion",
+    "name": "Grugastadion",
+    "city": null,
+    "countryCode": "DEU",
+    "capacity": 40000,
+    "tenantClubs": []
+  },
+  {
+    "id": "estadio-da-cidadela",
+    "name": "Estádio da Cidadela",
+    "city": null,
+    "countryCode": "AGO",
+    "capacity": 40000,
+    "tenantClubs": [
+      "s-l-benfica"
+    ]
+  },
+  {
+    "id": "anoeta-stadium",
+    "name": "Anoeta Stadium",
+    "city": null,
+    "countryCode": "ESP",
+    "capacity": 40000,
+    "tenantClubs": [
+      "real-sociedad"
+    ]
+  },
+  {
+    "id": "bao-an-sports-center",
+    "name": "Bao'an Sports Center",
+    "city": null,
+    "countryCode": "CHN",
+    "capacity": 40000,
+    "tenantClubs": [
+      "shenzhen-f-c"
+    ]
+  },
+  {
+    "id": "stade-velodrome-de-rocourt",
+    "name": "Stade Vélodrome de Rocourt",
+    "city": null,
+    "countryCode": "BEL",
+    "capacity": 40000,
+    "tenantClubs": [
+      "r-f-c-de-liege"
+    ]
+  },
+  {
+    "id": "nippert-stadium",
+    "name": "Nippert Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 40000,
+    "tenantClubs": [
+      "cincinnati-bearcats",
+      "cincinnati-bearcats-football",
+      "cincinnati-bengals",
+      "cincinnati-comets",
+      "fc-cincinnati"
+    ]
+  },
+  {
+    "id": "ahmed-zabana-stadium",
+    "name": "Ahmed Zabana Stadium",
+    "city": null,
+    "countryCode": "DZA",
+    "capacity": 40000,
+    "tenantClubs": [
+      "mouloudia-club-of-oran"
+    ]
+  },
+  {
+    "id": "barombong-stadium",
+    "name": "Barombong Stadium",
+    "city": null,
+    "countryCode": "IDN",
+    "capacity": 40000,
+    "tenantClubs": [
+      "psm-makassar"
+    ]
+  },
+  {
+    "id": "sree-kanteerava-stadium",
+    "name": "Sree Kanteerava Stadium",
+    "city": "Bengaluru",
+    "countryCode": "IND",
+    "capacity": 40000,
+    "tenantClubs": [
+      "bengaluru-fc"
+    ]
+  },
+  {
+    "id": "riyadh-stadium",
+    "name": "Riyadh Stadium",
+    "city": null,
+    "countryCode": "SAU",
+    "capacity": 40000,
+    "tenantClubs": []
+  },
+  {
+    "id": "estadio-monumental-jose-fierro",
+    "name": "Estadio Monumental José Fierro",
+    "city": null,
+    "countryCode": "ARG",
+    "capacity": 40000,
+    "tenantClubs": [
+      "atletico-tucuman"
+    ]
+  },
+  {
+    "id": "hong-kong-stadium",
+    "name": "Hong Kong Stadium",
+    "city": "So Kon Po",
+    "countryCode": "CHN",
+    "capacity": 40000,
+    "tenantClubs": [
+      "eastern-fc",
+      "football-association-of-hong-kong-china",
+      "hong-kong-men-s-national-football-team",
+      "hong-kong-rugby-union"
+    ]
+  },
+  {
+    "id": "g-m-c-balayogi-athletic-stadium",
+    "name": "G. M. C. Balayogi Athletic Stadium",
+    "city": "Gachibowli",
+    "countryCode": "IND",
+    "capacity": 40000,
+    "tenantClubs": [
+      "fateh-hyderabad-f-c"
+    ]
+  },
+  {
+    "id": "almeidao",
+    "name": "Almeidão",
+    "city": "João Pessoa",
+    "countryCode": "BRA",
+    "capacity": 40000,
+    "tenantClubs": [
+      "botafogo-futebol-clube"
+    ]
+  },
+  {
+    "id": "estadio-monumental-universidad-andina-de-juliaca",
+    "name": "Estadio Monumental Universidad Andina de Juliaca",
+    "city": null,
+    "countryCode": "PER",
+    "capacity": 40000,
+    "tenantClubs": []
+  },
+  {
+    "id": "castelao-bra",
+    "name": "Castelão",
+    "city": null,
+    "countryCode": "BRA",
+    "capacity": 40000,
+    "tenantClubs": [
+      "maranhao-atletico-clube"
+    ]
+  },
+  {
+    "id": "national-olympic-sports-centre-stadium",
+    "name": "National Olympic Sports Centre Stadium",
+    "city": null,
+    "countryCode": "CHN",
+    "capacity": 40000,
+    "tenantClubs": []
+  },
+  {
+    "id": "al-markhiya-stadium",
+    "name": "Al-Markhiya Stadium",
+    "city": null,
+    "countryCode": "QAT",
+    "capacity": 40000,
+    "tenantClubs": [
+      "al-markhiya-sports-club"
+    ]
+  },
+  {
+    "id": "independence-stadium-gmb",
+    "name": "Independence Stadium",
+    "city": "Bakau",
+    "countryCode": "GMB",
+    "capacity": 40000,
+    "tenantClubs": [
+      "the-gambia-men-s-national-football-team"
+    ]
+  },
+  {
+    "id": "bogyoke-aung-san-stadium",
+    "name": "Bogyoke Aung San Stadium",
+    "city": null,
+    "countryCode": "MMR",
+    "capacity": 40000,
+    "tenantClubs": [
+      "yangon-united-f-c"
+    ]
+  },
+  {
+    "id": "peoples-football-stadium",
+    "name": "Peoples Football Stadium",
+    "city": "Karachi",
+    "countryCode": "PAK",
+    "capacity": 40000,
+    "tenantClubs": [
+      "hbl-f-c"
+    ]
+  },
+  {
+    "id": "civo-stadium",
+    "name": "Civo Stadium",
+    "city": null,
+    "countryCode": "MWI",
+    "capacity": 40000,
+    "tenantClubs": [
+      "civo-united"
+    ]
+  },
+  {
+    "id": "sunan-stadium",
+    "name": "Sunan Stadium",
+    "city": "Pyongyang",
+    "countryCode": "PRK",
+    "capacity": 40000,
+    "tenantClubs": []
+  },
+  {
+    "id": "orlando-stadium",
+    "name": "Orlando Stadium",
+    "city": null,
+    "countryCode": "ZAF",
+    "capacity": 40000,
+    "tenantClubs": [
+      "orlando-pirates-f-c"
+    ]
+  },
+  {
+    "id": "huizhou-olympic-stadium",
+    "name": "Huizhou Olympic Stadium",
+    "city": null,
+    "countryCode": "CHN",
+    "capacity": 40000,
+    "tenantClubs": []
+  },
+  {
+    "id": "vive-claro",
+    "name": "Vive Claro",
+    "city": null,
+    "countryCode": "COL",
+    "capacity": 40000,
+    "tenantClubs": []
+  },
+  {
+    "id": "panathinaikos-f-c-new-stadium",
+    "name": "Panathinaikos F.C. New Stadium",
+    "city": "Votanikos",
+    "countryCode": "GRC",
+    "capacity": 40000,
+    "tenantClubs": []
+  },
+  {
+    "id": "al-thumama-stadium",
+    "name": "Al Thumama Stadium",
+    "city": "Doha",
+    "countryCode": "QAT",
+    "capacity": 40000,
+    "tenantClubs": []
+  },
+  {
+    "id": "hang-jebat-stadium",
+    "name": "Hang Jebat Stadium",
+    "city": "Krubong",
+    "countryCode": "MYS",
+    "capacity": 40000,
+    "tenantClubs": [
+      "melaka-united"
+    ]
+  },
+  {
+    "id": "sultan-ibrahim-stadium",
+    "name": "Sultan Ibrahim Stadium",
+    "city": null,
+    "countryCode": "MYS",
+    "capacity": 40000,
+    "tenantClubs": [
+      "johor-darul-takzim-f-c"
+    ]
+  },
+  {
+    "id": "stade-de-la-paix",
+    "name": "Stade de la Paix",
+    "city": null,
+    "countryCode": "CIV",
+    "capacity": 40000,
+    "tenantClubs": [
+      "asc-bouake"
+    ]
+  },
+  {
+    "id": "ali-la-pointe-stadium",
+    "name": "Ali La Pointe Stadium",
+    "city": "Douéra",
+    "countryCode": "DZA",
+    "capacity": 40000,
+    "tenantClubs": [
+      "mc-algiers"
+    ]
+  },
+  {
+    "id": "gelora-joko-samudro-stadium",
+    "name": "Gelora Joko Samudro Stadium",
+    "city": null,
+    "countryCode": "IDN",
+    "capacity": 40000,
+    "tenantClubs": [
+      "persegres-gresik-united"
+    ]
+  },
+  {
+    "id": "birsa-munda-football-stadium",
+    "name": "Birsa Munda Football Stadium",
+    "city": "Ranchi",
+    "countryCode": "IND",
+    "capacity": 40000,
+    "tenantClubs": []
+  },
+  {
+    "id": "hauptstadion",
+    "name": "Hauptstadion",
+    "city": null,
+    "countryCode": "DEU",
+    "capacity": 40000,
+    "tenantClubs": [
+      "chio-aachen"
+    ]
+  },
+  {
+    "id": "penang-state-stadium",
+    "name": "Penang State Stadium",
+    "city": null,
+    "countryCode": "MYS",
+    "capacity": 40000,
+    "tenantClubs": [
+      "penang-f-c"
+    ]
+  },
+  {
+    "id": "stade-d-angondje",
+    "name": "Stade d'Angondjé",
+    "city": null,
+    "countryCode": "GAB",
+    "capacity": 40000,
+    "tenantClubs": []
+  },
+  {
+    "id": "tuanku-abdul-rahman-stadium",
+    "name": "Tuanku Abdul Rahman Stadium",
+    "city": "Paroi",
+    "countryCode": "MYS",
+    "capacity": 40000,
+    "tenantClubs": [
+      "negeri-sembilan-fa"
+    ]
+  },
+  {
+    "id": "franso-hariri-stadium",
+    "name": "Franso Hariri Stadium",
+    "city": null,
+    "countryCode": "IRQ",
+    "capacity": 40000,
+    "tenantClubs": [
+      "erbil-sc"
+    ]
+  },
+  {
+    "id": "stade-du-4-aout",
+    "name": "Stade du 4 Août",
+    "city": null,
+    "countryCode": "BFA",
+    "capacity": 40000,
+    "tenantClubs": [
+      "etoile-filante-de-ouagadougou"
+    ]
+  },
+  {
+    "id": "hyde-road",
+    "name": "Hyde Road",
+    "city": null,
+    "countryCode": "GBR",
+    "capacity": 40000,
+    "tenantClubs": [
+      "belle-vue-aces"
+    ]
+  },
+  {
+    "id": "oita-stadium",
+    "name": "Ōita Stadium",
+    "city": "Ōita-shi",
+    "countryCode": "JPN",
+    "capacity": 40000,
+    "tenantClubs": [
+      "oita-trinita"
+    ]
+  },
+  {
+    "id": "tdecu-stadium",
+    "name": "TDECU Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 40000,
+    "tenantClubs": [
+      "houston-cougars",
+      "houston-cougars-football",
+      "houston-roughnecks"
+    ]
+  },
+  {
+    "id": "benghazi-international-stadium",
+    "name": "Benghazi International Stadium",
+    "city": null,
+    "countryCode": "LBY",
+    "capacity": 40000,
+    "tenantClubs": []
+  },
+  {
+    "id": "estadio-hernan-ramirez-villegas",
+    "name": "Estadio Hernán Ramírez Villegas",
+    "city": null,
+    "countryCode": "COL",
+    "capacity": 39890,
+    "tenantClubs": [
+      "deportivo-pereira"
+    ]
+  },
+  {
+    "id": "luoyang-stadium",
+    "name": "Luoyang Stadium",
+    "city": null,
+    "countryCode": "CHN",
+    "capacity": 39888,
+    "tenantClubs": []
+  },
+  {
+    "id": "helan-mountain-stadium",
+    "name": "Helan Mountain Stadium",
+    "city": "Yinchuan",
+    "countryCode": "CHN",
+    "capacity": 39872,
+    "tenantClubs": []
+  },
+  {
+    "id": "hillsborough-stadium",
+    "name": "Hillsborough Stadium",
+    "city": null,
+    "countryCode": "GBR",
+    "capacity": 39732,
+    "tenantClubs": [
+      "sheffield-eagles",
+      "sheffield-wednesday-f-c"
+    ]
+  },
+  {
+    "id": "suita-stadium",
+    "name": "Suita Stadium",
+    "city": "Expo '70 Commemorative Park",
+    "countryCode": "JPN",
+    "capacity": 39694,
+    "tenantClubs": [
+      "gamba-osaka"
+    ]
+  },
+  {
+    "id": "target-field",
+    "name": "Target Field",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 39504,
+    "tenantClubs": [
+      "minnesota-twins"
+    ]
+  },
+  {
+    "id": "guangzhou-higher-education-mega-center-central-stadium",
+    "name": "Guangzhou Higher Education Mega Center Central Stadium",
+    "city": null,
+    "countryCode": "CHN",
+    "capacity": 39346,
+    "tenantClubs": [
+      "guangzhou-city-f-c"
+    ]
+  },
+  {
+    "id": "university-stadium",
+    "name": "University Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 39224,
+    "tenantClubs": [
+      "new-mexico-lobos-football"
+    ]
+  },
+  {
+    "id": "rogers-centre",
+    "name": "Rogers Centre",
+    "city": "Downtown Toronto",
+    "countryCode": "CAN",
+    "capacity": 39150,
+    "tenantClubs": [
+      "toronto-argonauts",
+      "toronto-blue-jays",
+      "toronto-raptors"
+    ]
+  },
+  {
+    "id": "fukuoka-dome",
+    "name": "Fukuoka Dome",
+    "city": "Hawks Town",
+    "countryCode": "JPN",
+    "capacity": 38561,
+    "tenantClubs": [
+      "fukuoka-softbank-hawks"
+    ]
+  },
+  {
+    "id": "st-jakob-park",
+    "name": "St. Jakob-Park",
+    "city": null,
+    "countryCode": "CHE",
+    "capacity": 38512,
+    "tenantClubs": [
+      "fc-basel"
+    ]
+  },
+  {
+    "id": "chengdu-sports-centre",
+    "name": "Chengdu Sports Centre",
+    "city": null,
+    "countryCode": "CHN",
+    "capacity": 38269,
+    "tenantClubs": [
+      "chengdu-tiancheng-f-c"
+    ]
+  },
+  {
+    "id": "joan-c-edwards-stadium",
+    "name": "Joan C. Edwards Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 38227,
+    "tenantClubs": [
+      "marshall-thundering-herd",
+      "marshall-thundering-herd-football"
+    ]
+  },
+  {
+    "id": "stade-bollaert-delelis",
+    "name": "Stade Bollaert-Delelis",
+    "city": "Lens",
+    "countryCode": "FRA",
+    "capacity": 38223,
+    "tenantClubs": [
+      "r-c-lens"
+    ]
+  },
+  {
+    "id": "parken-stadium",
+    "name": "Parken Stadium",
+    "city": "Østerbro",
+    "countryCode": "DNK",
+    "capacity": 38065,
+    "tenantClubs": [
+      "f-c-copenhagen"
+    ]
+  },
+  {
+    "id": "changchun-city-stadium",
+    "name": "Changchun City Stadium",
+    "city": null,
+    "countryCode": "CHN",
+    "capacity": 38000,
+    "tenantClubs": [
+      "changchun-yatai-f-c"
+    ]
+  },
+  {
+    "id": "estadio-hernando-siles",
+    "name": "Estadio Hernando Siles",
+    "city": null,
+    "countryCode": "BOL",
+    "capacity": 38000,
+    "tenantClubs": [
+      "club-always-ready",
+      "club-bolivar",
+      "the-strongest"
+    ]
+  },
+  {
+    "id": "gelora-bandung-lautan-api-stadium",
+    "name": "Gelora Bandung Lautan Api Stadium",
+    "city": null,
+    "countryCode": "IDN",
+    "capacity": 38000,
+    "tenantClubs": [
+      "persib-bandung"
+    ]
+  },
+  {
+    "id": "eduardo-gallardon-stadium",
+    "name": "Eduardo Gallardón Stadium",
+    "city": null,
+    "countryCode": "ARG",
+    "capacity": 38000,
+    "tenantClubs": [
+      "club-atletico-los-andes"
+    ]
+  },
+  {
+    "id": "king-abdulaziz-sports-city",
+    "name": "King Abdulaziz Sports City",
+    "city": null,
+    "countryCode": "SAU",
+    "capacity": 38000,
+    "tenantClubs": [
+      "al-wehda-fc"
+    ]
+  },
+  {
+    "id": "michie-stadium",
+    "name": "Michie Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 38000,
+    "tenantClubs": [
+      "army-black-knights-football"
+    ]
+  },
+  {
+    "id": "meiji-jingu-stadium",
+    "name": "Meiji Jingu Stadium",
+    "city": "Meiji Shrine Outer Garden",
+    "countryCode": "JPN",
+    "capacity": 37933,
+    "tenantClubs": [
+      "tokyo-big6-baseball-league"
+    ]
+  },
+  {
+    "id": "kauffman-stadium",
+    "name": "Kauffman Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 37903,
+    "tenantClubs": [
+      "kansas-city-royals"
+    ]
+  },
+  {
+    "id": "pnc-park",
+    "name": "PNC Park",
+    "city": "North Shore",
+    "countryCode": "USA",
+    "capacity": 37898,
+    "tenantClubs": [
+      "pittsburgh-pirates"
+    ]
+  },
+  {
+    "id": "stadio-san-filippo",
+    "name": "Stadio San Filippo",
+    "city": null,
+    "countryCode": "ITA",
+    "capacity": 37895,
+    "tenantClubs": [
+      "a-c-r-messina"
+    ]
+  },
+  {
+    "id": "elland-road",
+    "name": "Elland Road",
+    "city": null,
+    "countryCode": "GBR",
+    "capacity": 37792,
+    "tenantClubs": [
+      "leeds-united-f-c"
+    ]
+  },
+  {
+    "id": "estadio-do-pacaembu",
+    "name": "Estádio do Pacaembu",
+    "city": "São Paulo",
+    "countryCode": "BRA",
+    "capacity": 37730,
+    "tenantClubs": [
+      "s-c-corinthians-paulista"
+    ]
+  },
+  {
+    "id": "stadion-gladbeck",
+    "name": "Stadion Gladbeck",
+    "city": null,
+    "countryCode": "DEU",
+    "capacity": 37612,
+    "tenantClubs": [
+      "chemnitzer-bc"
+    ]
+  },
+  {
+    "id": "estadio-nacional",
+    "name": "Estádio Nacional",
+    "city": "Oeiras",
+    "countryCode": "PRT",
+    "capacity": 37593,
+    "tenantClubs": [
+      "portugal-men-s-national-football-team"
+    ]
+  },
+  {
+    "id": "johannesburg-stadium",
+    "name": "Johannesburg Stadium",
+    "city": "Doornfontein",
+    "countryCode": "ZAF",
+    "capacity": 37500,
+    "tenantClubs": [
+      "orlando-pirates-f-c"
+    ]
+  },
+  {
+    "id": "fenway-park",
+    "name": "Fenway Park",
+    "city": "Boston",
+    "countryCode": "USA",
+    "capacity": 37499,
+    "tenantClubs": [
+      "boston-red-sox",
+      "washington-commanders"
+    ]
+  },
+  {
+    "id": "estadio-jose-antonio-anzoategui",
+    "name": "Estadio José Antonio Anzoátegui",
+    "city": "Q391221",
+    "countryCode": "VEN",
+    "capacity": 37485,
+    "tenantClubs": [
+      "deportivo-anzoategui"
+    ]
+  },
+  {
+    "id": "estadio-olimpico-metropolitano",
+    "name": "Estadio Olímpico Metropolitano",
+    "city": "San Pedro Sula",
+    "countryCode": "HND",
+    "capacity": 37325,
+    "tenantClubs": [
+      "honduras-men-s-national-football-team"
+    ]
+  },
+  {
+    "id": "mcmahon-stadium",
+    "name": "McMahon Stadium",
+    "city": "Calgary",
+    "countryCode": "CAN",
+    "capacity": 37317,
+    "tenantClubs": [
+      "calgary-boomers",
+      "calgary-colts",
+      "calgary-dinos-football",
+      "calgary-stampeders",
+      "calgary-wild-fc"
+    ]
+  },
+  {
+    "id": "stadio-arechi",
+    "name": "Stadio Arechi",
+    "city": null,
+    "countryCode": "ITA",
+    "capacity": 37245,
+    "tenantClubs": [
+      "u-s-salernitana-1919"
+    ]
+  },
+  {
+    "id": "stadion-hoheluft",
+    "name": "Stadion Hoheluft",
+    "city": "Eppendorf",
+    "countryCode": "DEU",
+    "capacity": 37000,
+    "tenantClubs": [
+      "hamburg-sea-devils",
+      "sc-victoria-hamburg"
+    ]
+  },
+  {
+    "id": "stoll-field-mclean-stadium",
+    "name": "Stoll Field/McLean Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 37000,
+    "tenantClubs": [
+      "kentucky-wildcats-football"
+    ]
+  },
+  {
+    "id": "estadio-silvadier-estanislao-lopez",
+    "name": "Estadio silvadier Estanislao lopez",
+    "city": null,
+    "countryCode": "ARG",
+    "capacity": 37000,
+    "tenantClubs": [
+      "club-atletico-colon"
+    ]
+  },
+  {
+    "id": "estadio-nacional-jose-de-la-paz-herrera",
+    "name": "Estadio Nacional Jose de la Paz Herrera",
+    "city": null,
+    "countryCode": "HND",
+    "capacity": 37000,
+    "tenantClubs": [
+      "c-d-olimpia",
+      "f-c-motagua",
+      "tegucigalpa-f-c"
+    ]
+  },
+  {
+    "id": "sam-boyd-stadium",
+    "name": "Sam Boyd Stadium",
+    "city": "Whitney",
+    "countryCode": "USA",
+    "capacity": 36800,
+    "tenantClubs": [
+      "las-vegas-bowl",
+      "unlv-rebels-football",
+      "usa-sevens"
+    ]
+  },
+  {
+    "id": "loandepot-park",
+    "name": "LoanDepot Park",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 36742,
+    "tenantClubs": [
+      "miami-marlins"
+    ]
+  },
+  {
+    "id": "century-lotus-stadium",
+    "name": "Century Lotus Stadium",
+    "city": null,
+    "countryCode": "CHN",
+    "capacity": 36686,
+    "tenantClubs": []
+  },
+  {
+    "id": "estadio-palogrande",
+    "name": "Estadio Palogrande",
+    "city": "Manizales",
+    "countryCode": "COL",
+    "capacity": 36553,
+    "tenantClubs": [
+      "once-caldas"
+    ]
+  },
+  {
+    "id": "philips-stadion",
+    "name": "Philips Stadion",
+    "city": null,
+    "countryCode": null,
+    "capacity": 36500,
+    "tenantClubs": [
+      "psv-eindhoven"
+    ]
+  },
+  {
+    "id": "kyocera-dome-osaka",
+    "name": "Kyocera Dome Osaka",
+    "city": "Nishi-ku",
+    "countryCode": "JPN",
+    "capacity": 36477,
+    "tenantClubs": [
+      "orix-buffaloes",
+      "osaka-kintetsu-buffaloes"
+    ]
+  },
+  {
+    "id": "stadio-renato-dall-ara",
+    "name": "Stadio Renato Dall'Ara",
+    "city": null,
+    "countryCode": "ITA",
+    "capacity": 36462,
+    "tenantClubs": [
+      "bologna-f-c-1909"
+    ]
+  },
+  {
+    "id": "teixeirao",
+    "name": "Teixeirão",
+    "city": null,
+    "countryCode": "BRA",
+    "capacity": 36426,
+    "tenantClubs": [
+      "america-futebol-clube"
+    ]
+  },
+  {
+    "id": "teda-football-stadium",
+    "name": "TEDA Football Stadium",
+    "city": "Tianjin Economic-Technological Development Area",
+    "countryCode": "CHN",
+    "capacity": 36390,
+    "tenantClubs": [
+      "tianjin-jinmen-tiger-f-c"
+    ]
+  },
+  {
+    "id": "albertsons-stadium",
+    "name": "Albertsons Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 36387,
+    "tenantClubs": [
+      "boise-state-broncos",
+      "boise-state-broncos-football"
+    ]
+  },
+  {
+    "id": "stadio-renzo-barbera",
+    "name": "Stadio Renzo Barbera",
+    "city": null,
+    "countryCode": "ITA",
+    "capacity": 36365,
+    "tenantClubs": [
+      "palermo-f-c"
+    ]
+  },
+  {
+    "id": "estadio-el-campin",
+    "name": "Estadio El Campín",
+    "city": null,
+    "countryCode": "COL",
+    "capacity": 36343,
+    "tenantClubs": [
+      "independiente-santa-fe",
+      "millonarios"
+    ]
+  },
+  {
+    "id": "krasnodar-stadium",
+    "name": "Krasnodar Stadium",
+    "city": null,
+    "countryCode": "RUS",
+    "capacity": 36260,
+    "tenantClubs": [
+      "fc-krasnodar"
+    ]
+  },
+  {
+    "id": "allianz-riviera",
+    "name": "Allianz Riviera",
+    "city": "Nice",
+    "countryCode": "FRA",
+    "capacity": 36178,
+    "tenantClubs": [
+      "ogc-nice",
+      "ogc-nice-women"
+    ]
+  },
+  {
+    "id": "m-m-roberts-stadium",
+    "name": "M. M. Roberts Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 36000,
+    "tenantClubs": [
+      "southern-miss-golden-eagles"
+    ]
+  },
+  {
+    "id": "estadio-do-cafe",
+    "name": "Estádio do Café",
+    "city": null,
+    "countryCode": "BRA",
+    "capacity": 36000,
+    "tenantClubs": [
+      "londrina-e-c"
+    ]
+  },
+  {
+    "id": "national-stadium-dhaka",
+    "name": "National Stadium, Dhaka",
+    "city": "Dhaka",
+    "countryCode": "BGD",
+    "capacity": 36000,
+    "tenantClubs": [
+      "bangladesh-men-s-national-football-team",
+      "bangladesh-women-s-national-football-team",
+      "bangladesh-women-s-national-under-20-football-team"
+    ]
+  },
+  {
+    "id": "st-tiernach-s-park",
+    "name": "St Tiernach's Park",
+    "city": null,
+    "countryCode": "IRL",
+    "capacity": 36000,
+    "tenantClubs": [
+      "monaghan-gaa"
+    ]
+  },
+  {
+    "id": "xinhua-road-sports-center",
+    "name": "Xinhua Road Sports Center",
+    "city": null,
+    "countryCode": "CHN",
+    "capacity": 36000,
+    "tenantClubs": []
+  },
+  {
+    "id": "green-island-stadium",
+    "name": "Green Island Stadium",
+    "city": null,
+    "countryCode": "CHN",
+    "capacity": 36000,
+    "tenantClubs": []
+  },
+  {
+    "id": "morelos-stadium",
+    "name": "Morelos Stadium",
+    "city": "Morelia",
+    "countryCode": "MEX",
+    "capacity": 35869,
+    "tenantClubs": [
+      "club-atletico-morelia"
+    ]
+  },
+  {
+    "id": "estadio-metropolitano-de-madrid",
+    "name": "Estadio Metropolitano de Madrid",
+    "city": "University City of Madrid",
+    "countryCode": "ESP",
+    "capacity": 35800,
+    "tenantClubs": [
+      "atletico-madrid"
+    ]
+  },
+  {
+    "id": "estadio-olimpico-atahualpa",
+    "name": "Estadio Olímpico Atahualpa",
+    "city": null,
+    "countryCode": "ECU",
+    "capacity": 35742,
+    "tenantClubs": [
+      "club-deportivo-el-nacional",
+      "ecuador-men-s-national-football-team",
+      "s-d-quito",
+      "universidad-catolica-del-ecuador"
+    ]
+  },
+  {
+    "id": "estadio-de-bata",
+    "name": "Estadio de Bata",
+    "city": null,
+    "countryCode": "GNQ",
+    "capacity": 35700,
+    "tenantClubs": [
+      "equatorial-guinea-men-s-national-association-football-team",
+      "juvenil-reyes"
+    ]
+  },
+  {
+    "id": "barradao",
+    "name": "Barradão",
+    "city": "Q20053126",
+    "countryCode": "BRA",
+    "capacity": 35632,
+    "tenantClubs": [
+      "e-c-vitoria"
+    ]
+  },
+  {
+    "id": "corregidora-stadium",
+    "name": "Corregidora Stadium",
+    "city": null,
+    "countryCode": "MEX",
+    "capacity": 35575,
+    "tenantClubs": [
+      "queretaro-f-c"
+    ]
+  },
+  {
+    "id": "metallurg-stadium",
+    "name": "Metallurg Stadium",
+    "city": null,
+    "countryCode": "RUS",
+    "capacity": 35330,
+    "tenantClubs": [
+      "fc-krylia-sovetov-samara"
+    ]
+  },
+  {
+    "id": "stade-de-la-beaujoire",
+    "name": "Stade de la Beaujoire",
+    "city": "Nantes",
+    "countryCode": "FRA",
+    "capacity": 35318,
+    "tenantClubs": [
+      "fc-nantes"
+    ]
+  },
+  {
+    "id": "ludwigsparkstadion",
+    "name": "Ludwigsparkstadion",
+    "city": null,
+    "countryCode": "DEU",
+    "capacity": 35303,
+    "tenantClubs": [
+      "1-fc-saarbrucken",
+      "saarland-hurricanes"
+    ]
+  },
+  {
+    "id": "meihu-sports-centre",
+    "name": "Meihu Sports Centre",
+    "city": null,
+    "countryCode": "CHN",
+    "capacity": 35260,
+    "tenantClubs": []
+  },
+  {
+    "id": "stadion-am-gesundbrunnen",
+    "name": "Stadion am Gesundbrunnen",
+    "city": "Gesundbrunnen",
+    "countryCode": "DEU",
+    "capacity": 35239,
+    "tenantClubs": [
+      "hertha-bsc"
+    ]
+  },
+  {
+    "id": "rubber-bowl",
+    "name": "Rubber Bowl",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 35202,
+    "tenantClubs": [
+      "akron-zips-football"
+    ]
+  },
+  {
+    "id": "estadio-ramon-tahuichi-aguilera",
+    "name": "Estadio Ramón Tahuichi Aguilera",
+    "city": "Santa Cruz de la Sierra",
+    "countryCode": "BOL",
+    "capacity": 35180,
+    "tenantClubs": [
+      "oriente-petrolero"
+    ]
+  },
+  {
+    "id": "estadio-nacional-de-costa-rica",
+    "name": "Estadio Nacional de Costa Rica",
+    "city": null,
+    "countryCode": "CRI",
+    "capacity": 35175,
+    "tenantClubs": [
+      "costa-rica-men-s-national-football-team"
+    ]
+  },
+  {
+    "id": "ciudad-de-los-deportes-stadium",
+    "name": "Ciudad de los Deportes Stadium",
+    "city": null,
+    "countryCode": "MEX",
+    "capacity": 35161,
+    "tenantClubs": [
+      "atlante-f-c"
+    ]
+  },
+  {
+    "id": "ordos-stadium",
+    "name": "Ordos Stadium",
+    "city": null,
+    "countryCode": "CHN",
+    "capacity": 35107,
+    "tenantClubs": []
+  },
+  {
+    "id": "estadio-ilha-do-retiro",
+    "name": "Estádio Ilha do Retiro",
+    "city": null,
+    "countryCode": "BRA",
+    "capacity": 35020,
+    "tenantClubs": [
+      "sport-club-do-recife"
+    ]
+  },
+  {
+    "id": "vysocina-arena",
+    "name": "Vysočina Arena",
+    "city": "Nové Město na Moravě",
+    "countryCode": "CZE",
+    "capacity": 35000,
+    "tenantClubs": []
+  },
+  {
+    "id": "manahan-stadium",
+    "name": "Manahan Stadium",
+    "city": null,
+    "countryCode": "IDN",
+    "capacity": 35000,
+    "tenantClubs": [
+      "persis-solo"
+    ]
+  },
+  {
+    "id": "birsa-munda-athletics-stadium",
+    "name": "Birsa Munda Athletics Stadium",
+    "city": "Ranchi",
+    "countryCode": "IND",
+    "capacity": 35000,
+    "tenantClubs": [
+      "2011-national-games-of-india"
+    ]
+  },
+  {
+    "id": "pinheirao",
+    "name": "Pinheirão",
+    "city": null,
+    "countryCode": "BRA",
+    "capacity": 35000,
+    "tenantClubs": []
+  },
+  {
+    "id": "osman-ahmed-osman-stadium",
+    "name": "Osman Ahmed Osman Stadium",
+    "city": null,
+    "countryCode": "EGY",
+    "capacity": 35000,
+    "tenantClubs": [
+      "al-mokawloon-al-arab-sc"
+    ]
+  },
+  {
+    "id": "estadio-george-capwell",
+    "name": "Estadio George Capwell",
+    "city": null,
+    "countryCode": "ECU",
+    "capacity": 35000,
+    "tenantClubs": [
+      "club-sport-emelec"
+    ]
+  },
+  {
+    "id": "prince-mohamed-bin-fahd-stadium",
+    "name": "Prince Mohamed bin Fahd Stadium",
+    "city": null,
+    "countryCode": "SAU",
+    "capacity": 35000,
+    "tenantClubs": [
+      "al-qadsiah-fc"
+    ]
+  },
+  {
+    "id": "ccm-kirumba-stadium",
+    "name": "CCM Kirumba Stadium",
+    "city": null,
+    "countryCode": "TZA",
+    "capacity": 35000,
+    "tenantClubs": []
+  },
+  {
+    "id": "stade-frederic-kibassa-maliba",
+    "name": "Stade Frederic Kibassa Maliba",
+    "city": null,
+    "countryCode": "COD",
+    "capacity": 35000,
+    "tenantClubs": [
+      "tp-mazembe"
+    ]
+  },
+  {
+    "id": "ryan-field",
+    "name": "Ryan Field",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 35000,
+    "tenantClubs": [
+      "northwestern-wildcats-football"
+    ]
+  },
+  {
+    "id": "amigao",
+    "name": "Amigão",
+    "city": "Campina Grande",
+    "countryCode": "BRA",
+    "capacity": 35000,
+    "tenantClubs": [
+      "campinense-clube"
+    ]
+  },
+  {
+    "id": "ombaka-national-stadium",
+    "name": "Ombaka National Stadium",
+    "city": null,
+    "countryCode": "AGO",
+    "capacity": 35000,
+    "tenantClubs": []
+  },
+  {
+    "id": "kobe-sports-park-baseball-stadium",
+    "name": "Kobe Sports Park Baseball Stadium",
+    "city": null,
+    "countryCode": "JPN",
+    "capacity": 35000,
+    "tenantClubs": [
+      "orix-buffaloes"
+    ]
+  },
+  {
+    "id": "sariwon-youth-stadium",
+    "name": "Sariwon Youth Stadium",
+    "city": "Sariwon",
+    "countryCode": "PRK",
+    "capacity": 35000,
+    "tenantClubs": []
+  },
+  {
+    "id": "estadio-felix-capriles",
+    "name": "Estadio Félix Capriles",
+    "city": "Q42797420",
+    "countryCode": "BOL",
+    "capacity": 35000,
+    "tenantClubs": [
+      "c-d-jorge-wilstermann",
+      "club-aurora"
+    ]
+  },
+  {
+    "id": "larbi-zaouli-stadium",
+    "name": "Larbi Zaouli Stadium",
+    "city": null,
+    "countryCode": "MAR",
+    "capacity": 35000,
+    "tenantClubs": [
+      "tas-de-casablanca"
+    ]
+  },
+  {
+    "id": "victoria-stadium",
+    "name": "Victoria Stadium",
+    "city": null,
+    "countryCode": "MEX",
+    "capacity": 35000,
+    "tenantClubs": [
+      "club-necaxa"
+    ]
+  },
+  {
+    "id": "nuevo-francisco-urbano-stadium",
+    "name": "Nuevo Francisco Urbano Stadium",
+    "city": "Morón",
+    "countryCode": "ARG",
+    "capacity": 35000,
+    "tenantClubs": [
+      "club-deportivo-moron",
+      "deportivo-moron-women"
+    ]
+  },
+  {
+    "id": "honor-stadium",
+    "name": "Honor Stadium",
+    "city": "Oujda",
+    "countryCode": "MAR",
+    "capacity": 35000,
+    "tenantClubs": [
+      "mc-oujda"
+    ]
+  },
+  {
+    "id": "independence-park",
+    "name": "Independence Park",
+    "city": null,
+    "countryCode": "JAM",
+    "capacity": 35000,
+    "tenantClubs": [
+      "jamaica-men-s-national-association-football-team"
+    ]
+  },
+  {
+    "id": "barthelemy-boganda-stadium",
+    "name": "Barthélemy Boganda Stadium",
+    "city": null,
+    "countryCode": "CAF",
+    "capacity": 35000,
+    "tenantClubs": [
+      "central-african-republic-men-s-national-football-team"
+    ]
+  },
+  {
+    "id": "muhammadu-dikko-stadium",
+    "name": "Muhammadu Dikko Stadium",
+    "city": "Katsina",
+    "countryCode": "NGA",
+    "capacity": 35000,
+    "tenantClubs": []
+  },
+  {
+    "id": "gelora-delta-stadium",
+    "name": "Gelora Delta Stadium",
+    "city": null,
+    "countryCode": "IDN",
+    "capacity": 35000,
+    "tenantClubs": []
+  },
+  {
+    "id": "estadio-jesus-bermudez",
+    "name": "Estadio Jesús Bermúdez",
+    "city": null,
+    "countryCode": "BOL",
+    "capacity": 35000,
+    "tenantClubs": [
+      "cd-san-jose"
+    ]
+  },
+  {
+    "id": "thrissur-municipal-corporation-stadium",
+    "name": "Thrissur Municipal Corporation Stadium",
+    "city": "Thrissur",
+    "countryCode": "IND",
+    "capacity": 35000,
+    "tenantClubs": []
+  },
+  {
+    "id": "addis-ababa-stadium",
+    "name": "Addis Ababa Stadium",
+    "city": null,
+    "countryCode": "ETH",
+    "capacity": 35000,
+    "tenantClubs": [
+      "ethiopia-men-s-national-football-team"
+    ]
+  },
+  {
+    "id": "jahnstadion-deu",
+    "name": "Jahnstadion",
+    "city": null,
+    "countryCode": "DEU",
+    "capacity": 35000,
+    "tenantClubs": []
+  },
+  {
+    "id": "stade-de-l-amitie",
+    "name": "Stade de l'Amitié",
+    "city": null,
+    "countryCode": "BEN",
+    "capacity": 35000,
+    "tenantClubs": [
+      "benin-men-s-national-football-team"
+    ]
+  },
+  {
+    "id": "stadion-poljud",
+    "name": "Stadion Poljud",
+    "city": "Spinut",
+    "countryCode": "HRV",
+    "capacity": 35000,
+    "tenantClubs": [
+      "hnk-hajduk-split"
+    ]
+  },
+  {
+    "id": "emam-reeza-stadium",
+    "name": "emam reeza  Stadium",
+    "city": null,
+    "countryCode": "IRN",
+    "capacity": 35000,
+    "tenantClubs": [
+      "aboomoslem-f-c"
+    ]
+  },
+  {
+    "id": "estadio-manuel-rivera-sanchez",
+    "name": "Estadio Manuel Rivera Sanchez",
+    "city": null,
+    "countryCode": "PER",
+    "capacity": 35000,
+    "tenantClubs": [
+      "jose-galvez-fbc",
+      "union-juventud"
+    ]
+  },
+  {
+    "id": "kaesong-youth-stadium",
+    "name": "Kaesong Youth Stadium",
+    "city": null,
+    "countryCode": "PRK",
+    "capacity": 35000,
+    "tenantClubs": []
+  },
+  {
+    "id": "gajayana-stadium",
+    "name": "Gajayana Stadium",
+    "city": null,
+    "countryCode": "IDN",
+    "capacity": 35000,
+    "tenantClubs": [
+      "persema-malang"
+    ]
+  },
+  {
+    "id": "estadio-nido-del-colibri",
+    "name": "Estadio Nido del Colibri",
+    "city": null,
+    "countryCode": "MEX",
+    "capacity": 35000,
+    "tenantClubs": []
+  },
+  {
+    "id": "central-stadium",
+    "name": "Central Stadium",
+    "city": null,
+    "countryCode": "GEO",
+    "capacity": 35000,
+    "tenantClubs": [
+      "fc-dinamo-tbilisi"
+    ]
+  },
+  {
+    "id": "arena-barueri",
+    "name": "Arena Barueri",
+    "city": "Barueri",
+    "countryCode": "BRA",
+    "capacity": 35000,
+    "tenantClubs": [
+      "gremio-barueri-futebol"
+    ]
+  },
+  {
+    "id": "maguwoharjo-stadium",
+    "name": "Maguwoharjo Stadium",
+    "city": "Sleman",
+    "countryCode": "IDN",
+    "capacity": 35000,
+    "tenantClubs": [
+      "pss-sleman"
+    ]
+  },
+  {
+    "id": "horseed-stadium",
+    "name": "Horseed Stadium",
+    "city": null,
+    "countryCode": "SOM",
+    "capacity": 35000,
+    "tenantClubs": [
+      "brothers-somali-fc"
+    ]
+  },
+  {
+    "id": "al-shaab-stadium",
+    "name": "Al-Shaab Stadium",
+    "city": "Baghdad",
+    "countryCode": "IRQ",
+    "capacity": 35000,
+    "tenantClubs": [
+      "iraq-men-s-national-football-team"
+    ]
+  },
+  {
+    "id": "yingkou-olympic-sports-centre-stadium",
+    "name": "Yingkou Olympic Sports Centre Stadium",
+    "city": null,
+    "countryCode": "CHN",
+    "capacity": 35000,
+    "tenantClubs": []
+  },
+  {
+    "id": "zhuhai-sports-center",
+    "name": "Zhuhai Sports Center",
+    "city": null,
+    "countryCode": "CHN",
+    "capacity": 35000,
+    "tenantClubs": [
+      "zhuhai-qin-ao-f-c"
+    ]
+  },
+  {
+    "id": "hamhung-stadium",
+    "name": "Hamhung Stadium",
+    "city": null,
+    "countryCode": "PRK",
+    "capacity": 35000,
+    "tenantClubs": []
+  },
+  {
+    "id": "pakhtakor-markaziy-stadium",
+    "name": "Pakhtakor Markaziy Stadium",
+    "city": "Shaykhontohur",
+    "countryCode": "UZB",
+    "capacity": 35000,
+    "tenantClubs": [
+      "pakhtakor-tashkent-fk"
+    ]
+  },
+  {
+    "id": "sultan-agung-stadium",
+    "name": "Sultan Agung Stadium",
+    "city": "Bantul",
+    "countryCode": "IDN",
+    "capacity": 35000,
+    "tenantClubs": [
+      "persiba-bantul"
+    ]
+  },
+  {
+    "id": "rks-skra-stadium",
+    "name": "RKS Skra Stadium",
+    "city": "Warsaw",
+    "countryCode": "POL",
+    "capacity": 35000,
+    "tenantClubs": [
+      "skra-warszawa"
+    ]
+  },
+  {
+    "id": "samuel-kanyon-doe-sports-complex",
+    "name": "Samuel Kanyon Doe Sports Complex",
+    "city": "Paynesville",
+    "countryCode": "LBR",
+    "capacity": 35000,
+    "tenantClubs": [
+      "liberia-men-s-national-football-team"
+    ]
+  },
+  {
+    "id": "stade-modibo-keita",
+    "name": "Stade Modibo Kéïta",
+    "city": "Bamako",
+    "countryCode": "MLI",
+    "capacity": 35000,
+    "tenantClubs": [
+      "as-korofina",
+      "as-real-bamako",
+      "mali-men-s-national-football-team",
+      "q103819845"
+    ]
+  },
+  {
+    "id": "yunak-stadium",
+    "name": "Yunak Stadium",
+    "city": "Sofia",
+    "countryCode": "BGR",
+    "capacity": 35000,
+    "tenantClubs": [
+      "bulgaria-men-s-national-football-team"
+    ]
+  },
+  {
+    "id": "stade-general-seyni-kountche",
+    "name": "Stade Général Seyni Kountché",
+    "city": null,
+    "countryCode": "NER",
+    "capacity": 35000,
+    "tenantClubs": [
+      "niger-men-s-national-football-team",
+      "us-gn"
+    ]
+  },
+  {
+    "id": "chandrasekharan-nair-stadium",
+    "name": "Chandrasekharan Nair Stadium",
+    "city": "Thiruvananthapuram",
+    "countryCode": "IND",
+    "capacity": 35000,
+    "tenantClubs": []
+  },
+  {
+    "id": "jiaxing-stadium",
+    "name": "Jiaxing Stadium",
+    "city": null,
+    "countryCode": "CHN",
+    "capacity": 35000,
+    "tenantClubs": []
+  },
+  {
+    "id": "serejao",
+    "name": "Serejão",
+    "city": null,
+    "countryCode": "BRA",
+    "capacity": 35000,
+    "tenantClubs": [
+      "taguatinga-esporte-clube"
+    ]
+  },
+  {
+    "id": "suzhou-sports-center",
+    "name": "Suzhou Sports Center",
+    "city": null,
+    "countryCode": "CHN",
+    "capacity": 35000,
+    "tenantClubs": []
+  },
+  {
+    "id": "amakhosi-stadium",
+    "name": "Amakhosi Stadium",
+    "city": "Krugersdorp",
+    "countryCode": "ZAF",
+    "capacity": 35000,
+    "tenantClubs": []
+  },
+  {
+    "id": "charles-mopeli-stadium",
+    "name": "Charles Mopeli Stadium",
+    "city": null,
+    "countryCode": "ZAF",
+    "capacity": 35000,
+    "tenantClubs": [
+      "free-state-stars-f-c"
+    ]
+  },
+  {
+    "id": "likas-stadium",
+    "name": "Likas Stadium",
+    "city": null,
+    "countryCode": "MYS",
+    "capacity": 35000,
+    "tenantClubs": [
+      "sabah-f-c"
+    ]
+  },
+  {
+    "id": "tinsulanonda-stadium",
+    "name": "Tinsulanonda Stadium",
+    "city": "Mueang Songkhla",
+    "countryCode": "THA",
+    "capacity": 35000,
+    "tenantClubs": [
+      "football-at-the-1998-asian-games"
+    ]
+  },
+  {
+    "id": "mko-abiola-stadium",
+    "name": "MKO Abiola Stadium",
+    "city": "Abeokuta",
+    "countryCode": "NGA",
+    "capacity": 35000,
+    "tenantClubs": [
+      "gateway-united-f-c"
+    ]
+  },
+  {
+    "id": "r-premadasa-stadium",
+    "name": "R. Premadasa Stadium",
+    "city": "Maligawatta",
+    "countryCode": "LKA",
+    "capacity": 35000,
+    "tenantClubs": []
+  },
+  {
+    "id": "new-eskisehir-stadium",
+    "name": "New Eskişehir Stadium",
+    "city": null,
+    "countryCode": "TUR",
+    "capacity": 34930,
+    "tenantClubs": [
+      "eskisehirspor"
+    ]
+  },
+  {
+    "id": "arena-lviv",
+    "name": "Arena Lviv",
+    "city": "Lviv",
+    "countryCode": "UKR",
+    "capacity": 34915,
+    "tenantClubs": [
+      "fc-karpaty-lviv"
+    ]
+  },
+  {
+    "id": "estadio-couto-pereira",
+    "name": "Estádio Couto Pereira",
+    "city": null,
+    "countryCode": "BRA",
+    "capacity": 34872,
+    "tenantClubs": [
+      "coritiba-f-c"
+    ]
+  },
+  {
+    "id": "julio-cesar-villagra-stadium",
+    "name": "Julio Cesar Villagra Stadium",
+    "city": "Barrio Alberdi Córdoba",
+    "countryCode": "ARG",
+    "capacity": 34830,
+    "tenantClubs": [
+      "club-atletico-belgrano",
+      "club-atletico-belgrano-women"
+    ]
+  },
+  {
+    "id": "riverside-stadium",
+    "name": "Riverside Stadium",
+    "city": "Middlesbrough",
+    "countryCode": "GBR",
+    "capacity": 34742,
+    "tenantClubs": [
+      "middlesbrough-f-c"
+    ]
+  },
+  {
+    "id": "europa-park-stadion",
+    "name": "Europa-Park-Stadion",
+    "city": null,
+    "countryCode": "DEU",
+    "capacity": 34700,
+    "tenantClubs": [
+      "sc-freiburg"
+    ]
+  },
+  {
+    "id": "estadio-garcilaso",
+    "name": "Estadio Garcilaso",
+    "city": "Cusco",
+    "countryCode": "PER",
+    "capacity": 34500,
+    "tenantClubs": [
+      "cienciano",
+      "club-deportivo-garcilaso"
+    ]
+  },
+  {
+    "id": "grotenburg-stadion",
+    "name": "Grotenburg-Stadion",
+    "city": null,
+    "countryCode": "DEU",
+    "capacity": 34500,
+    "tenantClubs": [
+      "kfc-uerdingen-05"
+    ]
+  },
+  {
+    "id": "jining-stadium",
+    "name": "Jining Stadium",
+    "city": "Jining",
+    "countryCode": "CHN",
+    "capacity": 34318,
+    "tenantClubs": []
+  },
+  {
+    "id": "chornomorets-stadium",
+    "name": "Chornomorets Stadium",
+    "city": "Shevchenko Park",
+    "countryCode": "UKR",
+    "capacity": 34164,
+    "tenantClubs": [
+      "fc-chornomorets-odesa"
+    ]
+  },
+  {
+    "id": "yokohama-stadium",
+    "name": "Yokohama Stadium",
+    "city": "Yokohama Park",
+    "countryCode": "JPN",
+    "capacity": 34046,
+    "tenantClubs": [
+      "yokohama-dena-baystars"
+    ]
+  },
+  {
+    "id": "mewa-arena",
+    "name": "Mewa Arena",
+    "city": null,
+    "countryCode": "DEU",
+    "capacity": 34034,
+    "tenantClubs": [
+      "1-fsv-mainz-05"
+    ]
+  },
+  {
+    "id": "stadion-rujevica",
+    "name": "Stadion Rujevica",
+    "city": "Rijeka",
+    "countryCode": "HRV",
+    "capacity": 34000,
+    "tenantClubs": [
+      "hnk-rijeka"
+    ]
+  },
+  {
+    "id": "bunyodkor-stadium",
+    "name": "Bunyodkor Stadium",
+    "city": "Chilanzar",
+    "countryCode": "UZB",
+    "capacity": 34000,
+    "tenantClubs": [
+      "f-c-bunyodkor"
+    ]
+  },
+  {
+    "id": "quanzhou-sports-center",
+    "name": "Quanzhou Sports Center",
+    "city": "Quanzhou",
+    "countryCode": "CHN",
+    "capacity": 34000,
+    "tenantClubs": []
+  },
+  {
+    "id": "estadio-gran-parque-central",
+    "name": "Estadio Gran Parque Central",
+    "city": null,
+    "countryCode": "URY",
+    "capacity": 34000,
+    "tenantClubs": [
+      "club-nacional-de-football"
+    ]
+  },
+  {
+    "id": "navy-marine-corps-memorial-stadium",
+    "name": "Navy–Marine Corps Memorial Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 34000,
+    "tenantClubs": [
+      "chesapeake-bayhawks",
+      "navy-midshipmen",
+      "navy-midshipmen-football",
+      "navy-midshipmen-men-s-lacrosse"
+    ]
+  },
+  {
+    "id": "sultan-qaboos-sports-complex",
+    "name": "Sultan Qaboos Sports Complex",
+    "city": "Bawshar",
+    "countryCode": "OMN",
+    "capacity": 34000,
+    "tenantClubs": [
+      "oman-men-s-national-football-team"
+    ]
+  },
+  {
+    "id": "athlone-stadium",
+    "name": "Athlone Stadium",
+    "city": null,
+    "countryCode": "ZAF",
+    "capacity": 34000,
+    "tenantClubs": [
+      "santos-f-c"
+    ]
+  },
+  {
+    "id": "oakland-ballpark",
+    "name": "Oakland Ballpark",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 34000,
+    "tenantClubs": [
+      "athletics"
+    ]
+  },
+  {
+    "id": "gluckauf-kampfbahn",
+    "name": "Glückauf-Kampfbahn",
+    "city": null,
+    "countryCode": "DEU",
+    "capacity": 34000,
+    "tenantClubs": [
+      "schalke-04"
+    ]
+  },
+  {
+    "id": "agia-sophia-stadium",
+    "name": "Agia Sophia Stadium",
+    "city": "Nea Filadelfeia",
+    "countryCode": "GRC",
+    "capacity": 34000,
+    "tenantClubs": [
+      "olympiacos-f-c"
+    ]
+  },
+  {
+    "id": "wallace-wade-stadium",
+    "name": "Wallace Wade Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 33941,
+    "tenantClubs": [
+      "duke-blue-devils-football"
+    ]
+  },
+  {
+    "id": "alejandro-villanueva-stadium",
+    "name": "Alejandro Villanueva Stadium",
+    "city": null,
+    "countryCode": "PER",
+    "capacity": 33938,
+    "tenantClubs": [
+      "club-alianza-lima"
+    ]
+  },
+  {
+    "id": "samsun-19-may-s-stadium",
+    "name": "Samsun 19 Mayıs Stadium",
+    "city": "Tekkeköy district",
+    "countryCode": "TUR",
+    "capacity": 33919,
+    "tenantClubs": [
+      "samsunspor-fc"
+    ]
+  },
+  {
+    "id": "pride-park-stadium",
+    "name": "Pride Park Stadium",
+    "city": "Pride Park",
+    "countryCode": "GBR",
+    "capacity": 33597,
+    "tenantClubs": [
+      "derby-county-f-c"
+    ]
+  },
+  {
+    "id": "qinhuangdao-olympic-sports-center-stadium",
+    "name": "Qinhuangdao Olympic Sports Center Stadium",
+    "city": null,
+    "countryCode": "CHN",
+    "capacity": 33572,
+    "tenantClubs": []
+  },
+  {
+    "id": "gaziantep-stadium",
+    "name": "Gaziantep Stadium",
+    "city": "Göktürk",
+    "countryCode": "TUR",
+    "capacity": 33502,
+    "tenantClubs": [
+      "gaziantep-f-k"
+    ]
+  },
+  {
+    "id": "kardinia-park",
+    "name": "Kardinia Park",
+    "city": "South Geelong",
+    "countryCode": "AUS",
+    "capacity": 33500,
+    "tenantClubs": [
+      "geelong-cats-football-club-aflw",
+      "geelong-football-club"
+    ]
+  },
+  {
+    "id": "ladd-peebles-stadium",
+    "name": "Ladd–Peebles Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 33471,
+    "tenantClubs": [
+      "senior-bowl",
+      "south-alabama-jaguars-football"
+    ]
+  },
+  {
+    "id": "arena-philip-ii-of-macedonia-tose-proeski-todor",
+    "name": "Arena ”Philip II. of Macedonia / Toše Proeski / Todor”",
+    "city": null,
+    "countryCode": "MKD",
+    "capacity": 33460,
+    "tenantClubs": [
+      "fk-vardar"
+    ]
+  },
+  {
+    "id": "princess-auto-stadium",
+    "name": "Princess Auto Stadium",
+    "city": "University of Manitoba",
+    "countryCode": "CAN",
+    "capacity": 33422,
+    "tenantClubs": [
+      "valour-fc",
+      "winnipeg-blue-bombers"
+    ]
+  },
+  {
+    "id": "karaiskakis-stadium",
+    "name": "Karaiskakis Stadium",
+    "city": "Piraeus",
+    "countryCode": "GRC",
+    "capacity": 33334,
+    "tenantClubs": [
+      "olympiacos-f-c"
+    ]
+  },
+  {
+    "id": "stade-chaban-delmas",
+    "name": "Stade Chaban-Delmas",
+    "city": null,
+    "countryCode": "FRA",
+    "capacity": 33290,
+    "tenantClubs": [
+      "union-bordeaux-begles"
+    ]
+  },
+  {
+    "id": "cardiff-city-stadium",
+    "name": "Cardiff City Stadium",
+    "city": "Cardiff",
+    "countryCode": "GBR",
+    "capacity": 33260,
+    "tenantClubs": [
+      "cardiff-city-f-c",
+      "cardiff-rugby"
+    ]
+  },
+  {
+    "id": "stadio-luigi-ferraris",
+    "name": "Stadio Luigi Ferraris",
+    "city": null,
+    "countryCode": "ITA",
+    "capacity": 33205,
+    "tenantClubs": [
+      "2021-22-u-c-sampdoria-season",
+      "genoa-cfc",
+      "u-c-sampdoria"
+    ]
+  },
+  {
+    "id": "wildparkstadion",
+    "name": "Wildparkstadion",
+    "city": null,
+    "countryCode": "DEU",
+    "capacity": 33180,
+    "tenantClubs": [
+      "karlsruher-sc"
+    ]
+  },
+  {
+    "id": "stadium-municipal",
+    "name": "Stadium Municipal",
+    "city": null,
+    "countryCode": "FRA",
+    "capacity": 33150,
+    "tenantClubs": [
+      "toulouse-fc"
+    ]
+  },
+  {
+    "id": "stadion-miejski-in-krakow",
+    "name": "Stadion Miejski in Kraków",
+    "city": null,
+    "countryCode": "POL",
+    "capacity": 33130,
+    "tenantClubs": [
+      "wis-a-krakow"
+    ]
+  },
+  {
+    "id": "stade-alphonse-massemba-debat",
+    "name": "Stade Alphonse Massemba-Débat",
+    "city": null,
+    "countryCode": "COG",
+    "capacity": 33037,
+    "tenantClubs": [
+      "ajax-de-ouenze",
+      "cara-brazzaville",
+      "etoile-du-congo",
+      "fc-kondzo",
+      "manchester-congo-mouilla",
+      "patronage-sainte-anne",
+      "saint-michel-d-ouenze"
+    ]
+  },
+  {
+    "id": "estadio-anisio-haddad",
+    "name": "Estádio Anísio Haddad",
+    "city": null,
+    "countryCode": "BRA",
+    "capacity": 33000,
+    "tenantClubs": [
+      "rio-preto-esporte-clube"
+    ]
+  },
+  {
+    "id": "yale-field",
+    "name": "Yale Field",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 33000,
+    "tenantClubs": [
+      "yale-bulldogs-football"
+    ]
+  },
+  {
+    "id": "stade-oceane",
+    "name": "Stade Océane",
+    "city": null,
+    "countryCode": "FRA",
+    "capacity": 33000,
+    "tenantClubs": [
+      "le-havre-ac"
+    ]
+  },
+  {
+    "id": "national-football-stadium",
+    "name": "National Football Stadium",
+    "city": "Minsk",
+    "countryCode": "BLR",
+    "capacity": 33000,
+    "tenantClubs": []
+  },
+  {
+    "id": "estadio-jk",
+    "name": "Estádio JK",
+    "city": null,
+    "countryCode": "BRA",
+    "capacity": 33000,
+    "tenantClubs": [
+      "itumbiara-esporte-clube"
+    ]
+  },
+  {
+    "id": "deutsches-stadion-deu",
+    "name": "Deutsches Stadion",
+    "city": null,
+    "countryCode": "DEU",
+    "capacity": 33000,
+    "tenantClubs": [
+      "list-of-german-football-champions"
+    ]
+  },
+  {
+    "id": "mosaic-stadium",
+    "name": "Mosaic Stadium",
+    "city": null,
+    "countryCode": "CAN",
+    "capacity": 33000,
+    "tenantClubs": [
+      "saskatchewan-roughriders"
+    ]
+  },
+  {
+    "id": "markaziy-stadium",
+    "name": "Markaziy Stadium",
+    "city": null,
+    "countryCode": "UZB",
+    "capacity": 33000,
+    "tenantClubs": [
+      "navbahor-namangan"
+    ]
+  },
+  {
+    "id": "colt-stadium",
+    "name": "Colt Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 33000,
+    "tenantClubs": [
+      "houston-astros"
+    ]
+  },
+  {
+    "id": "stadionul-dan-paltinisanu",
+    "name": "Stadionul Dan Păltinișanu",
+    "city": null,
+    "countryCode": "ROU",
+    "capacity": 32972,
+    "tenantClubs": [
+      "acs-poli-timisoara",
+      "fc-politehnica-timisoara",
+      "scm-usv-timisoara"
+    ]
+  },
+  {
+    "id": "new-tivoli",
+    "name": "New Tivoli",
+    "city": "Soers",
+    "countryCode": "DEU",
+    "capacity": 32960,
+    "tenantClubs": [
+      "alemannia-aachen"
+    ]
+  },
+  {
+    "id": "stade-de-la-mosson",
+    "name": "Stade de la Mosson",
+    "city": "Montpellier",
+    "countryCode": "FRA",
+    "capacity": 32900,
+    "tenantClubs": [
+      "montpellier-herault-sport-club"
+    ]
+  },
+  {
+    "id": "kelly-shorts-stadium",
+    "name": "Kelly/Shorts Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 32885,
+    "tenantClubs": [
+      "central-michigan-chippewas",
+      "central-michigan-chippewas-football"
+    ]
+  },
+  {
+    "id": "kadir-has-stadium",
+    "name": "Kadir Has Stadium",
+    "city": null,
+    "countryCode": "TUR",
+    "capacity": 32864,
+    "tenantClubs": [
+      "kayserispor"
+    ]
+  },
+  {
+    "id": "estadio-municipal-de-aveiro-mario-duarte",
+    "name": "Estádio Municipal de Aveiro – Mário Duarte",
+    "city": "Aveiro",
+    "countryCode": "PRT",
+    "capacity": 32830,
+    "tenantClubs": [
+      "s-c-beira-mar"
+    ]
+  },
+  {
+    "id": "estadio-sergio-leon-chavez",
+    "name": "Estadio Sergio León Chávez",
+    "city": "Irapuato",
+    "countryCode": "MEX",
+    "capacity": 32784,
+    "tenantClubs": [
+      "atletico-irapuato"
+    ]
+  },
+  {
+    "id": "tsentralnyi-profsoyuz-stadion",
+    "name": "Tsentralnyi Profsoyuz Stadion",
+    "city": null,
+    "countryCode": "RUS",
+    "capacity": 32750,
+    "tenantClubs": [
+      "fc-fakel-voronezh"
+    ]
+  },
+  {
+    "id": "martin-stadium",
+    "name": "Martin Stadium",
+    "city": "Washington State University",
+    "countryCode": "USA",
+    "capacity": 32740,
+    "tenantClubs": [
+      "washington-state-cougars",
+      "washington-state-cougars-football"
+    ]
+  },
+  {
+    "id": "partizan-stadium",
+    "name": "Partizan Stadium",
+    "city": "Autokomanda",
+    "countryCode": "SRB",
+    "capacity": 32710,
+    "tenantClubs": [
+      "fk-partizan"
+    ]
+  },
+  {
+    "id": "bramall-lane",
+    "name": "Bramall Lane",
+    "city": null,
+    "countryCode": "GBR",
+    "capacity": 32702,
+    "tenantClubs": [
+      "sheffield-eagles",
+      "sheffield-united-f-c",
+      "sheffield-united-w-f-c",
+      "yorkshire-county-cricket-club"
+    ]
+  },
+  {
+    "id": "ricoh-arena",
+    "name": "Ricoh Arena",
+    "city": null,
+    "countryCode": "GBR",
+    "capacity": 32609,
+    "tenantClubs": [
+      "coventry-city-f-c",
+      "wasps-rfc"
+    ]
+  },
+  {
+    "id": "estadio-universitario-alberto-chivo-cordova",
+    "name": "Estadio Universitario Alberto Chivo Cordova",
+    "city": "Toluca de Lerdo",
+    "countryCode": "MEX",
+    "capacity": 32603,
+    "tenantClubs": [
+      "potros-salvajes-uaem"
+    ]
+  },
+  {
+    "id": "chang-arena",
+    "name": "Chang Arena",
+    "city": "Buri Ram",
+    "countryCode": "THA",
+    "capacity": 32600,
+    "tenantClubs": [
+      "buriram-united-f-c"
+    ]
+  },
+  {
+    "id": "casement-park",
+    "name": "Casement Park",
+    "city": null,
+    "countryCode": "GBR",
+    "capacity": 32600,
+    "tenantClubs": [
+      "antrim-gaa"
+    ]
+  },
+  {
+    "id": "st-mary-s-stadium",
+    "name": "St Mary's Stadium",
+    "city": null,
+    "countryCode": "GBR",
+    "capacity": 32589,
+    "tenantClubs": [
+      "southampton-f-c",
+      "southampton-women-s-fc"
+    ]
+  },
+  {
+    "id": "juan-domingo-peron-stadium",
+    "name": "Juan Domingo Perón Stadium",
+    "city": null,
+    "countryCode": "ARG",
+    "capacity": 32535,
+    "tenantClubs": [
+      "club-sport-emelec"
+    ]
+  },
+  {
+    "id": "nueva-espana-stadium",
+    "name": "Nueva España Stadium",
+    "city": "Parque Avellaneda",
+    "countryCode": "ARG",
+    "capacity": 32500,
+    "tenantClubs": [
+      "deportivo-espanol"
+    ]
+  },
+  {
+    "id": "robert-rice-stadium",
+    "name": "Robert Rice Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 32500,
+    "tenantClubs": [
+      "utah-utes"
+    ]
+  },
+  {
+    "id": "shenzhen-stadium",
+    "name": "Shenzhen Stadium",
+    "city": "Futian District",
+    "countryCode": "CHN",
+    "capacity": 32500,
+    "tenantClubs": [
+      "shenzhen-f-c"
+    ]
+  },
+  {
+    "id": "estadio-municipal-de-abanca-riazor",
+    "name": "Estadio Municipal de Abanca Riazor",
+    "city": null,
+    "countryCode": "ESP",
+    "capacity": 32490,
+    "tenantClubs": [
+      "deportivo-de-la-coruna"
+    ]
+  },
+  {
+    "id": "republican-spartak-stadium",
+    "name": "Republican Spartak Stadium",
+    "city": null,
+    "countryCode": "RUS",
+    "capacity": 32464,
+    "tenantClubs": [
+      "fc-alania-vladikavkaz"
+    ]
+  },
+  {
+    "id": "stadio-nereo-rocco",
+    "name": "Stadio Nereo Rocco",
+    "city": null,
+    "countryCode": "ITA",
+    "capacity": 32454,
+    "tenantClubs": [
+      "us-triestina-calcio-1918"
+    ]
+  },
+  {
+    "id": "stadio-euganeo",
+    "name": "Stadio Euganeo",
+    "city": null,
+    "countryCode": "ITA",
+    "capacity": 32420,
+    "tenantClubs": [
+      "calcio-padova"
+    ]
+  },
+  {
+    "id": "gran-canaria-stadium",
+    "name": "Gran Canaria Stadium",
+    "city": "Las Palmas de Gran Canaria",
+    "countryCode": "ESP",
+    "capacity": 32392,
+    "tenantClubs": [
+      "ud-las-palmas"
+    ]
+  },
+  {
+    "id": "darul-aman-stadium",
+    "name": "Darul Aman Stadium",
+    "city": null,
+    "countryCode": "MYS",
+    "capacity": 32387,
+    "tenantClubs": [
+      "kedah-darul-aman-f-c"
+    ]
+  },
+  {
+    "id": "monumental-stadium-football-miguel-aleman-valdes",
+    "name": "Monumental Stadium football Miguel Aleman Valdes",
+    "city": "Celaya",
+    "countryCode": "MEX",
+    "capacity": 32300,
+    "tenantClubs": [
+      "atletico-celaya"
+    ]
+  },
+  {
+    "id": "leicester-city-stadium",
+    "name": "Leicester City Stadium",
+    "city": null,
+    "countryCode": "GBR",
+    "capacity": 32261,
+    "tenantClubs": [
+      "leicester-city-f-c",
+      "leicester-city-w-f-c",
+      "leicester-tigers"
+    ]
+  },
+  {
+    "id": "nantong-stadium",
+    "name": "Nantong Stadium",
+    "city": null,
+    "countryCode": "CHN",
+    "capacity": 32244,
+    "tenantClubs": []
+  },
+  {
+    "id": "estadio-de-pituacu",
+    "name": "Estádio de Pituaçu",
+    "city": "Pituaçu",
+    "countryCode": "BRA",
+    "capacity": 32157,
+    "tenantClubs": [
+      "esporte-clube-bahia"
+    ]
+  },
+  {
+    "id": "central-stadium-rus",
+    "name": "Central Stadium",
+    "city": null,
+    "countryCode": "RUS",
+    "capacity": 32120,
+    "tenantClubs": [
+      "fc-rotor-volgograd"
+    ]
+  },
+  {
+    "id": "rudolf-harbig-stadion",
+    "name": "Rudolf-Harbig-Stadion",
+    "city": null,
+    "countryCode": "DEU",
+    "capacity": 32085,
+    "tenantClubs": [
+      "dynamo-dresden"
+    ]
+  },
+  {
+    "id": "weinan-sports-center-stadium",
+    "name": "Weinan Sports Center Stadium",
+    "city": null,
+    "countryCode": "CHN",
+    "capacity": 32000,
+    "tenantClubs": [
+      "shaanxi-union-f-c"
+    ]
+  },
+  {
+    "id": "gerald-j-ford-stadium",
+    "name": "Gerald J. Ford Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 32000,
+    "tenantClubs": [
+      "smu-mustangs"
+    ]
+  },
+  {
+    "id": "zabuthiri-stadium",
+    "name": "Zabuthiri Stadium",
+    "city": null,
+    "countryCode": "MMR",
+    "capacity": 32000,
+    "tenantClubs": []
+  },
+  {
+    "id": "homs-municipal-stadium",
+    "name": "Homs Municipal Stadium",
+    "city": null,
+    "countryCode": "SYR",
+    "capacity": 32000,
+    "tenantClubs": [
+      "al-karamah-sc"
+    ]
+  },
+  {
+    "id": "marschweg-stadion",
+    "name": "Marschweg-Stadion",
+    "city": null,
+    "countryCode": "DEU",
+    "capacity": 32000,
+    "tenantClubs": [
+      "sc-preu-en-munster"
+    ]
+  },
+  {
+    "id": "datianwan-stadium",
+    "name": "Datianwan Stadium",
+    "city": null,
+    "countryCode": "CHN",
+    "capacity": 32000,
+    "tenantClubs": []
+  },
+  {
+    "id": "stadion-wankdorf",
+    "name": "Stadion Wankdorf",
+    "city": "Breitfeld",
+    "countryCode": "CHE",
+    "capacity": 32000,
+    "tenantClubs": [
+      "bsc-young-boys"
+    ]
+  },
+  {
+    "id": "stadion-am-schloss-strunkede",
+    "name": "Stadion am Schloss Strünkede",
+    "city": null,
+    "countryCode": "DEU",
+    "capacity": 32000,
+    "tenantClubs": [
+      "sc-westfalia-herne"
+    ]
+  },
+  {
+    "id": "shanxi-provincial-stadium",
+    "name": "Shanxi Provincial Stadium",
+    "city": null,
+    "countryCode": "CHN",
+    "capacity": 32000,
+    "tenantClubs": []
+  },
+  {
+    "id": "hailanjiang-stadium",
+    "name": "Hailanjiang Stadium",
+    "city": null,
+    "countryCode": "CHN",
+    "capacity": 32000,
+    "tenantClubs": []
+  },
+  {
+    "id": "estadio-rommel-fernandez",
+    "name": "Estadio Rommel Fernández",
+    "city": null,
+    "countryCode": "PAN",
+    "capacity": 32000,
+    "tenantClubs": [
+      "panama-men-s-national-football-team"
+    ]
+  },
+  {
+    "id": "estadio-jorge-el-magico-gonzalez",
+    "name": "Estadio Jorge \"El Mágico\" González",
+    "city": null,
+    "countryCode": "SLV",
+    "capacity": 32000,
+    "tenantClubs": [
+      "alianza-futbol-cub"
+    ]
+  },
+  {
+    "id": "estadio-nilmo-edwards",
+    "name": "Estadio Nilmo Edwards",
+    "city": null,
+    "countryCode": "HND",
+    "capacity": 32000,
+    "tenantClubs": [
+      "club-deportivo-victoria"
+    ]
+  },
+  {
+    "id": "worthersee-stadion",
+    "name": "Wörthersee Stadion",
+    "city": "Klagenfurt am Wörthersee",
+    "countryCode": "AUT",
+    "capacity": 32000,
+    "tenantClubs": [
+      "sk-austria-karnten"
+    ]
+  },
+  {
+    "id": "paris-la-defense-arena",
+    "name": "Paris La Défense Arena",
+    "city": "La Défense",
+    "countryCode": "FRA",
+    "capacity": 32000,
+    "tenantClubs": [
+      "racing-92"
+    ]
+  },
+  {
+    "id": "tai-an-sports-center-stadium",
+    "name": "Tai'an Sports Center Stadium",
+    "city": null,
+    "countryCode": "CHN",
+    "capacity": 32000,
+    "tenantClubs": []
+  },
+  {
+    "id": "estadio-victor-agustin-ugarte",
+    "name": "Estadio Víctor Agustín Ugarte",
+    "city": null,
+    "countryCode": "BOL",
+    "capacity": 32000,
+    "tenantClubs": [
+      "club-real-potosi"
+    ]
+  },
+  {
+    "id": "al-madina-stadium",
+    "name": "Al-Madina Stadium",
+    "city": null,
+    "countryCode": "IRQ",
+    "capacity": 32000,
+    "tenantClubs": []
+  },
+  {
+    "id": "kamuzu-stadium",
+    "name": "Kamuzu Stadium",
+    "city": null,
+    "countryCode": "MWI",
+    "capacity": 32000,
+    "tenantClubs": [
+      "big-bullets-f-c",
+      "malawi-men-s-national-football-team",
+      "mighty-wanderers-f-c"
+    ]
+  },
+  {
+    "id": "ischelandstadion",
+    "name": "Ischelandstadion",
+    "city": null,
+    "countryCode": "DEU",
+    "capacity": 32000,
+    "tenantClubs": [
+      "bbv-hagen"
+    ]
+  },
+  {
+    "id": "hiroshima-municipal-stadium",
+    "name": "Hiroshima Municipal Stadium",
+    "city": null,
+    "countryCode": "JPN",
+    "capacity": 31984,
+    "tenantClubs": [
+      "hiroshima-toyo-carp"
+    ]
+  },
+  {
+    "id": "red-bull-arena-aut",
+    "name": "Red Bull Arena",
+    "city": null,
+    "countryCode": "AUT",
+    "capacity": 31895,
+    "tenantClubs": [
+      "fc-red-bull-salzburg"
+    ]
+  },
+  {
+    "id": "estadio-municipal-radialista-mario-helenio",
+    "name": "Estádio Municipal Radialista Mário Helênio",
+    "city": "Juiz de Fora",
+    "countryCode": "BRA",
+    "capacity": 31863,
+    "tenantClubs": [
+      "association-football"
+    ]
+  },
+  {
+    "id": "brighton-community-stadium",
+    "name": "Brighton Community Stadium",
+    "city": "Falmer",
+    "countryCode": "GBR",
+    "capacity": 31800,
+    "tenantClubs": [
+      "brighton-hove-albion-f-c"
+    ]
+  },
+  {
+    "id": "teddy-stadium",
+    "name": "Teddy Stadium",
+    "city": null,
+    "countryCode": "ISR",
+    "capacity": 31733,
+    "tenantClubs": [
+      "beitar-jerusalem-f-c",
+      "hapoel-jerusalem-f-c",
+      "israel-men-s-national-football-team"
+    ]
+  },
+  {
+    "id": "shakhtar-stadium",
+    "name": "Shakhtar Stadium",
+    "city": null,
+    "countryCode": "UKR",
+    "capacity": 31718,
+    "tenantClubs": [
+      "fc-shakhtar-donetsk"
+    ]
+  },
+  {
+    "id": "kuban-stadium",
+    "name": "Kuban Stadium",
+    "city": null,
+    "countryCode": "RUS",
+    "capacity": 31654,
+    "tenantClubs": [
+      "fc-krasnodar",
+      "fc-kuban-holding",
+      "fc-kuban-krasnodar",
+      "kubanochka-krasnodar",
+      "pfc-kuban-krasnodar"
+    ]
+  },
+  {
+    "id": "seibu-dome",
+    "name": "Seibu Dome",
+    "city": null,
+    "countryCode": "JPN",
+    "capacity": 31552,
+    "tenantClubs": [
+      "saitama-seibu-lions"
+    ]
+  },
+  {
+    "id": "estadio-santa-cruz",
+    "name": "Estádio Santa Cruz",
+    "city": "Ribeirão Preto",
+    "countryCode": "BRA",
+    "capacity": 31527,
+    "tenantClubs": [
+      "botafogo-futebol-clube"
+    ]
+  },
+  {
+    "id": "cessna-stadium",
+    "name": "Cessna Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 31500,
+    "tenantClubs": [
+      "wichita-state-shockers-football"
+    ]
+  },
+  {
+    "id": "allegacy-federal-credit-union-stadium",
+    "name": "Allegacy Federal Credit Union Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 31500,
+    "tenantClubs": [
+      "wake-forest-demon-deacons-football"
+    ]
+  },
+  {
+    "id": "schauinsland-reisen-arena",
+    "name": "Schauinsland-Reisen-Arena",
+    "city": null,
+    "countryCode": "DEU",
+    "capacity": 31500,
+    "tenantClubs": [
+      "msv-duisburg"
+    ]
+  },
+  {
+    "id": "jose-hernandez-amphitheatre",
+    "name": "José Hernández Amphitheatre",
+    "city": "Jesús María",
+    "countryCode": "ARG",
+    "capacity": 31500,
+    "tenantClubs": []
+  },
+  {
+    "id": "stadio-via-del-mare",
+    "name": "Stadio Via del Mare",
+    "city": null,
+    "countryCode": "ITA",
+    "capacity": 31461,
+    "tenantClubs": [
+      "us-lecce"
+    ]
+  },
+  {
+    "id": "estadio-manuel-martinez-valero",
+    "name": "Estadio Manuel Martínez Valero",
+    "city": "Elche",
+    "countryCode": "ESP",
+    "capacity": 31388,
+    "tenantClubs": [
+      "elche-cf"
+    ]
+  },
+  {
+    "id": "ewood-park",
+    "name": "Ewood Park",
+    "city": "Blackburn",
+    "countryCode": "GBR",
+    "capacity": 31367,
+    "tenantClubs": [
+      "blackburn-rovers-f-c"
+    ]
+  },
+  {
+    "id": "stadionul-steaua",
+    "name": "Stadionul Steaua",
+    "city": null,
+    "countryCode": "ROU",
+    "capacity": 31254,
+    "tenantClubs": [
+      "fcsb"
+    ]
+  },
+  {
+    "id": "rutgers-stadium",
+    "name": "Rutgers Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 31219,
+    "tenantClubs": [
+      "rutgers-scarlet-knights-football"
+    ]
+  },
+  {
+    "id": "ammo-baba-stadium",
+    "name": "Ammo Baba stadium",
+    "city": null,
+    "countryCode": "IRQ",
+    "capacity": 31200,
+    "tenantClubs": []
+  },
+  {
+    "id": "tofiq-bahramov-stadium",
+    "name": "Tofiq Bahramov Stadium",
+    "city": null,
+    "countryCode": "AZE",
+    "capacity": 31200,
+    "tenantClubs": [
+      "azerbaijan-men-s-national-football-team",
+      "qarabag-fk"
+    ]
+  },
+  {
+    "id": "estadio-nueva-condomina",
+    "name": "Estadio Nueva Condomina",
+    "city": "Murcia",
+    "countryCode": "ESP",
+    "capacity": 31179,
+    "tenantClubs": [
+      "real-murcia"
+    ]
+  },
+  {
+    "id": "roazhon-park",
+    "name": "Roazhon Park",
+    "city": null,
+    "countryCode": "FRA",
+    "capacity": 31127,
+    "tenantClubs": [
+      "stade-rennais-f-c"
+    ]
+  },
+  {
+    "id": "polish-army-stadium",
+    "name": "Polish Army Stadium",
+    "city": null,
+    "countryCode": "POL",
+    "capacity": 31106,
+    "tenantClubs": [
+      "legia-warsaw"
+    ]
+  },
+  {
+    "id": "stadio-marcantonio-bentegodi",
+    "name": "Stadio Marcantonio Bentegodi",
+    "city": null,
+    "countryCode": "ITA",
+    "capacity": 31045,
+    "tenantClubs": [
+      "ac-chievoverona",
+      "hellas-verona-fc"
+    ]
+  },
+  {
+    "id": "dnipro-arena",
+    "name": "Dnipro Arena",
+    "city": null,
+    "countryCode": "UKR",
+    "capacity": 31003,
+    "tenantClubs": [
+      "fc-dnipro"
+    ]
+  },
+  {
+    "id": "birkebeineren-ski-stadium",
+    "name": "Birkebeineren Ski Stadium",
+    "city": null,
+    "countryCode": "NOR",
+    "capacity": 31000,
+    "tenantClubs": [
+      "1994-winter-olympics"
+    ]
+  },
+  {
+    "id": "dalian-jinzhou-stadium",
+    "name": "Dalian Jinzhou Stadium",
+    "city": null,
+    "countryCode": "CHN",
+    "capacity": 31000,
+    "tenantClubs": [
+      "dalian-shide-f-c"
+    ]
+  },
+  {
+    "id": "gifu-nagaragawa-stadium",
+    "name": "Gifu Nagaragawa Stadium",
+    "city": null,
+    "countryCode": "JPN",
+    "capacity": 31000,
+    "tenantClubs": [
+      "fc-gifu"
+    ]
+  },
+  {
+    "id": "university-at-buffalo-stadium",
+    "name": "University at Buffalo Stadium",
+    "city": "Amherst",
+    "countryCode": "USA",
+    "capacity": 31000,
+    "tenantClubs": [
+      "buffalo-bulls-football",
+      "buffalo-bulls-men-s-soccer"
+    ]
+  },
+  {
+    "id": "cajun-field-at-our-lady-of-lourdes-stadium",
+    "name": "Cajun Field at Our Lady of Lourdes Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 31000,
+    "tenantClubs": [
+      "louisiana-ragin-cajuns",
+      "louisiana-ragin-cajuns-football"
+    ]
+  },
+  {
+    "id": "sammy-ofer-stadium",
+    "name": "Sammy Ofer Stadium",
+    "city": null,
+    "countryCode": "ISR",
+    "capacity": 30950,
+    "tenantClubs": [
+      "hapoel-haifa-f-c",
+      "israel-men-s-national-football-team",
+      "maccabi-haifa-f-c"
+    ]
+  },
+  {
+    "id": "stadionul-ion-oblemenco",
+    "name": "Stadionul Ion Oblemenco",
+    "city": "Craiova",
+    "countryCode": "ROU",
+    "capacity": 30944,
+    "tenantClubs": [
+      "cs-universitatea-craiova",
+      "fc-u-craiova-1948"
+    ]
+  },
+  {
+    "id": "molineux-stadium",
+    "name": "Molineux Stadium",
+    "city": null,
+    "countryCode": "GBR",
+    "capacity": 30852,
+    "tenantClubs": [
+      "wolverhampton-wanderers-f-c"
+    ]
+  },
+  {
+    "id": "datcu-stadium",
+    "name": "DATCU Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 30850,
+    "tenantClubs": [
+      "north-texas-mean-green",
+      "north-texas-mean-green-football"
+    ]
+  },
+  {
+    "id": "francisco-stedile-stadium",
+    "name": "Francisco Stédile Stadium",
+    "city": "Caxias do Sul",
+    "countryCode": "BRA",
+    "capacity": 30802,
+    "tenantClubs": [
+      "sociedade-esportiva-e-recreativa-caxias-do-sul"
+    ]
+  },
+  {
+    "id": "chengdu-longquanyi-football-stadium",
+    "name": "Chengdu Longquanyi Football Stadium",
+    "city": null,
+    "countryCode": "CHN",
+    "capacity": 30800,
+    "tenantClubs": []
+  },
+  {
+    "id": "johnny-red-floyd-stadium",
+    "name": "Johnny \"Red\" Floyd Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 30788,
+    "tenantClubs": [
+      "middle-tennessee-blue-raiders-football"
+    ]
+  },
+  {
+    "id": "forsyth-barr-stadium",
+    "name": "Forsyth Barr Stadium",
+    "city": "Central Dunedin",
+    "countryCode": "NZL",
+    "capacity": 30748,
+    "tenantClubs": [
+      "highlanders",
+      "otago-rfu",
+      "southern-united-fc"
+    ]
+  },
+  {
+    "id": "estadio-olimpico-patria",
+    "name": "Estadio Olímpico Patria",
+    "city": null,
+    "countryCode": "BOL",
+    "capacity": 30700,
+    "tenantClubs": [
+      "club-universitario"
+    ]
+  },
+  {
+    "id": "wwk-arena",
+    "name": "WWK Arena",
+    "city": null,
+    "countryCode": "DEU",
+    "capacity": 30660,
+    "tenantClubs": [
+      "fc-augsburg"
+    ]
+  },
+  {
+    "id": "foolad-khuzestan-stadium",
+    "name": "Foolad Khuzestan Stadium",
+    "city": "Ahvaz",
+    "countryCode": "IRN",
+    "capacity": 30655,
+    "tenantClubs": [
+      "foolad-f-c"
+    ]
+  },
+  {
+    "id": "akhmat-arena",
+    "name": "Akhmat-Arena",
+    "city": null,
+    "countryCode": "RUS",
+    "capacity": 30597,
+    "tenantClubs": [
+      "fc-akhmat-grozny"
+    ]
+  },
+  {
+    "id": "sajik-baseball-stadium",
+    "name": "Sajik Baseball Stadium",
+    "city": null,
+    "countryCode": "KOR",
+    "capacity": 30543,
+    "tenantClubs": [
+      "lotte-giants"
+    ]
+  },
+  {
+    "id": "estadio-alfredo-jaconi",
+    "name": "Estádio Alfredo Jaconi",
+    "city": null,
+    "countryCode": "BRA",
+    "capacity": 30519,
+    "tenantClubs": [
+      "esporte-clube-juventude"
+    ]
+  },
+  {
+    "id": "dignity-health-sports-park",
+    "name": "Dignity Health Sports Park",
+    "city": "Carson",
+    "countryCode": "USA",
+    "capacity": 30510,
+    "tenantClubs": [
+      "chivas-usa",
+      "la-galaxy",
+      "los-angeles-chargers",
+      "los-angeles-wildcats",
+      "san-diego-state-aztecs-football"
+    ]
+  },
+  {
+    "id": "stadium-mk",
+    "name": "Stadium MK",
+    "city": null,
+    "countryCode": "GBR",
+    "capacity": 30500,
+    "tenantClubs": [
+      "milton-keynes-dons-f-c"
+    ]
+  },
+  {
+    "id": "carlos-tartiere-stadium",
+    "name": "Carlos Tartiere Stadium",
+    "city": null,
+    "countryCode": "ESP",
+    "capacity": 30500,
+    "tenantClubs": [
+      "real-oviedo"
+    ]
+  },
+  {
+    "id": "muscat-stadium",
+    "name": "Muscat Stadium",
+    "city": "Nakashō",
+    "countryCode": "JPN",
+    "capacity": 30494,
+    "tenantClubs": []
+  },
+  {
+    "id": "incheon-ssg-landers-field",
+    "name": "Incheon SSG Landers Field",
+    "city": null,
+    "countryCode": "KOR",
+    "capacity": 30480,
+    "tenantClubs": [
+      "ssg-landers"
+    ]
+  },
+  {
+    "id": "cefcu-stadium",
+    "name": "CEFCU Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 30456,
+    "tenantClubs": [
+      "san-jose-state-spartans",
+      "san-jose-state-spartans-football"
+    ]
+  },
+  {
+    "id": "jps-field-at-malone-stadium",
+    "name": "JPS Field at Malone Stadium",
+    "city": "Monroe",
+    "countryCode": "USA",
+    "capacity": 30427,
+    "tenantClubs": [
+      "louisiana-monroe-warhawks-football"
+    ]
+  },
+  {
+    "id": "city-ground",
+    "name": "City Ground",
+    "city": "Nottingham",
+    "countryCode": "GBR",
+    "capacity": 30404,
+    "tenantClubs": [
+      "nottingham-forest-f-c",
+      "nottingham-forest-women-f-c"
+    ]
+  },
+  {
+    "id": "centennial-bank-stadium",
+    "name": "Centennial Bank Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 30382,
+    "tenantClubs": [
+      "arkansas-state-red-wolves",
+      "arkansas-state-red-wolves-football"
+    ]
+  },
+  {
+    "id": "aggie-memorial-stadium",
+    "name": "Aggie Memorial Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 30343,
+    "tenantClubs": [
+      "new-mexico-state-aggies",
+      "new-mexico-state-aggies-football"
+    ]
+  },
+  {
+    "id": "cluj-arena",
+    "name": "Cluj Arena",
+    "city": "Cluj-Napoca",
+    "countryCode": "ROU",
+    "capacity": 30335,
+    "tenantClubs": [
+      "fc-universitatea-cluj"
+    ]
+  },
+  {
+    "id": "harvard-stadium",
+    "name": "Harvard Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 30323,
+    "tenantClubs": [
+      "harvard-crimson-football"
+    ]
+  },
+  {
+    "id": "tianjin-tuanbo-football-stadium",
+    "name": "Tianjin Tuanbo Football Stadium",
+    "city": "Tianjin",
+    "countryCode": "CHN",
+    "capacity": 30320,
+    "tenantClubs": [
+      "tianjin-tianhai-f-c"
+    ]
+  },
+  {
+    "id": "portman-road",
+    "name": "Portman Road",
+    "city": "Ipswich",
+    "countryCode": "GBR",
+    "capacity": 30311,
+    "tenantClubs": [
+      "ipswich-town-f-c"
+    ]
+  },
+  {
+    "id": "estadio-algarve",
+    "name": "Estádio Algarve",
+    "city": "Loulé",
+    "countryCode": "PRT",
+    "capacity": 30305,
+    "tenantClubs": [
+      "gibraltar-men-s-national-football-team",
+      "louletano-d-c",
+      "portugal-men-s-national-football-team",
+      "s-c-farense"
+    ]
+  },
+  {
+    "id": "municipal-stadium-sidi-bennour",
+    "name": "Municipal Stadium (Sidi Bennour)",
+    "city": "Sidi Bennour Province",
+    "countryCode": "MAR",
+    "capacity": 30286,
+    "tenantClubs": [
+      "amal-club-sidi-bennour",
+      "club-fateh-sidi-bennour"
+    ]
+  },
+  {
+    "id": "estadio-municipal-de-braga",
+    "name": "Estádio Municipal de Braga",
+    "city": "Braga",
+    "countryCode": "PRT",
+    "capacity": 30286,
+    "tenantClubs": [
+      "s-c-braga"
+    ]
+  },
+  {
+    "id": "estadio-manuel-murillo-toro",
+    "name": "Estadio Manuel Murillo Toro",
+    "city": "Ibagué",
+    "countryCode": "COL",
+    "capacity": 30279,
+    "tenantClubs": [
+      "atletico-huila",
+      "deportes-tolima"
+    ]
+  },
+  {
+    "id": "jamsil-baseball-stadium",
+    "name": "Jamsil Baseball Stadium",
+    "city": "Jamsil-dong",
+    "countryCode": "KOR",
+    "capacity": 30265,
+    "tenantClubs": [
+      "doosan-bears",
+      "lg-twins"
+    ]
+  },
+  {
+    "id": "eva-peron-la-ciudadela",
+    "name": "Eva Peron \"La Ciudadela\"",
+    "city": "San Miguel de Tucumán",
+    "countryCode": "ARG",
+    "capacity": 30250,
+    "tenantClubs": []
+  },
+  {
+    "id": "bayarena",
+    "name": "BayArena",
+    "city": null,
+    "countryCode": "DEU",
+    "capacity": 30210,
+    "tenantClubs": [
+      "bayer-04-leverkusen"
+    ]
+  },
+  {
+    "id": "waldo-stadium",
+    "name": "Waldo Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 30200,
+    "tenantClubs": [
+      "western-michigan-broncos",
+      "western-michigan-broncos-football"
+    ]
+  },
+  {
+    "id": "estadio-ester-roa-rebolledo",
+    "name": "Estadio Ester Roa Rebolledo",
+    "city": "Concepción",
+    "countryCode": "CHL",
+    "capacity": 30200,
+    "tenantClubs": [
+      "c-d-universidad-de-concepcion"
+    ]
+  },
+  {
+    "id": "estadio-centenario-ciudad-de-quilmes",
+    "name": "Estadio Centenario Ciudad de Quilmes",
+    "city": "Quilmes",
+    "countryCode": "ARG",
+    "capacity": 30200,
+    "tenantClubs": [
+      "quilmes-atletico-club"
+    ]
+  },
+  {
+    "id": "rynearson-stadium",
+    "name": "Rynearson Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 30200,
+    "tenantClubs": [
+      "eastern-michigan-eagles-football"
+    ]
+  },
+  {
+    "id": "jiangyin-sports-centre",
+    "name": "Jiangyin Sports Centre",
+    "city": "Jiangyin",
+    "countryCode": "CHN",
+    "capacity": 30161,
+    "tenantClubs": []
+  },
+  {
+    "id": "prezero-arena",
+    "name": "PreZero-Arena",
+    "city": null,
+    "countryCode": "DEU",
+    "capacity": 30150,
+    "tenantClubs": [
+      "tsg-1899-hoffenheim"
+    ]
+  },
+  {
+    "id": "takhti-stadium-tehran",
+    "name": "Takhti Stadium (Tehran)",
+    "city": null,
+    "countryCode": "IRN",
+    "capacity": 30122,
+    "tenantClubs": [
+      "iran-national-under-20-football-team"
+    ]
+  },
+  {
+    "id": "asim-ferhatovic-hase-stadium",
+    "name": "Asim Ferhatović Hase Stadium",
+    "city": null,
+    "countryCode": "BIH",
+    "capacity": 30121,
+    "tenantClubs": [
+      "f-k-sarajevo"
+    ]
+  },
+  {
+    "id": "kagawa-marugame-stadium",
+    "name": "Kagawa Marugame Stadium",
+    "city": "Marugame",
+    "countryCode": "JPN",
+    "capacity": 30099,
+    "tenantClubs": [
+      "kamatamare-sanuki"
+    ]
+  },
+  {
+    "id": "avnet-arena",
+    "name": "Avnet Arena",
+    "city": null,
+    "countryCode": "DEU",
+    "capacity": 30098,
+    "tenantClubs": [
+      "1-fc-magdeburg"
+    ]
+  },
+  {
+    "id": "stade-de-geneve",
+    "name": "Stade de Genève",
+    "city": null,
+    "countryCode": "CHE",
+    "capacity": 30084,
+    "tenantClubs": [
+      "servette-fc"
+    ]
+  },
+  {
+    "id": "melbourne-rectangular-stadium",
+    "name": "Melbourne Rectangular Stadium",
+    "city": "Olympic Park",
+    "countryCode": "AUS",
+    "capacity": 30050,
+    "tenantClubs": [
+      "melbourne-city-fc",
+      "melbourne-rebels",
+      "melbourne-storm",
+      "melbourne-victory-fc",
+      "western-united-fc"
+    ]
+  },
+  {
+    "id": "la-rosaleda-stadium",
+    "name": "La Rosaleda Stadium",
+    "city": "Málaga",
+    "countryCode": "ESP",
+    "capacity": 30044,
+    "tenantClubs": [
+      "malaga-cf",
+      "malaga-cf-femenino"
+    ]
+  },
+  {
+    "id": "estadio-d-afonso-henriques",
+    "name": "Estádio D. Afonso Henriques",
+    "city": "Guimarães",
+    "countryCode": "PRT",
+    "capacity": 30029,
+    "tenantClubs": [
+      "vitoria-s-c",
+      "vitoria-s-c-b"
+    ]
+  },
+  {
+    "id": "stade-maurice-dufrasne",
+    "name": "Stade Maurice Dufrasne",
+    "city": null,
+    "countryCode": "BEL",
+    "capacity": 30023,
+    "tenantClubs": [
+      "standard-liege"
+    ]
+  },
+  {
+    "id": "estadio-jorge-luis-hirschi",
+    "name": "Estadio Jorge Luis Hirschi",
+    "city": "La Plata",
+    "countryCode": "ARG",
+    "capacity": 30018,
+    "tenantClubs": [
+      "estudiantes-de-la-plata",
+      "estudiantes-de-la-plata-women"
+    ]
+  },
+  {
+    "id": "st-andrew-s",
+    "name": "St Andrew's",
+    "city": "Bordesley",
+    "countryCode": "GBR",
+    "capacity": 30016,
+    "tenantClubs": [
+      "birmingham-city-f-c",
+      "birmingham-city-w-f-c"
+    ]
+  },
+  {
+    "id": "estadio-tres-de-marzo",
+    "name": "Estadio Tres de Marzo",
+    "city": null,
+    "countryCode": "MEX",
+    "capacity": 30015,
+    "tenantClubs": [
+      "tecos-f-c"
+    ]
+  },
+  {
+    "id": "3arena",
+    "name": "3Arena",
+    "city": "Johanneshov",
+    "countryCode": "SWE",
+    "capacity": 30001,
+    "tenantClubs": [
+      "djurgardens-if-fotboll",
+      "hammarby-fotboll"
+    ]
+  },
+  {
+    "id": "q2326073",
+    "name": "Q2326073",
+    "city": null,
+    "countryCode": "DEU",
+    "capacity": 30000,
+    "tenantClubs": [
+      "1-fc-recklinghausen",
+      "1-ffc-recklinghausen"
+    ]
+  },
+  {
+    "id": "honsellstra-e-stadium",
+    "name": "Honsellstraße stadium",
+    "city": null,
+    "countryCode": "DEU",
+    "capacity": 30000,
+    "tenantClubs": [
+      "karlsruher-sc"
+    ]
+  },
+  {
+    "id": "lal-bahadur-shastri-stadium",
+    "name": "Lal Bahadur Shastri Stadium",
+    "city": "Hyderabad",
+    "countryCode": "IND",
+    "capacity": 30000,
+    "tenantClubs": []
+  },
+  {
+    "id": "indomilk-arena",
+    "name": "Indomilk Arena",
+    "city": null,
+    "countryCode": "IDN",
+    "capacity": 30000,
+    "tenantClubs": []
+  },
+  {
+    "id": "billtalstadion",
+    "name": "Billtalstadion",
+    "city": "Bergedorf",
+    "countryCode": "DEU",
+    "capacity": 30000,
+    "tenantClubs": []
+  },
+  {
+    "id": "althawra-sports-city-stadium",
+    "name": "Althawra Sports City Stadium",
+    "city": null,
+    "countryCode": "YEM",
+    "capacity": 30000,
+    "tenantClubs": [
+      "al-ahli-club-sana-a",
+      "yemen-men-s-national-football-team"
+    ]
+  },
+  {
+    "id": "hanazono-rugby-stadium",
+    "name": "Hanazono Rugby Stadium",
+    "city": "Higashiōsaka-shi",
+    "countryCode": "JPN",
+    "capacity": 30000,
+    "tenantClubs": [
+      "fc-osaka",
+      "hanazono-kintetsu-liners"
+    ]
+  },
+  {
+    "id": "nyayo-national-stadium",
+    "name": "Nyayo National Stadium",
+    "city": null,
+    "countryCode": "KEN",
+    "capacity": 30000,
+    "tenantClubs": [
+      "a-f-c-leopards"
+    ]
+  },
+  {
+    "id": "yanggakdo-stadium",
+    "name": "Yanggakdo Stadium",
+    "city": "Pyongyang",
+    "countryCode": "PRK",
+    "capacity": 30000,
+    "tenantClubs": [
+      "north-korea-men-s-national-football-team"
+    ]
+  },
+  {
+    "id": "paljor-stadium",
+    "name": "Paljor Stadium",
+    "city": "Gangtok",
+    "countryCode": "IND",
+    "capacity": 30000,
+    "tenantClubs": [
+      "united-sikkim-f-c"
+    ]
+  },
+  {
+    "id": "stade-de-la-reunification",
+    "name": "Stade de la Réunification",
+    "city": null,
+    "countryCode": "CMR",
+    "capacity": 30000,
+    "tenantClubs": [
+      "union-douala"
+    ]
+  },
+  {
+    "id": "yulman-stadium",
+    "name": "Yulman Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 30000,
+    "tenantClubs": [
+      "tulane-green-wave",
+      "tulane-green-wave-football"
+    ]
+  },
+  {
+    "id": "tottori-athletics-stadium",
+    "name": "Tottori Athletics Stadium",
+    "city": "Tottori",
+    "countryCode": "JPN",
+    "capacity": 30000,
+    "tenantClubs": []
+  },
+  {
+    "id": "volkswagen-arena",
+    "name": "Volkswagen Arena",
+    "city": null,
+    "countryCode": "DEU",
+    "capacity": 30000,
+    "tenantClubs": [
+      "vfl-wolfsburg"
+    ]
+  },
+  {
+    "id": "gifu-prefectural-baseball-stadium",
+    "name": "Gifu Prefectural Baseball Stadium",
+    "city": null,
+    "countryCode": "JPN",
+    "capacity": 30000,
+    "tenantClubs": []
+  },
+  {
+    "id": "kidd-brewer-stadium",
+    "name": "Kidd Brewer Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 30000,
+    "tenantClubs": [
+      "appalachian-state-mountaineers",
+      "appalachian-state-mountaineers-football"
+    ]
+  },
+  {
+    "id": "colonel-lotfi-stadium",
+    "name": "Colonel Lotfi Stadium",
+    "city": null,
+    "countryCode": "DZA",
+    "capacity": 30000,
+    "tenantClubs": [
+      "wa-tlemcen"
+    ]
+  },
+  {
+    "id": "30-june-stadium",
+    "name": "30 June Stadium",
+    "city": "Cairo",
+    "countryCode": "EGY",
+    "capacity": 30000,
+    "tenantClubs": []
+  },
+  {
+    "id": "al-salam-stadium",
+    "name": "Al Salam Stadium",
+    "city": null,
+    "countryCode": "EGY",
+    "capacity": 30000,
+    "tenantClubs": [
+      "al-ahly-sc",
+      "el-entag-el-harby"
+    ]
+  },
+  {
+    "id": "western-sydney-stadium",
+    "name": "Western Sydney Stadium",
+    "city": "Parramatta",
+    "countryCode": "AUS",
+    "capacity": 30000,
+    "tenantClubs": [
+      "parramatta-eels",
+      "parramatta-eels-women-s-rugby-league",
+      "western-sydney-wanderers-fc"
+    ]
+  },
+  {
+    "id": "konoike-athletic-stadium",
+    "name": "Kōnoike Athletic Stadium",
+    "city": null,
+    "countryCode": "JPN",
+    "capacity": 30000,
+    "tenantClubs": [
+      "nara-club"
+    ]
+  },
+  {
+    "id": "bakhshi-stadium",
+    "name": "Bakhshi Stadium",
+    "city": "Srinagar",
+    "countryCode": "IND",
+    "capacity": 30000,
+    "tenantClubs": []
+  },
+  {
+    "id": "niigata-prefectural-baseball-stadium",
+    "name": "Niigata Prefectural Baseball Stadium",
+    "city": "Niigata",
+    "countryCode": "JPN",
+    "capacity": 30000,
+    "tenantClubs": [
+      "oisix-niigata-albirex-baseball-club"
+    ]
+  },
+  {
+    "id": "sheikh-mohamed-laghdaf-stadium",
+    "name": "Sheikh Mohamed Laghdaf Stadium",
+    "city": null,
+    "countryCode": "MAR",
+    "capacity": 30000,
+    "tenantClubs": [
+      "js-massira"
+    ]
+  },
+  {
+    "id": "malappuram-district-sports-complex-stadium",
+    "name": "Malappuram District Sports Complex Stadium",
+    "city": "Payyanad",
+    "countryCode": "IND",
+    "capacity": 30000,
+    "tenantClubs": []
+  },
+  {
+    "id": "haihe-educational-football-stadium",
+    "name": "Haihe Educational Football Stadium",
+    "city": null,
+    "countryCode": "CHN",
+    "capacity": 30000,
+    "tenantClubs": []
+  },
+  {
+    "id": "liaocheng-sports-park-stadium",
+    "name": "Liaocheng Sports Park Stadium",
+    "city": null,
+    "countryCode": "CHN",
+    "capacity": 30000,
+    "tenantClubs": []
+  },
+  {
+    "id": "tan-sri-dato-haji-hassan-yunos-stadium",
+    "name": "Tan Sri Dato Haji Hassan Yunos Stadium",
+    "city": null,
+    "countryCode": "MYS",
+    "capacity": 30000,
+    "tenantClubs": [
+      "johor-darul-takzim-f-c"
+    ]
+  },
+  {
+    "id": "estadio-nacional-mexico",
+    "name": "Estadio Nacional (Mexico)",
+    "city": "Colonia Roma",
+    "countryCode": "MEX",
+    "capacity": 30000,
+    "tenantClubs": [
+      "1926-central-american-and-caribbean-games"
+    ]
+  },
+  {
+    "id": "estadio-agustin-tovar",
+    "name": "Estadio Agustín Tovar",
+    "city": "Barinas",
+    "countryCode": "VEN",
+    "capacity": 30000,
+    "tenantClubs": [
+      "internacional-de-barinas-fc",
+      "zamora-f-c"
+    ]
+  },
+  {
+    "id": "abebe-bikila-stadium",
+    "name": "Abebe Bikila Stadium",
+    "city": null,
+    "countryCode": "ETH",
+    "capacity": 30000,
+    "tenantClubs": [
+      "dedebit"
+    ]
+  },
+  {
+    "id": "lal-bahadur-shastri-stadium-kollam",
+    "name": "Lal Bahadur Shastri Stadium (Kollam)",
+    "city": "Kollam Cantonment",
+    "countryCode": "IND",
+    "capacity": 30000,
+    "tenantClubs": []
+  },
+  {
+    "id": "sailen-manna-stadium",
+    "name": "Sailen Manna Stadium",
+    "city": "Howrah",
+    "countryCode": "IND",
+    "capacity": 30000,
+    "tenantClubs": []
+  },
+  {
+    "id": "kiyohara-baseball-stadium",
+    "name": "Kiyohara Baseball Stadium",
+    "city": null,
+    "countryCode": "JPN",
+    "capacity": 30000,
+    "tenantClubs": []
+  },
+  {
+    "id": "chaohu-stadium",
+    "name": "Chaohu Stadium",
+    "city": "Chaohu",
+    "countryCode": "CHN",
+    "capacity": 30000,
+    "tenantClubs": []
+  },
+  {
+    "id": "q16605719",
+    "name": "Q16605719",
+    "city": null,
+    "countryCode": "POL",
+    "capacity": 30000,
+    "tenantClubs": []
+  },
+  {
+    "id": "q86666021",
+    "name": "Q86666021",
+    "city": null,
+    "countryCode": "YUG",
+    "capacity": 30000,
+    "tenantClubs": []
+  },
+  {
+    "id": "changzhi-stadium",
+    "name": "Changzhi Stadium",
+    "city": null,
+    "countryCode": "CHN",
+    "capacity": 30000,
+    "tenantClubs": []
+  },
+  {
+    "id": "changshu-stadium",
+    "name": "Changshu Stadium",
+    "city": null,
+    "countryCode": "CHN",
+    "capacity": 30000,
+    "tenantClubs": []
+  },
+  {
+    "id": "cangzhou-stadium",
+    "name": "Cangzhou Stadium",
+    "city": null,
+    "countryCode": "CHN",
+    "capacity": 30000,
+    "tenantClubs": []
+  },
+  {
+    "id": "yashwant-stadium",
+    "name": "Yashwant Stadium",
+    "city": null,
+    "countryCode": "IND",
+    "capacity": 30000,
+    "tenantClubs": []
+  },
+  {
+    "id": "estadio-daniel-villa-zapata",
+    "name": "Estadio Daniel Villa Zapata",
+    "city": "Barrancabermeja",
+    "countryCode": "COL",
+    "capacity": 30000,
+    "tenantClubs": [
+      "alianza-petrolera-f-c"
+    ]
+  },
+  {
+    "id": "wunna-theikdi-stadium",
+    "name": "Wunna Theikdi Stadium",
+    "city": null,
+    "countryCode": "MMR",
+    "capacity": 30000,
+    "tenantClubs": []
+  },
+  {
+    "id": "new-varna-stadium",
+    "name": "New Varna Stadium",
+    "city": null,
+    "countryCode": "BGR",
+    "capacity": 30000,
+    "tenantClubs": [
+      "pfc-cherno-more-varna"
+    ]
+  },
+  {
+    "id": "rajarshi-shahu-stadium",
+    "name": "Rajarshi Shahu Stadium",
+    "city": null,
+    "countryCode": "IND",
+    "capacity": 30000,
+    "tenantClubs": [
+      "mumbai-f-c"
+    ]
+  },
+  {
+    "id": "jawaharlal-nehru-stadium-shillong",
+    "name": "Jawaharlal Nehru Stadium, Shillong",
+    "city": "Shillong",
+    "countryCode": "IND",
+    "capacity": 30000,
+    "tenantClubs": [
+      "shillong-lajong-f-c"
+    ]
+  },
+  {
+    "id": "mandala-stadium",
+    "name": "Mandala Stadium",
+    "city": null,
+    "countryCode": "IDN",
+    "capacity": 30000,
+    "tenantClubs": [
+      "persipura-jayapura"
+    ]
+  },
+  {
+    "id": "rand-stadium",
+    "name": "Rand Stadium",
+    "city": "Rosettenville",
+    "countryCode": "ZAF",
+    "capacity": 30000,
+    "tenantClubs": [
+      "kaizer-chiefs-f-c"
+    ]
+  },
+  {
+    "id": "hakatanomori-athletic-stadium",
+    "name": "Hakatanomori Athletic Stadium",
+    "city": null,
+    "countryCode": "JPN",
+    "capacity": 30000,
+    "tenantClubs": [
+      "1995-summer-universiade"
+    ]
+  },
+  {
+    "id": "estadio-15-de-abril",
+    "name": "Estadio 15 de Abril",
+    "city": null,
+    "countryCode": "ARG",
+    "capacity": 30000,
+    "tenantClubs": [
+      "union-de-santa-fe"
+    ]
+  },
+  {
+    "id": "botchan-stadium",
+    "name": "Botchan Stadium",
+    "city": "Matsuyama",
+    "countryCode": "JPN",
+    "capacity": 30000,
+    "tenantClubs": [
+      "japanese-high-school-baseball-championship"
+    ]
+  },
+  {
+    "id": "abbasiyyin-stadium",
+    "name": "Abbasiyyin Stadium",
+    "city": null,
+    "countryCode": "SYR",
+    "capacity": 30000,
+    "tenantClubs": [
+      "al-shorta-sc",
+      "al-wahda-sc-damascus",
+      "al-wathbaa",
+      "damascus-al-ahli-club",
+      "syria-men-s-national-association-football-team"
+    ]
+  },
+  {
+    "id": "mount-smart-stadium",
+    "name": "Mount Smart Stadium",
+    "city": null,
+    "countryCode": "NZL",
+    "capacity": 30000,
+    "tenantClubs": [
+      "moana-pasifika",
+      "new-zealand-warriors"
+    ]
+  },
+  {
+    "id": "zozo-marine-stadium",
+    "name": "ZOZO Marine Stadium",
+    "city": "Makuhari Seaside Park",
+    "countryCode": "JPN",
+    "capacity": 30000,
+    "tenantClubs": [
+      "chiba-lotte-marines",
+      "pacific-league"
+    ]
+  },
+  {
+    "id": "saga-sunrise-park-athletic-stadium",
+    "name": "SAGA Sunrise Park Athletic Stadium",
+    "city": null,
+    "countryCode": "JPN",
+    "capacity": 30000,
+    "tenantClubs": []
+  },
+  {
+    "id": "rongcheng-stadium",
+    "name": "Rongcheng Stadium",
+    "city": null,
+    "countryCode": "CHN",
+    "capacity": 30000,
+    "tenantClubs": []
+  },
+  {
+    "id": "stadio-filadelfia",
+    "name": "Stadio Filadelfia",
+    "city": null,
+    "countryCode": "ITA",
+    "capacity": 30000,
+    "tenantClubs": [
+      "torino-fc"
+    ]
+  },
+  {
+    "id": "guru-nanak-stadium",
+    "name": "Guru Nanak Stadium",
+    "city": "Ludhiana",
+    "countryCode": "IND",
+    "capacity": 30000,
+    "tenantClubs": [
+      "national-games-of-india",
+      "punjab-fc"
+    ]
+  },
+  {
+    "id": "guangxi-zhuang-autonomous-region-stadium",
+    "name": "Guangxi Zhuang Autonomous Region Stadium",
+    "city": null,
+    "countryCode": "CHN",
+    "capacity": 30000,
+    "tenantClubs": []
+  },
+  {
+    "id": "stade-de-kegue",
+    "name": "Stade de Kégué",
+    "city": "Lomé",
+    "countryCode": "TGO",
+    "capacity": 30000,
+    "tenantClubs": [
+      "togo-men-s-national-football-team"
+    ]
+  },
+  {
+    "id": "estadio-pedro-marrero",
+    "name": "Estadio Pedro Marrero",
+    "city": null,
+    "countryCode": "CUB",
+    "capacity": 30000,
+    "tenantClubs": [
+      "ciudad-de-la-habana"
+    ]
+  },
+  {
+    "id": "estadio-luis-pirata-fuente",
+    "name": "Estadio Luis \"Pirata\" Fuente",
+    "city": "Boca del Río",
+    "countryCode": "MEX",
+    "capacity": 30000,
+    "tenantClubs": [
+      "tiburones-rojos-de-veracruz"
+    ]
+  },
+  {
+    "id": "estadio-olimpico-colosso-da-lagoa",
+    "name": "Estádio Olímpico Colosso da Lagoa",
+    "city": null,
+    "countryCode": "BRA",
+    "capacity": 30000,
+    "tenantClubs": [
+      "ypiranga-futebol-clube"
+    ]
+  },
+  {
+    "id": "incheon-asiad-main-stadium",
+    "name": "Incheon Asiad Main Stadium",
+    "city": null,
+    "countryCode": "KOR",
+    "capacity": 30000,
+    "tenantClubs": [
+      "2014-asian-games"
+    ]
+  },
+  {
+    "id": "bobcat-stadium",
+    "name": "Bobcat Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 30000,
+    "tenantClubs": [
+      "texas-state-bobcats",
+      "texas-state-bobcats-football"
+    ]
+  },
+  {
+    "id": "lacerdao",
+    "name": "Lacerdão",
+    "city": null,
+    "countryCode": "BRA",
+    "capacity": 30000,
+    "tenantClubs": [
+      "central-sport-club"
+    ]
+  },
+  {
+    "id": "estadio-doroteo-guamuch-flores",
+    "name": "Estadio Doroteo Guamuch Flores",
+    "city": null,
+    "countryCode": "GTM",
+    "capacity": 30000,
+    "tenantClubs": [
+      "guatemala-men-s-national-football-team"
+    ]
+  },
+  {
+    "id": "new-beaver-field",
+    "name": "New Beaver Field",
+    "city": "Penn State University Park",
+    "countryCode": "USA",
+    "capacity": 30000,
+    "tenantClubs": [
+      "penn-state-nittany-lions-baseball",
+      "penn-state-nittany-lions-football",
+      "penn-state-nittany-lions-men-s-lacrosse",
+      "penn-state-nittany-lions-men-s-soccer"
+    ]
+  },
+  {
+    "id": "kawasaki-stadium",
+    "name": "Kawasaki Stadium",
+    "city": "Kawasaki",
+    "countryCode": "JPN",
+    "capacity": 30000,
+    "tenantClubs": [
+      "chiba-lotte-marines",
+      "takahashi-unions",
+      "yokohama-dena-baystars"
+    ]
+  },
+  {
+    "id": "kunshan-stadium",
+    "name": "Kunshan Stadium",
+    "city": null,
+    "countryCode": "CHN",
+    "capacity": 30000,
+    "tenantClubs": []
+  },
+  {
+    "id": "khuman-lampak-main-stadium",
+    "name": "Khuman Lampak Main Stadium",
+    "city": "Imphal",
+    "countryCode": "IND",
+    "capacity": 30000,
+    "tenantClubs": [
+      "shillong-lajong-f-c"
+    ]
+  },
+  {
+    "id": "fukushima-azuma-baseball-stadium",
+    "name": "Fukushima Azuma Baseball Stadium",
+    "city": "Fukushima Prefectural Azuma Sports Park",
+    "countryCode": "JPN",
+    "capacity": 30000,
+    "tenantClubs": [
+      "2020-summer-olympics"
+    ]
+  },
+  {
+    "id": "faridpur-stadium",
+    "name": "Faridpur Stadium",
+    "city": "Faridpur Sadar Upazila",
+    "countryCode": "BGD",
+    "capacity": 30000,
+    "tenantClubs": []
+  },
+  {
+    "id": "empire-stadium-gzira",
+    "name": "Empire Stadium, Gżira",
+    "city": "Gżira",
+    "countryCode": "MLT",
+    "capacity": 30000,
+    "tenantClubs": [
+      "hibernians-f-c"
+    ]
+  },
+  {
+    "id": "hengyang-stadium",
+    "name": "Hengyang Stadium",
+    "city": null,
+    "countryCode": "CHN",
+    "capacity": 30000,
+    "tenantClubs": []
+  },
+  {
+    "id": "ghazi-stadium",
+    "name": "Ghazi Stadium",
+    "city": null,
+    "countryCode": "AFG",
+    "capacity": 30000,
+    "tenantClubs": [
+      "afghanistan-men-s-national-football-team"
+    ]
+  },
+  {
+    "id": "william-dick-price-stadium",
+    "name": "William \"Dick\" Price Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 30000,
+    "tenantClubs": [
+      "norfolk-state-spartans-football"
+    ]
+  },
+  {
+    "id": "kamoike-ballpark",
+    "name": "Kamoike Ballpark",
+    "city": "Kagoshima",
+    "countryCode": "JPN",
+    "capacity": 30000,
+    "tenantClubs": []
+  },
+  {
+    "id": "estadio-heroe-de-nacozari",
+    "name": "Estadio Héroe de Nacozari",
+    "city": null,
+    "countryCode": "MEX",
+    "capacity": 30000,
+    "tenantClubs": [
+      "cimarrones-de-sonora-fc"
+    ]
+  },
+  {
+    "id": "astana-arena",
+    "name": "Astana Arena",
+    "city": "Astana",
+    "countryCode": "KAZ",
+    "capacity": 30000,
+    "tenantClubs": [
+      "fc-astana",
+      "fc-bayterek",
+      "kazakhstan-men-s-national-football-team"
+    ]
+  },
+  {
+    "id": "sector-42-stadium",
+    "name": "Sector 42 Stadium",
+    "city": "Chandigarh",
+    "countryCode": "IND",
+    "capacity": 30000,
+    "tenantClubs": [
+      "world-series-hockey"
+    ]
+  },
+  {
+    "id": "gelora-10-november-stadium",
+    "name": "Gelora 10 November Stadium",
+    "city": "Tambaksari",
+    "countryCode": "IDN",
+    "capacity": 30000,
+    "tenantClubs": [
+      "persebaya-surabaya"
+    ]
+  },
+  {
+    "id": "salah-al-din-stadium",
+    "name": "Salah Al Din Stadium",
+    "city": null,
+    "countryCode": "IRQ",
+    "capacity": 30000,
+    "tenantClubs": []
+  },
+  {
+    "id": "de-grolsch-veste",
+    "name": "De Grolsch Veste",
+    "city": null,
+    "countryCode": null,
+    "capacity": 30000,
+    "tenantClubs": [
+      "fc-twente"
+    ]
+  },
+  {
+    "id": "khartoum-stadium",
+    "name": "Khartoum Stadium",
+    "city": null,
+    "countryCode": "SDN",
+    "capacity": 30000,
+    "tenantClubs": [
+      "khartoum-nc"
+    ]
+  },
+  {
+    "id": "friedrich-ludwig-jahn-stadium-herford",
+    "name": "Friedrich-Ludwig-Jahn-Stadium (Herford)",
+    "city": null,
+    "countryCode": "DEU",
+    "capacity": 30000,
+    "tenantClubs": [
+      "herforder-sv-borussia-friedenstal"
+    ]
+  },
+  {
+    "id": "punjab-stadium",
+    "name": "Punjab Stadium",
+    "city": null,
+    "countryCode": "PAK",
+    "capacity": 30000,
+    "tenantClubs": [
+      "wapda-f-c"
+    ]
+  },
+  {
+    "id": "jawahar-municipal-stadium",
+    "name": "Jawahar Municipal Stadium",
+    "city": "Kannur",
+    "countryCode": "IND",
+    "capacity": 30000,
+    "tenantClubs": []
+  },
+  {
+    "id": "stade-ahmed-kaid",
+    "name": "Stade Ahmed Kaïd",
+    "city": null,
+    "countryCode": "DZA",
+    "capacity": 30000,
+    "tenantClubs": [
+      "jsm-tiaret"
+    ]
+  },
+  {
+    "id": "jeonju-sports-complex",
+    "name": "Jeonju Sports Complex",
+    "city": null,
+    "countryCode": "KOR",
+    "capacity": 30000,
+    "tenantClubs": []
+  },
+  {
+    "id": "1-november-1954-stadium",
+    "name": "1 November 1954 Stadium",
+    "city": null,
+    "countryCode": "DZA",
+    "capacity": 30000,
+    "tenantClubs": [
+      "js-kabylie"
+    ]
+  },
+  {
+    "id": "mianyang-stadium",
+    "name": "Mianyang Stadium",
+    "city": null,
+    "countryCode": "CHN",
+    "capacity": 30000,
+    "tenantClubs": []
+  },
+  {
+    "id": "yuvileiny-stadium",
+    "name": "Yuvileiny Stadium",
+    "city": null,
+    "countryCode": "UKR",
+    "capacity": 30000,
+    "tenantClubs": [
+      "fc-spartak-sumy"
+    ]
+  },
+  {
+    "id": "stade-de-l-unite-africaine",
+    "name": "Stade de l'Unité Africaine",
+    "city": null,
+    "countryCode": "DZA",
+    "capacity": 30000,
+    "tenantClubs": [
+      "ghali-chabab-mascara"
+    ]
+  },
+  {
+    "id": "fujian-provincial-sports-centre-stadium",
+    "name": "Fujian Provincial Sports Centre Stadium",
+    "city": null,
+    "countryCode": "CHN",
+    "capacity": 30000,
+    "tenantClubs": []
+  },
+  {
+    "id": "independence-stadium-zmb",
+    "name": "Independence Stadium",
+    "city": null,
+    "countryCode": "ZMB",
+    "capacity": 30000,
+    "tenantClubs": [
+      "zambia-men-s-national-football-team"
+    ]
+  },
+  {
+    "id": "estadio-unico-madre-de-ciudades",
+    "name": "Estadio Único Madre de Ciudades",
+    "city": "Santiago del Estero",
+    "countryCode": "ARG",
+    "capacity": 30000,
+    "tenantClubs": [
+      "central-cordoba-de-santiago-del-estero",
+      "club-atletico-guemes",
+      "club-atletico-mitre"
+    ]
+  },
+  {
+    "id": "yiyang-stadium",
+    "name": "Yiyang Stadium",
+    "city": "Yiyang",
+    "countryCode": "CHN",
+    "capacity": 30000,
+    "tenantClubs": []
+  },
+  {
+    "id": "corona-stadium",
+    "name": "Corona Stadium",
+    "city": "Torreón",
+    "countryCode": "MEX",
+    "capacity": 30000,
+    "tenantClubs": [
+      "santos-laguna"
+    ]
+  },
+  {
+    "id": "shahid-shiroudi-stadium",
+    "name": "Shahid Shiroudi Stadium",
+    "city": null,
+    "countryCode": "IRN",
+    "capacity": 30000,
+    "tenantClubs": [
+      "iran-men-s-national-football-team"
+    ]
+  },
+  {
+    "id": "ulanqab-stadium",
+    "name": "Ulanqab Stadium",
+    "city": "Ulanqab",
+    "countryCode": "CHN",
+    "capacity": 30000,
+    "tenantClubs": []
+  },
+  {
+    "id": "sarusajai-stadium-guwahati",
+    "name": "Sarusajai Stadium (Guwahati)",
+    "city": null,
+    "countryCode": "IND",
+    "capacity": 30000,
+    "tenantClubs": [
+      "guwahati-town-club"
+    ]
+  },
+  {
+    "id": "brookland-stadium",
+    "name": "Brookland Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 30000,
+    "tenantClubs": [
+      "catholic-university-cardinals",
+      "washington-darts"
+    ]
+  },
+  {
+    "id": "jinshan-sports-centre",
+    "name": "Jinshan Sports Centre",
+    "city": null,
+    "countryCode": "CHN",
+    "capacity": 30000,
+    "tenantClubs": [
+      "shanghai-shenxin-f-c"
+    ]
+  },
+  {
+    "id": "zhengzhou-hanghai-stadium",
+    "name": "Zhengzhou Hanghai Stadium",
+    "city": null,
+    "countryCode": "CHN",
+    "capacity": 30000,
+    "tenantClubs": [
+      "henan-f-c"
+    ]
+  },
+  {
+    "id": "ahmadu-bello-stadium",
+    "name": "Ahmadu Bello Stadium",
+    "city": null,
+    "countryCode": "NGA",
+    "capacity": 30000,
+    "tenantClubs": []
+  },
+  {
+    "id": "anji-arena",
+    "name": "Anji Arena",
+    "city": "Kaspiysk",
+    "countryCode": "RUS",
+    "capacity": 30000,
+    "tenantClubs": [
+      "fc-anzhi-makhachkala",
+      "fc-dynamo-makhachkala",
+      "fc-makhachkala"
+    ]
+  },
+  {
+    "id": "rizal-memorial-stadium",
+    "name": "Rizal Memorial Stadium",
+    "city": null,
+    "countryCode": "PHL",
+    "capacity": 30000,
+    "tenantClubs": [
+      "philippines-men-s-national-association-football-team"
+    ]
+  },
+  {
+    "id": "yangsan-stadium",
+    "name": "Yangsan Stadium",
+    "city": null,
+    "countryCode": "KOR",
+    "capacity": 30000,
+    "tenantClubs": []
+  },
+  {
+    "id": "taoyuan-city-stadium",
+    "name": "Taoyuan City Stadium",
+    "city": null,
+    "countryCode": "TWN",
+    "capacity": 30000,
+    "tenantClubs": []
+  },
+  {
+    "id": "takhti-stadium",
+    "name": "Takhti Stadium",
+    "city": null,
+    "countryCode": "IRN",
+    "capacity": 30000,
+    "tenantClubs": [
+      "foolad-f-c"
+    ]
+  },
+  {
+    "id": "mackay-stadium",
+    "name": "Mackay Stadium",
+    "city": "Reno",
+    "countryCode": "USA",
+    "capacity": 30000,
+    "tenantClubs": [
+      "nevada-wolf-pack",
+      "nevada-wolf-pack-football"
+    ]
+  },
+  {
+    "id": "olympic-stadium-tkm",
+    "name": "Olympic Stadium",
+    "city": null,
+    "countryCode": "TKM",
+    "capacity": 30000,
+    "tenantClubs": [
+      "turkmenistan-men-s-national-football-team"
+    ]
+  },
+  {
+    "id": "tainan-county-stadium",
+    "name": "Tainan County Stadium",
+    "city": null,
+    "countryCode": "TWN",
+    "capacity": 30000,
+    "tenantClubs": []
+  },
+  {
+    "id": "dazhou-xiwai-stadium",
+    "name": "Dazhou Xiwai Stadium",
+    "city": null,
+    "countryCode": "CHN",
+    "capacity": 30000,
+    "tenantClubs": []
+  },
+  {
+    "id": "estadio-fredis-saldivar",
+    "name": "Estádio Fredis Saldívar",
+    "city": "Dourados",
+    "countryCode": "BRA",
+    "capacity": 30000,
+    "tenantClubs": [
+      "clube-desportivo-sete-de-setembro"
+    ]
+  },
+  {
+    "id": "iowa-field",
+    "name": "Iowa Field",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 30000,
+    "tenantClubs": [
+      "iowa-hawkeyes-football"
+    ]
+  },
+  {
+    "id": "hassanal-bolkiah-national-stadium",
+    "name": "Hassanal Bolkiah National Stadium",
+    "city": null,
+    "countryCode": "BRN",
+    "capacity": 30000,
+    "tenantClubs": [
+      "brunei-men-s-national-football-team"
+    ]
+  },
+  {
+    "id": "al-mina-a-stadium",
+    "name": "Al Mina'a Stadium",
+    "city": null,
+    "countryCode": "IRQ",
+    "capacity": 30000,
+    "tenantClubs": [
+      "al-mina-a-sc"
+    ]
+  },
+  {
+    "id": "iwate-athletic-stadium",
+    "name": "Iwate Athletic Stadium",
+    "city": "Morioka",
+    "countryCode": "JPN",
+    "capacity": 30000,
+    "tenantClubs": []
+  },
+  {
+    "id": "tengzhou-olympic-center-stadium",
+    "name": "Tengzhou Olympic Center Stadium",
+    "city": null,
+    "countryCode": "CHN",
+    "capacity": 30000,
+    "tenantClubs": []
+  },
+  {
+    "id": "may-22-stadium",
+    "name": "May 22 Stadium",
+    "city": null,
+    "countryCode": "YEM",
+    "capacity": 30000,
+    "tenantClubs": []
+  },
+  {
+    "id": "stade-of-1st-november-1954",
+    "name": "Stade of 1st November 1954",
+    "city": null,
+    "countryCode": "DZA",
+    "capacity": 30000,
+    "tenantClubs": [
+      "ca-batna"
+    ]
+  },
+  {
+    "id": "maharaja-college-stadium",
+    "name": "Maharaja College Stadium",
+    "city": "Kochi",
+    "countryCode": "IND",
+    "capacity": 30000,
+    "tenantClubs": [
+      "maharaja-s-college"
+    ]
+  },
+  {
+    "id": "du-stadium",
+    "name": "DU Stadium",
+    "city": "University of Denver",
+    "countryCode": "USA",
+    "capacity": 30000,
+    "tenantClubs": [
+      "denver-pioneers"
+    ]
+  },
+  {
+    "id": "mgr-race-course-stadium",
+    "name": "MGR Race Course Stadium",
+    "city": null,
+    "countryCode": "IND",
+    "capacity": 30000,
+    "tenantClubs": []
+  },
+  {
+    "id": "east-pyongyang-stadium",
+    "name": "East Pyongyang Stadium",
+    "city": null,
+    "countryCode": "PRK",
+    "capacity": 30000,
+    "tenantClubs": []
+  },
+  {
+    "id": "infocision-stadium-summa-field",
+    "name": "InfoCision Stadium – Summa Field",
+    "city": "Akron",
+    "countryCode": "USA",
+    "capacity": 30000,
+    "tenantClubs": [
+      "akron-zips",
+      "akron-zips-football"
+    ]
+  },
+  {
+    "id": "zayyarthiri-stadium",
+    "name": "Zayyarthiri Stadium",
+    "city": "Naypyidaw",
+    "countryCode": "MMR",
+    "capacity": 30000,
+    "tenantClubs": [
+      "2013-southeast-asian-games"
+    ]
+  },
+  {
+    "id": "najaf-stadium",
+    "name": "Najaf Stadium",
+    "city": "Najaf",
+    "countryCode": "IRQ",
+    "capacity": 30000,
+    "tenantClubs": [
+      "najaf-fc"
+    ]
+  },
+  {
+    "id": "pakansari-stadium",
+    "name": "Pakansari Stadium",
+    "city": null,
+    "countryCode": "IDN",
+    "capacity": 30000,
+    "tenantClubs": []
+  },
+  {
+    "id": "stade-balibie",
+    "name": "Stade Balibiè",
+    "city": null,
+    "countryCode": "BFA",
+    "capacity": 30000,
+    "tenantClubs": [
+      "asec-koudougou"
+    ]
+  },
+  {
+    "id": "new-minaa-stadium",
+    "name": "New Minaa Stadium",
+    "city": "Basra",
+    "countryCode": "IRQ",
+    "capacity": 30000,
+    "tenantClubs": []
+  },
+  {
+    "id": "chiba-sports-center-stadium",
+    "name": "Chiba Sports Center Stadium",
+    "city": "Chiba",
+    "countryCode": "JPN",
+    "capacity": 30000,
+    "tenantClubs": []
+  },
+  {
+    "id": "stade-lumumba",
+    "name": "Stade Lumumba",
+    "city": null,
+    "countryCode": "COD",
+    "capacity": 30000,
+    "tenantClubs": [
+      "as-nika"
+    ]
+  },
+  {
+    "id": "sultan-mohammad-iv-stadium",
+    "name": "Sultan Mohammad IV Stadium",
+    "city": null,
+    "countryCode": "MYS",
+    "capacity": 30000,
+    "tenantClubs": [
+      "kelantan-f-c"
+    ]
+  },
+  {
+    "id": "war-heroes-stadium",
+    "name": "War Heroes Stadium",
+    "city": null,
+    "countryCode": "IND",
+    "capacity": 30000,
+    "tenantClubs": []
+  },
+  {
+    "id": "lake-placid-equestrian-stadium",
+    "name": "Lake Placid Equestrian Stadium",
+    "city": "Lake Placid",
+    "countryCode": "USA",
+    "capacity": 30000,
+    "tenantClubs": []
+  },
+  {
+    "id": "dasarath-rangasala-stadium",
+    "name": "Dasarath Rangasala Stadium",
+    "city": null,
+    "countryCode": "NPL",
+    "capacity": 30000,
+    "tenantClubs": [
+      "nepal-men-s-national-football-team"
+    ]
+  },
+  {
+    "id": "olympia-park",
+    "name": "Olympia Park",
+    "city": null,
+    "countryCode": "ZAF",
+    "capacity": 30000,
+    "tenantClubs": []
+  },
+  {
+    "id": "nehru-stadium-coimbatore",
+    "name": "Nehru Stadium, Coimbatore",
+    "city": "Coimbatore",
+    "countryCode": "IND",
+    "capacity": 30000,
+    "tenantClubs": []
+  },
+  {
+    "id": "kusanagi-stadium",
+    "name": "Kusanagi Stadium",
+    "city": null,
+    "countryCode": "JPN",
+    "capacity": 30000,
+    "tenantClubs": []
+  },
+  {
+    "id": "gorda-hilda",
+    "name": "Gorda hilda",
+    "city": "Pachuca",
+    "countryCode": "MEX",
+    "capacity": 30000,
+    "tenantClubs": [
+      "cf-pachuca"
+    ]
+  },
+  {
+    "id": "gwangmyeong-velodrome",
+    "name": "Gwangmyeong Velodrome",
+    "city": "Gwangmyeong",
+    "countryCode": "KOR",
+    "capacity": 30000,
+    "tenantClubs": []
+  },
+  {
+    "id": "karbala-sports-city",
+    "name": "Karbala Sports City",
+    "city": "Karbala",
+    "countryCode": "IRQ",
+    "capacity": 30000,
+    "tenantClubs": [
+      "karbalaa-fc"
+    ]
+  },
+  {
+    "id": "metalurh-stadium",
+    "name": "Metalurh Stadium",
+    "city": "Kryvyi Rih",
+    "countryCode": "UKR",
+    "capacity": 29734,
+    "tenantClubs": [
+      "fc-hirnyk-kryvyi-rih"
+    ]
+  },
+  {
+    "id": "estadio-cidade-de-coimbra",
+    "name": "Estádio Cidade de Coimbra",
+    "city": "Coimbra",
+    "countryCode": "PRT",
+    "capacity": 29622,
+    "tenantClubs": [
+      "associacao-academica-de-coimbra-o-a-f"
+    ]
+  },
+  {
+    "id": "millerntor-stadion",
+    "name": "Millerntor-Stadion",
+    "city": "St. Pauli",
+    "countryCode": "DEU",
+    "capacity": 29546,
+    "tenantClubs": [
+      "fc-st-pauli"
+    ]
+  },
+  {
+    "id": "fau-stadium",
+    "name": "FAU Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 29419,
+    "tenantClubs": [
+      "florida-atlantic-owls",
+      "florida-atlantic-owls-football"
+    ]
+  },
+  {
+    "id": "bloomfield-stadium",
+    "name": "Bloomfield Stadium",
+    "city": "Tel Aviv",
+    "countryCode": "ISR",
+    "capacity": 29400,
+    "tenantClubs": [
+      "hapoel-tel-aviv-f-c",
+      "israel-men-s-national-football-team",
+      "maccabi-tel-aviv-f-c"
+    ]
+  },
+  {
+    "id": "el-molinon-enrique-castro-quini",
+    "name": "El Molinón-Enrique Castro Quini",
+    "city": "Gijón",
+    "countryCode": "ESP",
+    "capacity": 29371,
+    "tenantClubs": [
+      "sporting-de-gijon"
+    ]
+  },
+  {
+    "id": "ruhrstadion",
+    "name": "Ruhrstadion",
+    "city": null,
+    "countryCode": "DEU",
+    "capacity": 29299,
+    "tenantClubs": [
+      "vfl-bochum"
+    ]
+  },
+  {
+    "id": "georgi-asparuhov-stadium",
+    "name": "Georgi Asparuhov Stadium",
+    "city": "Sofia",
+    "countryCode": "BGR",
+    "capacity": 29200,
+    "tenantClubs": [
+      "pfc-levski-sofia"
+    ]
+  },
+  {
+    "id": "war-memorial-stadium",
+    "name": "War Memorial Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 29181,
+    "tenantClubs": [
+      "wyoming-cowboys-and-cowgirls",
+      "wyoming-cowboys-football"
+    ]
+  },
+  {
+    "id": "estadio-brinco-de-ouro",
+    "name": "Estádio Brinco de Ouro",
+    "city": "Campinas",
+    "countryCode": "BRA",
+    "capacity": 29130,
+    "tenantClubs": [
+      "guarani-futebol-clube"
+    ]
+  },
+  {
+    "id": "veb-arena",
+    "name": "VEB Arena",
+    "city": "Khodynka Field",
+    "countryCode": "RUS",
+    "capacity": 29071,
+    "tenantClubs": [
+      "pfc-cska-moscow"
+    ]
+  },
+  {
+    "id": "jan-breydel-stadium",
+    "name": "Jan Breydel Stadium",
+    "city": "Sint-Andries",
+    "countryCode": "BEL",
+    "capacity": 29062,
+    "tenantClubs": [
+      "cercle-brugge-k-s-v",
+      "club-brugge-k-v",
+      "club-yla"
+    ]
+  },
+  {
+    "id": "estadio-victor-manuel-reyna",
+    "name": "Estadio Víctor Manuel Reyna",
+    "city": "Tuxtla Gutiérrez",
+    "countryCode": "MEX",
+    "capacity": 29001,
+    "tenantClubs": [
+      "chiapas-f-c"
+    ]
+  },
+  {
+    "id": "ostseestadion",
+    "name": "Ostseestadion",
+    "city": null,
+    "countryCode": "DEU",
+    "capacity": 29000,
+    "tenantClubs": [
+      "f-c-hansa-rostock"
+    ]
+  },
+  {
+    "id": "estadio-centenario-col",
+    "name": "Estadio Centenario",
+    "city": "Armenia",
+    "countryCode": "COL",
+    "capacity": 29000,
+    "tenantClubs": [
+      "deportes-quindio"
+    ]
+  },
+  {
+    "id": "br-ndby-stadium",
+    "name": "Brøndby Stadium",
+    "city": "Brøndbyvester",
+    "countryCode": "DNK",
+    "capacity": 29000,
+    "tenantClubs": [
+      "br-ndby-if"
+    ]
+  },
+  {
+    "id": "sanl-urfa-11-nisan-stadium",
+    "name": "Şanlıurfa 11 Nisan Stadium",
+    "city": null,
+    "countryCode": "TUR",
+    "capacity": 28965,
+    "tenantClubs": [
+      "sanl-urfaspor"
+    ]
+  },
+  {
+    "id": "lucas-masterpieces-moripe-stadium",
+    "name": "Lucas Masterpieces Moripe Stadium",
+    "city": null,
+    "countryCode": "ZAF",
+    "capacity": 28900,
+    "tenantClubs": [
+      "supersport-united-f-c"
+    ]
+  },
+  {
+    "id": "toughsheet-community-stadium",
+    "name": "Toughsheet Community Stadium",
+    "city": "Bolton",
+    "countryCode": "GBR",
+    "capacity": 28723,
+    "tenantClubs": [
+      "bolton-wanderers-f-c"
+    ]
+  },
+  {
+    "id": "toumba-stadium",
+    "name": "Toumba Stadium",
+    "city": "Thessaloniki",
+    "countryCode": "GRC",
+    "capacity": 28703,
+    "tenantClubs": [
+      "p-a-o-k-f-c-women-s-football",
+      "paok-fc"
+    ]
+  },
+  {
+    "id": "joe-albi-stadium",
+    "name": "Joe Albi Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 28646,
+    "tenantClubs": [
+      "washington-state-cougars-football"
+    ]
+  },
+  {
+    "id": "joe-aillet-stadium",
+    "name": "Joe Aillet Stadium",
+    "city": "Ruston",
+    "countryCode": "USA",
+    "capacity": 28562,
+    "tenantClubs": [
+      "louisiana-tech-bulldogs-and-lady-techsters",
+      "louisiana-tech-bulldogs-football"
+    ]
+  },
+  {
+    "id": "city-of-vicente-lopez-stadium",
+    "name": "City of Vicente López Stadium",
+    "city": "Florida",
+    "countryCode": "ARG",
+    "capacity": 28530,
+    "tenantClubs": [
+      "club-atletico-platense",
+      "platense-women-s-football-team"
+    ]
+  },
+  {
+    "id": "olympic-stadium-adem-jashari",
+    "name": "Olympic Stadium Adem Jashari",
+    "city": "Mitrovica",
+    "countryCode": "XKS",
+    "capacity": 28500,
+    "tenantClubs": [
+      "fk-trepca",
+      "kf-trepca"
+    ]
+  },
+  {
+    "id": "toyama-athletic-stadium",
+    "name": "Toyama Athletic Stadium",
+    "city": "Toyama",
+    "countryCode": "JPN",
+    "capacity": 28494,
+    "tenantClubs": [
+      "kataller-toyama"
+    ]
+  },
+  {
+    "id": "arena-da-baixada",
+    "name": "Arena da Baixada",
+    "city": null,
+    "countryCode": "BRA",
+    "capacity": 28413,
+    "tenantClubs": [
+      "club-athletico-paranaense",
+      "club-athletico-paranaense-women"
+    ]
+  },
+  {
+    "id": "estadio-do-bessa",
+    "name": "Estádio do Bessa",
+    "city": "Porto",
+    "countryCode": "PRT",
+    "capacity": 28263,
+    "tenantClubs": [
+      "boavista-f-c"
+    ]
+  },
+  {
+    "id": "ernest-pohl-stadium",
+    "name": "Ernest Pohl Stadium",
+    "city": null,
+    "countryCode": "POL",
+    "capacity": 28236,
+    "tenantClubs": [
+      "gornik-zabrze"
+    ]
+  },
+  {
+    "id": "estadio-olimpico-regional-arnaldo-busatto",
+    "name": "Estádio Olímpico Regional Arnaldo Busatto",
+    "city": "Cascavel",
+    "countryCode": "BRA",
+    "capacity": 28125,
+    "tenantClubs": [
+      "cascavel-esporte-clube"
+    ]
+  },
+  {
+    "id": "ukraina-stadium",
+    "name": "Ukraina Stadium",
+    "city": null,
+    "countryCode": "UKR",
+    "capacity": 28051,
+    "tenantClubs": [
+      "fc-karpaty-lviv"
+    ]
+  },
+  {
+    "id": "chi-lang-stadium",
+    "name": "Chi Lang Stadium",
+    "city": null,
+    "countryCode": "VNM",
+    "capacity": 28000,
+    "tenantClubs": [
+      "shb-da-nang-f-c"
+    ]
+  },
+  {
+    "id": "estadio-antonio-oddone-sarubbi",
+    "name": "Estadio Antonio Oddone Sarubbi",
+    "city": null,
+    "countryCode": "PRY",
+    "capacity": 28000,
+    "tenantClubs": [
+      "club-atletico-3-de-febrero"
+    ]
+  },
+  {
+    "id": "kensington-oval",
+    "name": "Kensington Oval",
+    "city": null,
+    "countryCode": "BRB",
+    "capacity": 28000,
+    "tenantClubs": [
+      "west-indies-cricket-team"
+    ]
+  },
+  {
+    "id": "nicosia-ataturk-stadium",
+    "name": "Nicosia Atatürk Stadium",
+    "city": null,
+    "countryCode": "CYP",
+    "capacity": 28000,
+    "tenantClubs": [
+      "cetinkaya-turk-s-k"
+    ]
+  },
+  {
+    "id": "estadio-unico-de-villa-mercedes",
+    "name": "Estadio Único de Villa Mercedes",
+    "city": null,
+    "countryCode": "ARG",
+    "capacity": 28000,
+    "tenantClubs": []
+  },
+  {
+    "id": "schwelgernstadion",
+    "name": "Schwelgernstadion",
+    "city": null,
+    "countryCode": "DEU",
+    "capacity": 28000,
+    "tenantClubs": [
+      "q1264251"
+    ]
+  },
+  {
+    "id": "gopalganj-international-cricket-stadium",
+    "name": "Gopalganj International Cricket Stadium",
+    "city": "Gopalganj District",
+    "countryCode": "BGD",
+    "capacity": 28000,
+    "tenantClubs": [
+      "bangladesh-national-cricket-team"
+    ]
+  },
+  {
+    "id": "rosenaustadion",
+    "name": "Rosenaustadion",
+    "city": "Augsburg",
+    "countryCode": "DEU",
+    "capacity": 28000,
+    "tenantClubs": [
+      "fc-augsburg"
+    ]
+  },
+  {
+    "id": "stadio-renato-curi",
+    "name": "Stadio Renato Curi",
+    "city": null,
+    "countryCode": "ITA",
+    "capacity": 28000,
+    "tenantClubs": [
+      "a-c-perugia-calcio"
+    ]
+  },
+  {
+    "id": "estadio-1-de-maio",
+    "name": "Estádio 1º de Maio",
+    "city": "São José de São Lázaro",
+    "countryCode": "PRT",
+    "capacity": 28000,
+    "tenantClubs": []
+  },
+  {
+    "id": "lach-tray-stadium",
+    "name": "Lạch Tray Stadium",
+    "city": null,
+    "countryCode": "VNM",
+    "capacity": 28000,
+    "tenantClubs": [
+      "haiphong-football-club"
+    ]
+  },
+  {
+    "id": "stadion-eto",
+    "name": "Stadion ETO",
+    "city": "Győr",
+    "countryCode": "HUN",
+    "capacity": 28000,
+    "tenantClubs": [
+      "gyori-eto-fc"
+    ]
+  },
+  {
+    "id": "stadionul-republicii",
+    "name": "Stadionul Republicii",
+    "city": null,
+    "countryCode": "ROU",
+    "capacity": 28000,
+    "tenantClubs": [
+      "romania-men-s-national-association-football-team"
+    ]
+  },
+  {
+    "id": "kusanagi-athletic-stadium",
+    "name": "Kusanagi Athletic Stadium",
+    "city": null,
+    "countryCode": "JPN",
+    "capacity": 28000,
+    "tenantClubs": []
+  },
+  {
+    "id": "ullevaal-stadion",
+    "name": "Ullevaal Stadion",
+    "city": null,
+    "countryCode": "NOR",
+    "capacity": 28000,
+    "tenantClubs": [
+      "lyn-1896-fk",
+      "norway-men-s-national-association-football-team",
+      "valerenga-fotball"
+    ]
+  },
+  {
+    "id": "princeton-university-stadium",
+    "name": "Princeton University Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 27773,
+    "tenantClubs": [
+      "princeton-tigers",
+      "princeton-tigers-football"
+    ]
+  },
+  {
+    "id": "britannia-stadium",
+    "name": "Britannia Stadium",
+    "city": null,
+    "countryCode": "GBR",
+    "capacity": 27740,
+    "tenantClubs": [
+      "stoke-city-f-c"
+    ]
+  },
+  {
+    "id": "stadio-erasmo-iacovone",
+    "name": "Stadio Erasmo Iacovone",
+    "city": null,
+    "countryCode": "ITA",
+    "capacity": 27584,
+    "tenantClubs": [
+      "taranto-sport"
+    ]
+  },
+  {
+    "id": "kaftanzoglio-national-stadium",
+    "name": "Kaftanzoglio National Stadium",
+    "city": "Thessaloniki",
+    "countryCode": "GRC",
+    "capacity": 27560,
+    "tenantClubs": [
+      "g-s-iraklis-thessalonikis-men-s-association-football"
+    ]
+  },
+  {
+    "id": "prince-abdullah-bin-jalawi-sports-city",
+    "name": "Prince Abdullah bin Jalawi Sports City",
+    "city": null,
+    "countryCode": "SAU",
+    "capacity": 27550,
+    "tenantClubs": [
+      "al-fateh-sc"
+    ]
+  },
+  {
+    "id": "stadio-oreste-granillo",
+    "name": "Stadio Oreste Granillo",
+    "city": null,
+    "countryCode": "ITA",
+    "capacity": 27543,
+    "tenantClubs": [
+      "2020-21-reggina-1914-season",
+      "2021-22-reggina-1914-season",
+      "as-reggina-1914"
+    ]
+  },
+  {
+    "id": "odsal-stadium",
+    "name": "Odsal Stadium",
+    "city": null,
+    "countryCode": "GBR",
+    "capacity": 27491,
+    "tenantClubs": [
+      "bradford-bulls"
+    ]
+  },
+  {
+    "id": "leon-stadium",
+    "name": "León Stadium",
+    "city": "León de Los Aldama",
+    "countryCode": "MEX",
+    "capacity": 27432,
+    "tenantClubs": [
+      "club-leon"
+    ]
+  },
+  {
+    "id": "robina-stadium",
+    "name": "Robina Stadium",
+    "city": "Robina",
+    "countryCode": "AUS",
+    "capacity": 27400,
+    "tenantClubs": [
+      "gold-coast-titans"
+    ]
+  },
+  {
+    "id": "caliente-stadium",
+    "name": "Caliente Stadium",
+    "city": null,
+    "countryCode": "MEX",
+    "capacity": 27333,
+    "tenantClubs": [
+      "club-tijuana",
+      "galgos-de-tijuana"
+    ]
+  },
+  {
+    "id": "rzd-arena",
+    "name": "RZD Arena",
+    "city": "Moscow",
+    "countryCode": "RUS",
+    "capacity": 27320,
+    "tenantClubs": [
+      "fc-lokomotiv-moscow"
+    ]
+  },
+  {
+    "id": "bielefelder-alm",
+    "name": "Bielefelder Alm",
+    "city": null,
+    "countryCode": "DEU",
+    "capacity": 27300,
+    "tenantClubs": [
+      "arminia-bielefeld"
+    ]
+  },
+  {
+    "id": "carrow-road",
+    "name": "Carrow Road",
+    "city": null,
+    "countryCode": "GBR",
+    "capacity": 27244,
+    "tenantClubs": [
+      "norwich-city-f-c"
+    ]
+  },
+  {
+    "id": "mikheil-meskhi-stadium",
+    "name": "Mikheil Meskhi Stadium",
+    "city": null,
+    "countryCode": "GEO",
+    "capacity": 27223,
+    "tenantClubs": [
+      "fc-iberia-1999",
+      "georgia-men-s-national-rugby-union-team"
+    ]
+  },
+  {
+    "id": "estadio-atilio-paiva-olivera",
+    "name": "Estadio Atilio Paiva Olivera",
+    "city": null,
+    "countryCode": "URY",
+    "capacity": 27135,
+    "tenantClubs": [
+      "uruguay-men-s-national-football-team"
+    ]
+  },
+  {
+    "id": "the-valley",
+    "name": "The Valley",
+    "city": "Charlton",
+    "countryCode": "GBR",
+    "capacity": 27111,
+    "tenantClubs": [
+      "charlton-athletic-f-c",
+      "charlton-athletic-w-f-c",
+      "london-broncos"
+    ]
+  },
+  {
+    "id": "changwon-stadium",
+    "name": "Changwon Stadium",
+    "city": null,
+    "countryCode": "KOR",
+    "capacity": 27085,
+    "tenantClubs": []
+  },
+  {
+    "id": "hasely-crawford-stadium",
+    "name": "Hasely Crawford Stadium",
+    "city": "Port of Spain",
+    "countryCode": "TTO",
+    "capacity": 27000,
+    "tenantClubs": [
+      "defence-force-f-c"
+    ]
+  },
+  {
+    "id": "sportplatz-at-rothenbaum",
+    "name": "Sportplatz at Rothenbaum",
+    "city": "Harvestehude",
+    "countryCode": "DEU",
+    "capacity": 27000,
+    "tenantClubs": []
+  },
+  {
+    "id": "si-jalak-harupat-stadium",
+    "name": "Si Jalak Harupat Stadium",
+    "city": null,
+    "countryCode": "IDN",
+    "capacity": 27000,
+    "tenantClubs": [
+      "persikab-bandung"
+    ]
+  },
+  {
+    "id": "estadio-de-beisbol-monterrey",
+    "name": "Estadio de Béisbol Monterrey",
+    "city": null,
+    "countryCode": "MEX",
+    "capacity": 27000,
+    "tenantClubs": [
+      "sultanes-de-monterrey"
+    ]
+  },
+  {
+    "id": "mizuho-athletic-stadium",
+    "name": "Mizuho Athletic Stadium",
+    "city": "Nagoya",
+    "countryCode": "JPN",
+    "capacity": 27000,
+    "tenantClubs": [
+      "nagoya-grampus"
+    ]
+  },
+  {
+    "id": "prince-abdullah-al-faisal-sports-city",
+    "name": "Prince Abdullah Al Faisal Sports City",
+    "city": "Jeddah",
+    "countryCode": "SAU",
+    "capacity": 27000,
+    "tenantClubs": [
+      "al-ahli-fc",
+      "al-ittihad-fc"
+    ]
+  },
+  {
+    "id": "estadio-nacional-de-panama",
+    "name": "Estadio Nacional de Panamá",
+    "city": null,
+    "countryCode": "PAN",
+    "capacity": 27000,
+    "tenantClubs": [
+      "q2931080"
+    ]
+  },
+  {
+    "id": "ashton-gate-stadium",
+    "name": "Ashton Gate Stadium",
+    "city": "Bristol",
+    "countryCode": "GBR",
+    "capacity": 27000,
+    "tenantClubs": [
+      "bristol-bears",
+      "bristol-city-f-c"
+    ]
+  },
+  {
+    "id": "carl-benz-stadion",
+    "name": "Carl-Benz-Stadion",
+    "city": null,
+    "countryCode": "DEU",
+    "capacity": 27000,
+    "tenantClubs": [
+      "sv-waldhof-mannheim"
+    ]
+  },
+  {
+    "id": "estadio-feliciano-caceres",
+    "name": "Estadio Feliciano Cáceres",
+    "city": null,
+    "countryCode": "PRY",
+    "capacity": 27000,
+    "tenantClubs": [
+      "sportivo-luqueno"
+    ]
+  },
+  {
+    "id": "baoji-city-stadium",
+    "name": "Baoji City Stadium",
+    "city": null,
+    "countryCode": "CHN",
+    "capacity": 27000,
+    "tenantClubs": []
+  },
+  {
+    "id": "estadio-general-francisco-morazan",
+    "name": "Estadio General Francisco Morazán",
+    "city": null,
+    "countryCode": "HND",
+    "capacity": 26781,
+    "tenantClubs": [
+      "real-c-d-espana"
+    ]
+  },
+  {
+    "id": "atotxa-stadium",
+    "name": "Atotxa Stadium",
+    "city": null,
+    "countryCode": "ESP",
+    "capacity": 26700,
+    "tenantClubs": [
+      "real-sociedad"
+    ]
+  },
+  {
+    "id": "fargodome",
+    "name": "Fargodome",
+    "city": "North Dakota State University",
+    "countryCode": "USA",
+    "capacity": 26700,
+    "tenantClubs": [
+      "north-dakota-state-bison-football"
+    ]
+  },
+  {
+    "id": "nu-stadium",
+    "name": "Nu Stadium",
+    "city": "Miami Freedom Park",
+    "countryCode": "USA",
+    "capacity": 26700,
+    "tenantClubs": [
+      "inter-miami-cf"
+    ]
+  },
+  {
+    "id": "stade-saint-symphorien",
+    "name": "Stade Saint-Symphorien",
+    "city": null,
+    "countryCode": "FRA",
+    "capacity": 26671,
+    "tenantClubs": [
+      "fc-metz"
+    ]
+  },
+  {
+    "id": "the-oval",
+    "name": "The Oval",
+    "city": null,
+    "countryCode": "GBR",
+    "capacity": 26556,
+    "tenantClubs": [
+      "glentoran-f-c"
+    ]
+  },
+  {
+    "id": "estadio-de-chacarita-juniors",
+    "name": "Estadio de Chacarita Juniors",
+    "city": "Villa Maipú",
+    "countryCode": "ARG",
+    "capacity": 26530,
+    "tenantClubs": [
+      "chacarita-juniors"
+    ]
+  },
+  {
+    "id": "estadio-nuevo-jose-zorrilla",
+    "name": "Estadio Nuevo José Zorrilla",
+    "city": null,
+    "countryCode": "ESP",
+    "capacity": 26512,
+    "tenantClubs": [
+      "real-valladolid"
+    ]
+  },
+  {
+    "id": "tad-gormley-stadium",
+    "name": "Tad Gormley Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 26500,
+    "tenantClubs": [
+      "louisiana-high-school-athletic-association"
+    ]
+  },
+  {
+    "id": "malmo-stadion",
+    "name": "Malmö stadion",
+    "city": "Stadionområdet",
+    "countryCode": "SWE",
+    "capacity": 26500,
+    "tenantClubs": [
+      "malmo-ff"
+    ]
+  },
+  {
+    "id": "hornet-stadium",
+    "name": "Hornet Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 26500,
+    "tenantClubs": [
+      "alabama-state-hornets-football"
+    ]
+  },
+  {
+    "id": "thomond-park",
+    "name": "Thomond Park",
+    "city": "Limerick",
+    "countryCode": "IRL",
+    "capacity": 26500,
+    "tenantClubs": [
+      "munster-rugby"
+    ]
+  },
+  {
+    "id": "the-hawthorns",
+    "name": "The Hawthorns",
+    "city": null,
+    "countryCode": "GBR",
+    "capacity": 26445,
+    "tenantClubs": [
+      "west-bromwich-albion-f-c"
+    ]
+  },
+  {
+    "id": "estadi-ciutat-de-valencia",
+    "name": "Estadi Ciutat de València",
+    "city": null,
+    "countryCode": "ESP",
+    "capacity": 26354,
+    "tenantClubs": [
+      "levante-ud",
+      "levante-ud-b-women"
+    ]
+  },
+  {
+    "id": "estadio-jose-dellagiovanna",
+    "name": "Estadio José Dellagiovanna",
+    "city": "Victoria",
+    "countryCode": "ARG",
+    "capacity": 26282,
+    "tenantClubs": [
+      "club-atletico-tigre"
+    ]
+  },
+  {
+    "id": "selhurst-park",
+    "name": "Selhurst Park",
+    "city": "Selhurst",
+    "countryCode": "GBR",
+    "capacity": 26255,
+    "tenantClubs": [
+      "crystal-palace-f-c"
+    ]
+  },
+  {
+    "id": "pankritio-stadium",
+    "name": "Pankritio Stadium",
+    "city": "Heraklion",
+    "countryCode": "GRC",
+    "capacity": 26240,
+    "tenantClubs": [
+      "a-o-giouchtas-archanon",
+      "ergotelis-f-c"
+    ]
+  },
+  {
+    "id": "pearse-stadium",
+    "name": "Pearse Stadium",
+    "city": null,
+    "countryCode": "IRL",
+    "capacity": 26197,
+    "tenantClubs": [
+      "galway-gaa"
+    ]
+  },
+  {
+    "id": "stade-de-la-meinau",
+    "name": "Stade de la Meinau",
+    "city": null,
+    "countryCode": "FRA",
+    "capacity": 26109,
+    "tenantClubs": [
+      "rc-strasbourg-alsace"
+    ]
+  },
+  {
+    "id": "abe-lenstra-stadion",
+    "name": "Abe Lenstra Stadion",
+    "city": "Heerenveen",
+    "countryCode": null,
+    "capacity": 26100,
+    "tenantClubs": [
+      "sc-heerenveen"
+    ]
+  },
+  {
+    "id": "estadi-mallorca-son-moix",
+    "name": "Estadi Mallorca Son Moix",
+    "city": null,
+    "countryCode": "ESP",
+    "capacity": 26020,
+    "tenantClubs": [
+      "rcd-mallorca"
+    ]
+  },
+  {
+    "id": "kopetdag-stadium",
+    "name": "Köpetdag Stadium",
+    "city": null,
+    "countryCode": "TKM",
+    "capacity": 26000,
+    "tenantClubs": [
+      "kopetdag-asgabat"
+    ]
+  },
+  {
+    "id": "estadio-nuevo-mirandilla",
+    "name": "Estadio Nuevo Mirandilla",
+    "city": null,
+    "countryCode": "ESP",
+    "capacity": 26000,
+    "tenantClubs": [
+      "cadiz-club-de-futbol"
+    ]
+  },
+  {
+    "id": "rabindra-sarobar-stadium",
+    "name": "Rabindra Sarobar Stadium",
+    "city": null,
+    "countryCode": "IND",
+    "capacity": 26000,
+    "tenantClubs": [
+      "tollygunge-agragami"
+    ]
+  },
+  {
+    "id": "tql-stadium",
+    "name": "TQL Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 26000,
+    "tenantClubs": [
+      "fc-cincinnati"
+    ]
+  },
+  {
+    "id": "alfredo-beranger-stadium",
+    "name": "Alfredo Beranger Stadium",
+    "city": "Turdera",
+    "countryCode": "ARG",
+    "capacity": 26000,
+    "tenantClubs": [
+      "club-atletico-temperley"
+    ]
+  },
+  {
+    "id": "folsom-field",
+    "name": "Folsom Field",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 26000,
+    "tenantClubs": [
+      "colorado-buffaloes-football"
+    ]
+  },
+  {
+    "id": "stadio-del-conero",
+    "name": "Stadio del Conero",
+    "city": null,
+    "countryCode": "ITA",
+    "capacity": 26000,
+    "tenantClubs": [
+      "ssc-ancona"
+    ]
+  },
+  {
+    "id": "nanchang-bayi-stadium",
+    "name": "Nanchang Bayi Stadium",
+    "city": null,
+    "countryCode": "CHN",
+    "capacity": 26000,
+    "tenantClubs": []
+  },
+  {
+    "id": "osir-ska-ka",
+    "name": "OSiR Skałka",
+    "city": null,
+    "countryCode": "POL",
+    "capacity": 26000,
+    "tenantClubs": []
+  },
+  {
+    "id": "obed-itani-chilume-stadium",
+    "name": "Obed Itani Chilume Stadium",
+    "city": "Francistown",
+    "countryCode": "BWA",
+    "capacity": 26000,
+    "tenantClubs": [
+      "tafic-f-c"
+    ]
+  },
+  {
+    "id": "cheonan-stadium",
+    "name": "Cheonan Stadium",
+    "city": null,
+    "countryCode": "KOR",
+    "capacity": 26000,
+    "tenantClubs": []
+  },
+  {
+    "id": "welford-road-stadium",
+    "name": "Welford Road Stadium",
+    "city": "Leicester",
+    "countryCode": "GBR",
+    "capacity": 25849,
+    "tenantClubs": [
+      "leicester-tigers",
+      "london-broncos"
+    ]
+  },
+  {
+    "id": "waikato-stadium",
+    "name": "Waikato Stadium",
+    "city": "Hamilton",
+    "countryCode": "NZL",
+    "capacity": 25800,
+    "tenantClubs": [
+      "chiefs",
+      "chiefs-manawa",
+      "waikato-ru"
+    ]
+  },
+  {
+    "id": "estadio-alfonso-lastras",
+    "name": "Estadio Alfonso Lastras",
+    "city": "San Luis Potosí",
+    "countryCode": "MEX",
+    "capacity": 25709,
+    "tenantClubs": [
+      "atletico-de-san-luis"
+    ]
+  },
+  {
+    "id": "craven-cottage",
+    "name": "Craven Cottage",
+    "city": "Fulham",
+    "countryCode": "GBR",
+    "capacity": 25700,
+    "tenantClubs": [
+      "fulham-f-c",
+      "london-broncos"
+    ]
+  },
+  {
+    "id": "rsc-olimpiyskiy",
+    "name": "RSC Olimpiyskiy",
+    "city": null,
+    "countryCode": "UKR",
+    "capacity": 25678,
+    "tenantClubs": [
+      "fc-lokomotyv-donetsk",
+      "fc-shakhtar-donetsk"
+    ]
+  },
+  {
+    "id": "kumagaya-rugby-stadium",
+    "name": "Kumagaya Rugby Stadium",
+    "city": "Kumagaya",
+    "countryCode": "JPN",
+    "capacity": 25600,
+    "tenantClubs": [
+      "saiatama-panasonic-wild-knights"
+    ]
+  },
+  {
+    "id": "schoellkopf-field",
+    "name": "Schoellkopf Field",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 25597,
+    "tenantClubs": [
+      "cornell-big-red-football",
+      "cornell-big-red-men-s-lacrosse"
+    ]
+  },
+  {
+    "id": "buxoro-arena",
+    "name": "Buxoro Arena",
+    "city": null,
+    "countryCode": "UZB",
+    "capacity": 25520,
+    "tenantClubs": [
+      "fk-buxoro"
+    ]
+  },
+  {
+    "id": "maverik-stadium-utah-state",
+    "name": "Maverik Stadium, Utah State",
+    "city": "Utah State University",
+    "countryCode": "USA",
+    "capacity": 25513,
+    "tenantClubs": [
+      "utah-state-aggies-football"
+    ]
+  },
+  {
+    "id": "bragg-memorial-stadium",
+    "name": "Bragg Memorial Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 25500,
+    "tenantClubs": [
+      "florida-a-m-rattlers-and-lady-rattlers"
+    ]
+  },
+  {
+    "id": "inter-co-stadium",
+    "name": "Inter&Co Stadium",
+    "city": "Orlando",
+    "countryCode": "USA",
+    "capacity": 25500,
+    "tenantClubs": [
+      "orlando-city-b",
+      "orlando-city-sc",
+      "orlando-pride"
+    ]
+  },
+  {
+    "id": "stade-de-la-maladiere-1924",
+    "name": "Stade de la Maladière (1924)",
+    "city": "Neuchâtel",
+    "countryCode": "CHE",
+    "capacity": 25500,
+    "tenantClubs": [
+      "neuchatel-xamax"
+    ]
+  },
+  {
+    "id": "mersin-arena",
+    "name": "Mersin Arena",
+    "city": "Yenişehir",
+    "countryCode": "TUR",
+    "capacity": 25497,
+    "tenantClubs": [
+      "mersin-idmanyurdu",
+      "yeni-mersin-idmanyurdu"
+    ]
+  },
+  {
+    "id": "mkm-stadium",
+    "name": "MKM Stadium",
+    "city": null,
+    "countryCode": "GBR",
+    "capacity": 25400,
+    "tenantClubs": [
+      "hull-city-a-f-c",
+      "hull-f-c"
+    ]
+  },
+  {
+    "id": "dix-stadium",
+    "name": "Dix Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 25319,
+    "tenantClubs": [
+      "kent-state-golden-flashes",
+      "kent-state-golden-flashes-football"
+    ]
+  },
+  {
+    "id": "stadio-friuli",
+    "name": "Stadio Friuli",
+    "city": null,
+    "countryCode": "ITA",
+    "capacity": 25312,
+    "tenantClubs": [
+      "pordenone-fc",
+      "udinese-calcio"
+    ]
+  },
+  {
+    "id": "estadio-san-juan-del-bicentenario",
+    "name": "Estadio San Juan del Bicentenario",
+    "city": null,
+    "countryCode": "ARG",
+    "capacity": 25286,
+    "tenantClubs": [
+      "san-martin-de-san-juan"
+    ]
+  },
+  {
+    "id": "providence-park",
+    "name": "Providence Park",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 25218,
+    "tenantClubs": [
+      "oregon-ducks-football",
+      "portland-beavers",
+      "portland-breakers",
+      "portland-state-vikings-football",
+      "portland-thorns-fc",
+      "portland-timbers",
+      "portland-timbers-2"
+    ]
+  },
+  {
+    "id": "washington-grizzly-stadium",
+    "name": "Washington–Grizzly Stadium",
+    "city": "Missoula",
+    "countryCode": "USA",
+    "capacity": 25217,
+    "tenantClubs": [
+      "montana-grizzlies-football"
+    ]
+  },
+  {
+    "id": "sports-illustrated-stadium",
+    "name": "Sports Illustrated Stadium",
+    "city": "Harrison",
+    "countryCode": "USA",
+    "capacity": 25189,
+    "tenantClubs": [
+      "gotham-fc",
+      "red-bull-new-york"
+    ]
+  },
+  {
+    "id": "woldiya-stadium",
+    "name": "Woldiya Stadium",
+    "city": "Weldiya",
+    "countryCode": "ETH",
+    "capacity": 25155,
+    "tenantClubs": [
+      "woldia-s-c"
+    ]
+  },
+  {
+    "id": "valley-parade",
+    "name": "Valley Parade",
+    "city": null,
+    "countryCode": "GBR",
+    "capacity": 25136,
+    "tenantClubs": [
+      "bradford-city-a-f-c",
+      "manningham-f-c"
+    ]
+  },
+  {
+    "id": "q494388",
+    "name": "Q494388",
+    "city": null,
+    "countryCode": "GBR",
+    "capacity": 25133,
+    "tenantClubs": [
+      "wigan-athletic-f-c",
+      "wigan-warriors"
+    ]
+  },
+  {
+    "id": "stadionul-dinamo",
+    "name": "Stadionul Dinamo",
+    "city": null,
+    "countryCode": "ROU",
+    "capacity": 25059,
+    "tenantClubs": [
+      "fc-dinamo-bucharest"
+    ]
+  },
+  {
+    "id": "yongchuan-sports-center",
+    "name": "Yongchuan Sports Center",
+    "city": "Yongchuan District",
+    "countryCode": "CHN",
+    "capacity": 25017,
+    "tenantClubs": []
+  },
+  {
+    "id": "percival-molson-memorial-stadium",
+    "name": "Percival Molson Memorial Stadium",
+    "city": "Mont-Royal Heritage Site",
+    "countryCode": "CAN",
+    "capacity": 25012,
+    "tenantClubs": [
+      "mcgill-redbirds-football",
+      "mcgill-redbirds-soccer",
+      "montreal-alouettes"
+    ]
+  },
+  {
+    "id": "thupatemee-stadium",
+    "name": "Thupatemee Stadium",
+    "city": "Lam Luk Ka",
+    "countryCode": "THA",
+    "capacity": 25000,
+    "tenantClubs": [
+      "air-force-united-f-c"
+    ]
+  },
+  {
+    "id": "hm-pitje-stadium",
+    "name": "HM Pitje Stadium",
+    "city": "Mamelodi",
+    "countryCode": "ZAF",
+    "capacity": 25000,
+    "tenantClubs": []
+  },
+  {
+    "id": "stadion-rote-erde",
+    "name": "Stadion Rote Erde",
+    "city": null,
+    "countryCode": "DEU",
+    "capacity": 25000,
+    "tenantClubs": [
+      "borussia-dortmund"
+    ]
+  },
+  {
+    "id": "segiri-stadium",
+    "name": "Segiri Stadium",
+    "city": null,
+    "countryCode": "IDN",
+    "capacity": 25000,
+    "tenantClubs": [
+      "bali-united-f-c"
+    ]
+  },
+  {
+    "id": "estadio-sao-januario",
+    "name": "Estádio São Januário",
+    "city": "Rio de Janeiro",
+    "countryCode": "BRA",
+    "capacity": 25000,
+    "tenantClubs": [
+      "cr-vasco-da-gama"
+    ]
+  },
+  {
+    "id": "wilis-stadium",
+    "name": "Wilis Stadium",
+    "city": "Madiun",
+    "countryCode": "IDN",
+    "capacity": 25000,
+    "tenantClubs": [
+      "jakarta-fc-1928"
+    ]
+  },
+  {
+    "id": "giyani-stadium",
+    "name": "Giyani Stadium",
+    "city": null,
+    "countryCode": "ZAF",
+    "capacity": 25000,
+    "tenantClubs": [
+      "black-leopards-f-c"
+    ]
+  },
+  {
+    "id": "shangri-la-county-stadium",
+    "name": "Shangri-La County Stadium",
+    "city": null,
+    "countryCode": "CHN",
+    "capacity": 25000,
+    "tenantClubs": []
+  },
+  {
+    "id": "petro-sport-stadium",
+    "name": "Petro Sport Stadium",
+    "city": null,
+    "countryCode": "EGY",
+    "capacity": 25000,
+    "tenantClubs": [
+      "enppi-sc"
+    ]
+  },
+  {
+    "id": "heriberto-jara-corona-stadium",
+    "name": "Heriberto Jara Corona Stadium",
+    "city": null,
+    "countryCode": "MEX",
+    "capacity": 25000,
+    "tenantClubs": []
+  },
+  {
+    "id": "q5848038",
+    "name": "Q5848038",
+    "city": null,
+    "countryCode": "ARG",
+    "capacity": 25000,
+    "tenantClubs": [
+      "club-atletico-chaco-for-ever"
+    ]
+  },
+  {
+    "id": "okinawa-athletic-stadium",
+    "name": "Okinawa Athletic Stadium",
+    "city": "Okinawa Comprehensive Athletic Park",
+    "countryCode": "JPN",
+    "capacity": 25000,
+    "tenantClubs": [
+      "fc-ryukyu-okinawa"
+    ]
+  },
+  {
+    "id": "williams-stadium",
+    "name": "Williams Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 25000,
+    "tenantClubs": [
+      "liberty-flames-football"
+    ]
+  },
+  {
+    "id": "ganja-city-stadium",
+    "name": "Ganja City Stadium",
+    "city": null,
+    "countryCode": "AZE",
+    "capacity": 25000,
+    "tenantClubs": [
+      "kapaz-pfc"
+    ]
+  },
+  {
+    "id": "green-park-stadium",
+    "name": "Green Park Stadium",
+    "city": "Kanpur",
+    "countryCode": "IND",
+    "capacity": 25000,
+    "tenantClubs": []
+  },
+  {
+    "id": "kochi-haruno-athletic-stadium",
+    "name": "Kochi Haruno Athletic Stadium",
+    "city": null,
+    "countryCode": "JPN",
+    "capacity": 25000,
+    "tenantClubs": [
+      "kochi-united-sc"
+    ]
+  },
+  {
+    "id": "iksan-public-stadium",
+    "name": "Iksan Public Stadium",
+    "city": null,
+    "countryCode": "KOR",
+    "capacity": 25000,
+    "tenantClubs": [
+      "hallelujah-fc"
+    ]
+  },
+  {
+    "id": "xorazm-stadium",
+    "name": "Xorazm Stadium",
+    "city": null,
+    "countryCode": "UZB",
+    "capacity": 25000,
+    "tenantClubs": [
+      "fc-khorazm"
+    ]
+  },
+  {
+    "id": "estadio-reales-tamarindos",
+    "name": "Estadio Reales Tamarindos",
+    "city": null,
+    "countryCode": "ECU",
+    "capacity": 25000,
+    "tenantClubs": []
+  },
+  {
+    "id": "kuantan-singingi-sport-centre-stadium",
+    "name": "Kuantan Singingi Sport Centre Stadium",
+    "city": null,
+    "countryCode": "IDN",
+    "capacity": 25000,
+    "tenantClubs": [
+      "psps-riau"
+    ]
+  },
+  {
+    "id": "stadio-antonio-molinari",
+    "name": "Stadio Antonio Molinari",
+    "city": null,
+    "countryCode": "ITA",
+    "capacity": 25000,
+    "tenantClubs": [
+      "campobasso-fc",
+      "q126956491"
+    ]
+  },
+  {
+    "id": "enyimba-international-stadium",
+    "name": "Enyimba International Stadium",
+    "city": null,
+    "countryCode": "NGA",
+    "capacity": 25000,
+    "tenantClubs": [
+      "enyimba-international-f-c"
+    ]
+  },
+  {
+    "id": "mahabir-stadium",
+    "name": "Mahabir Stadium",
+    "city": "Hisar",
+    "countryCode": "IND",
+    "capacity": 25000,
+    "tenantClubs": []
+  },
+  {
+    "id": "nnamdi-azikiwe-stadium",
+    "name": "Nnamdi Azikiwe Stadium",
+    "city": null,
+    "countryCode": "NGA",
+    "capacity": 25000,
+    "tenantClubs": [
+      "enugu-rangers"
+    ]
+  },
+  {
+    "id": "petaling-jaya-stadium",
+    "name": "Petaling Jaya Stadium",
+    "city": "Petaling Jaya",
+    "countryCode": "MYS",
+    "capacity": 25000,
+    "tenantClubs": [
+      "airasia-f-c",
+      "felda-united-f-c"
+    ]
+  },
+  {
+    "id": "takhti-stadium-tabriz",
+    "name": "Takhti Stadium (Tabriz)",
+    "city": null,
+    "countryCode": "IRN",
+    "capacity": 25000,
+    "tenantClubs": [
+      "machine-sazi-f-c"
+    ]
+  },
+  {
+    "id": "chira-nakhon-stadium",
+    "name": "Chira Nakhon Stadium",
+    "city": null,
+    "countryCode": "THA",
+    "capacity": 25000,
+    "tenantClubs": [
+      "hat-yai-f-c"
+    ]
+  },
+  {
+    "id": "estadio-do-junco",
+    "name": "Estádio do Junco",
+    "city": null,
+    "countryCode": "BRA",
+    "capacity": 25000,
+    "tenantClubs": []
+  },
+  {
+    "id": "tun-abdul-razak-stadium",
+    "name": "Tun Abdul Razak Stadium",
+    "city": "Bandar Tun Razak, Jengka",
+    "countryCode": "MYS",
+    "capacity": 25000,
+    "tenantClubs": []
+  },
+  {
+    "id": "stadion-an-der-gellertstra-e",
+    "name": "Stadion an der Gellertstraße",
+    "city": "Gellertstraße",
+    "countryCode": "DEU",
+    "capacity": 25000,
+    "tenantClubs": [
+      "chemnitzer-fc"
+    ]
+  },
+  {
+    "id": "estadio-municipal-irmao-gino-maria-rossi",
+    "name": "Estádio Municipal Irmão Gino Maria Rossi",
+    "city": null,
+    "countryCode": "BRA",
+    "capacity": 25000,
+    "tenantClubs": []
+  },
+  {
+    "id": "q9255475",
+    "name": "Q9255475",
+    "city": null,
+    "countryCode": "BRA",
+    "capacity": 25000,
+    "tenantClubs": []
+  },
+  {
+    "id": "cegeka-arena",
+    "name": "Cegeka Arena",
+    "city": "Genk",
+    "countryCode": "BEL",
+    "capacity": 25000,
+    "tenantClubs": [
+      "jong-genk",
+      "k-r-c-genk"
+    ]
+  },
+  {
+    "id": "stade-du-28-septembre",
+    "name": "Stade du 28 Septembre",
+    "city": null,
+    "countryCode": "GIN",
+    "capacity": 25000,
+    "tenantClubs": [
+      "guinea-men-s-national-football-team"
+    ]
+  },
+  {
+    "id": "stade-8-mai-1945",
+    "name": "Stade 8 Mai 1945",
+    "city": null,
+    "countryCode": "DZA",
+    "capacity": 25000,
+    "tenantClubs": [
+      "es-setif"
+    ]
+  },
+  {
+    "id": "nogueirao",
+    "name": "Nogueirão",
+    "city": null,
+    "countryCode": "BRA",
+    "capacity": 25000,
+    "tenantClubs": []
+  },
+  {
+    "id": "estadio-domingo-burgueno",
+    "name": "Estadio Domingo Burgueño",
+    "city": null,
+    "countryCode": "URY",
+    "capacity": 25000,
+    "tenantClubs": [
+      "deportivo-maldonado"
+    ]
+  },
+  {
+    "id": "quan-khu-7-stadium",
+    "name": "Quan khu 7 Stadium",
+    "city": null,
+    "countryCode": "VNM",
+    "capacity": 25000,
+    "tenantClubs": []
+  },
+  {
+    "id": "amman-international-stadium",
+    "name": "Amman International Stadium",
+    "city": null,
+    "countryCode": "JOR",
+    "capacity": 25000,
+    "tenantClubs": [
+      "al-faisaly-sc",
+      "jordan-men-s-national-football-team"
+    ]
+  },
+  {
+    "id": "klokke-stadion",
+    "name": "Klokke Stadion",
+    "city": null,
+    "countryCode": "BEL",
+    "capacity": 25000,
+    "tenantClubs": [
+      "club-brugge-k-v"
+    ]
+  },
+  {
+    "id": "development-area-stadium",
+    "name": "Development Area Stadium",
+    "city": null,
+    "countryCode": "CHN",
+    "capacity": 25000,
+    "tenantClubs": [
+      "changchun-yatai-f-c",
+      "changchun-zhuoyue"
+    ]
+  },
+  {
+    "id": "shuangliu-sports-centre",
+    "name": "Shuangliu Sports Centre",
+    "city": "Shuangliu District",
+    "countryCode": "CHN",
+    "capacity": 25000,
+    "tenantClubs": [
+      "chengdu-rongcheng-f-c"
+    ]
+  },
+  {
+    "id": "stadium-merdeka",
+    "name": "Stadium Merdeka",
+    "city": null,
+    "countryCode": "MYS",
+    "capacity": 25000,
+    "tenantClubs": [
+      "malaysia-men-s-national-football-team"
+    ]
+  },
+  {
+    "id": "al-hilal-stadium",
+    "name": "Al-Hilal Stadium",
+    "city": null,
+    "countryCode": "SDN",
+    "capacity": 25000,
+    "tenantClubs": [
+      "al-hilal-club"
+    ]
+  },
+  {
+    "id": "q23893327",
+    "name": "Q23893327",
+    "city": null,
+    "countryCode": "DEU",
+    "capacity": 25000,
+    "tenantClubs": []
+  },
+  {
+    "id": "sugathadasa-stadium",
+    "name": "Sugathadasa Stadium",
+    "city": null,
+    "countryCode": "LKA",
+    "capacity": 25000,
+    "tenantClubs": [
+      "sri-lanka-men-s-national-football-team"
+    ]
+  },
+  {
+    "id": "olympiysky-sports-complex",
+    "name": "Olympiysky Sports Complex",
+    "city": null,
+    "countryCode": "RUS",
+    "capacity": 25000,
+    "tenantClubs": [
+      "kremlin-cup"
+    ]
+  },
+  {
+    "id": "trelawny-stadium",
+    "name": "Trelawny Stadium",
+    "city": "Trelawny Parish",
+    "countryCode": "JAM",
+    "capacity": 25000,
+    "tenantClubs": []
+  },
+  {
+    "id": "prince-mohammed-bin-abdul-aziz-stadium",
+    "name": "Prince Mohammed bin Abdul Aziz Stadium",
+    "city": null,
+    "countryCode": "SAU",
+    "capacity": 25000,
+    "tenantClubs": []
+  },
+  {
+    "id": "king-abdullah-sport-city-stadium",
+    "name": "King Abdullah Sport City Stadium",
+    "city": "Burayda",
+    "countryCode": "SAU",
+    "capacity": 25000,
+    "tenantClubs": [
+      "al-raed-fc",
+      "al-taawon-fc"
+    ]
+  },
+  {
+    "id": "bodenseestadion",
+    "name": "Bodenseestadion",
+    "city": null,
+    "countryCode": "DEU",
+    "capacity": 25000,
+    "tenantClubs": [
+      "sc-konstanz-wollmatingen"
+    ]
+  },
+  {
+    "id": "u-j-esuene-stadium",
+    "name": "U. J. Esuene Stadium",
+    "city": null,
+    "countryCode": "NGA",
+    "capacity": 25000,
+    "tenantClubs": []
+  },
+  {
+    "id": "stadion-am-bieberer-berg",
+    "name": "Stadion am Bieberer Berg",
+    "city": null,
+    "countryCode": "DEU",
+    "capacity": 25000,
+    "tenantClubs": [
+      "kickers-offenbach"
+    ]
+  },
+  {
+    "id": "q9255260",
+    "name": "Q9255260",
+    "city": null,
+    "countryCode": "BRA",
+    "capacity": 25000,
+    "tenantClubs": []
+  },
+  {
+    "id": "ivaylo-stadium",
+    "name": "Ivaylo Stadium",
+    "city": "Veliko Tarnovo",
+    "countryCode": "BGR",
+    "capacity": 25000,
+    "tenantClubs": [
+      "f-c-etar"
+    ]
+  },
+  {
+    "id": "stade-messaoud-zougar",
+    "name": "Stade Messaoud-Zougar",
+    "city": null,
+    "countryCode": "DZA",
+    "capacity": 25000,
+    "tenantClubs": [
+      "mc-el-eulma"
+    ]
+  },
+  {
+    "id": "stade-jules-lemaire",
+    "name": "Stade Jules Lemaire",
+    "city": null,
+    "countryCode": "FRA",
+    "capacity": 25000,
+    "tenantClubs": [
+      "sc-fives"
+    ]
+  },
+  {
+    "id": "estadio-departamental-libertad",
+    "name": "Estadio Departamental Libertad",
+    "city": "Pasto",
+    "countryCode": "COL",
+    "capacity": 25000,
+    "tenantClubs": [
+      "deportivo-pasto"
+    ]
+  },
+  {
+    "id": "q9186140",
+    "name": "Q9186140",
+    "city": null,
+    "countryCode": "BRA",
+    "capacity": 25000,
+    "tenantClubs": []
+  },
+  {
+    "id": "hfc-bank-stadium",
+    "name": "HFC Bank Stadium",
+    "city": "Suva",
+    "countryCode": "FJI",
+    "capacity": 25000,
+    "tenantClubs": [
+      "cook-islands-women-s-national-football-team",
+      "fiji-men-s-national-football-team"
+    ]
+  },
+  {
+    "id": "lawson-tama-stadium",
+    "name": "Lawson Tama Stadium",
+    "city": null,
+    "countryCode": "SLB",
+    "capacity": 25000,
+    "tenantClubs": [
+      "solomon-islands-men-s-national-football-team"
+    ]
+  },
+  {
+    "id": "uhuru-stadium",
+    "name": "Uhuru Stadium",
+    "city": "Kurasini",
+    "countryCode": "TZA",
+    "capacity": 25000,
+    "tenantClubs": []
+  },
+  {
+    "id": "estadio-e-torres-belon",
+    "name": "Estadio E. Torres Belón",
+    "city": null,
+    "countryCode": "PER",
+    "capacity": 25000,
+    "tenantClubs": [
+      "alfonso-ugarte-de-puno"
+    ]
+  },
+  {
+    "id": "petrokimia-stadium",
+    "name": "Petrokimia Stadium",
+    "city": "Gresik",
+    "countryCode": "IDN",
+    "capacity": 25000,
+    "tenantClubs": [
+      "persegres-gresik-united"
+    ]
+  },
+  {
+    "id": "stade-du-hainaut",
+    "name": "Stade du Hainaut",
+    "city": null,
+    "countryCode": "FRA",
+    "capacity": 25000,
+    "tenantClubs": [
+      "valenciennes-f-c"
+    ]
+  },
+  {
+    "id": "hazza-bin-zayed-stadium",
+    "name": "Hazza bin Zayed Stadium",
+    "city": "Al Ain",
+    "countryCode": "ARE",
+    "capacity": 25000,
+    "tenantClubs": [
+      "al-ain-fc"
+    ]
+  },
+  {
+    "id": "yakubu-gowon-stadium",
+    "name": "Yakubu Gowon Stadium",
+    "city": null,
+    "countryCode": "NGA",
+    "capacity": 25000,
+    "tenantClubs": [
+      "dolphins-f-c"
+    ]
+  },
+  {
+    "id": "sani-abacha-stadium",
+    "name": "Sani Abacha Stadium",
+    "city": "Kano",
+    "countryCode": "NGA",
+    "capacity": 25000,
+    "tenantClubs": [
+      "kano-pillars-f-c"
+    ]
+  },
+  {
+    "id": "new-laos-national-stadium",
+    "name": "New Laos National Stadium",
+    "city": null,
+    "countryCode": "LAO",
+    "capacity": 25000,
+    "tenantClubs": [
+      "2009-southeast-asian-games"
+    ]
+  },
+  {
+    "id": "estadio-ricardo-saprissa-ayma",
+    "name": "Estadio Ricardo Saprissa Aymá",
+    "city": null,
+    "countryCode": "CRI",
+    "capacity": 25000,
+    "tenantClubs": [
+      "deportivo-saprissa"
+    ]
+  },
+  {
+    "id": "estadio-luis-troccoli",
+    "name": "Estadio Luis Tróccoli",
+    "city": null,
+    "countryCode": "URY",
+    "capacity": 25000,
+    "tenantClubs": [
+      "c-a-cerro"
+    ]
+  },
+  {
+    "id": "the-darlington-arena",
+    "name": "The Darlington Arena",
+    "city": "Darlington",
+    "countryCode": "GBR",
+    "capacity": 25000,
+    "tenantClubs": [
+      "darlington-f-c"
+    ]
+  },
+  {
+    "id": "americo-montanini-stadium",
+    "name": "Américo Montanini Stadium",
+    "city": null,
+    "countryCode": "COL",
+    "capacity": 25000,
+    "tenantClubs": [
+      "atletico-bucaramanga"
+    ]
+  },
+  {
+    "id": "stadio-pino-zaccheria",
+    "name": "Stadio Pino Zaccheria",
+    "city": null,
+    "countryCode": "ITA",
+    "capacity": 25000,
+    "tenantClubs": [
+      "calcio-foggia-1920"
+    ]
+  },
+  {
+    "id": "bassel-al-assad-stadium-homs",
+    "name": "Bassel al-Assad Stadium (Homs)",
+    "city": null,
+    "countryCode": "SYR",
+    "capacity": 25000,
+    "tenantClubs": []
+  },
+  {
+    "id": "unique-san-nicolas-stadium",
+    "name": "Unique San Nicolás Stadium",
+    "city": "San Nicolás, Buenos Aires",
+    "countryCode": "ARG",
+    "capacity": 25000,
+    "tenantClubs": []
+  },
+  {
+    "id": "heiwadai-athletic-stadium",
+    "name": "Heiwadai Athletic Stadium",
+    "city": null,
+    "countryCode": "JPN",
+    "capacity": 25000,
+    "tenantClubs": []
+  },
+  {
+    "id": "iwate-prefectural-baseball-stadium",
+    "name": "Iwate Prefectural Baseball Stadium",
+    "city": null,
+    "countryCode": "JPN",
+    "capacity": 25000,
+    "tenantClubs": []
+  },
+  {
+    "id": "changlimithang-stadium",
+    "name": "Changlimithang Stadium",
+    "city": null,
+    "countryCode": "BTN",
+    "capacity": 25000,
+    "tenantClubs": [
+      "bhutan-men-s-national-football-team",
+      "druk-pol-fc",
+      "druk-star-f-c",
+      "thimphu-city-fc"
+    ]
+  },
+  {
+    "id": "estadio-waldemiro-wagner",
+    "name": "Estádio Waldemiro Wagner",
+    "city": null,
+    "countryCode": "BRA",
+    "capacity": 25000,
+    "tenantClubs": [
+      "atletico-clube-paranavai"
+    ]
+  },
+  {
+    "id": "imam-reza-stadium",
+    "name": "Imam Reza Stadium",
+    "city": null,
+    "countryCode": "IRN",
+    "capacity": 25000,
+    "tenantClubs": [
+      "shahr-khodro-f-c"
+    ]
+  },
+  {
+    "id": "stadio-ciro-vigorito",
+    "name": "Stadio Ciro Vigorito",
+    "city": null,
+    "countryCode": "ITA",
+    "capacity": 25000,
+    "tenantClubs": [
+      "benevento-calcio"
+    ]
+  },
+  {
+    "id": "etihad-park",
+    "name": "Etihad Park",
+    "city": "Willets Point",
+    "countryCode": "USA",
+    "capacity": 25000,
+    "tenantClubs": [
+      "new-york-city-fc"
+    ]
+  },
+  {
+    "id": "q2291675",
+    "name": "Q2291675",
+    "city": null,
+    "countryCode": "DEU",
+    "capacity": 25000,
+    "tenantClubs": [
+      "sv-motor-altenburg"
+    ]
+  },
+  {
+    "id": "queen-s-park-oval-port-of-spain",
+    "name": "Queen's Park Oval, Port of Spain",
+    "city": null,
+    "countryCode": "TTO",
+    "capacity": 25000,
+    "tenantClubs": [
+      "trinidad-and-tobago-national-cricket-team"
+    ]
+  },
+  {
+    "id": "q9341123",
+    "name": "Q9341123",
+    "city": null,
+    "countryCode": "POL",
+    "capacity": 25000,
+    "tenantClubs": [
+      "garbarnia-krakow"
+    ]
+  },
+  {
+    "id": "biju-patnaik-hockey-stadium",
+    "name": "Biju Patnaik Hockey Stadium",
+    "city": null,
+    "countryCode": "IND",
+    "capacity": 25000,
+    "tenantClubs": [
+      "india-men-s-national-field-hockey-team"
+    ]
+  },
+  {
+    "id": "letzigrund",
+    "name": "Letzigrund",
+    "city": "Zurich",
+    "countryCode": "CHE",
+    "capacity": 25000,
+    "tenantClubs": [
+      "fc-zurich"
+    ]
+  },
+  {
+    "id": "parque-asturias",
+    "name": "Parque Asturias",
+    "city": null,
+    "countryCode": "MEX",
+    "capacity": 25000,
+    "tenantClubs": [
+      "asturias-f-c"
+    ]
+  },
+  {
+    "id": "thong-nhat-stadium",
+    "name": "Thong Nhat Stadium",
+    "city": null,
+    "countryCode": "VNM",
+    "capacity": 25000,
+    "tenantClubs": [
+      "ho-chi-minh-city-f-c",
+      "sai-gon-f-c"
+    ]
+  },
+  {
+    "id": "ksu-stadium",
+    "name": "KSU Stadium",
+    "city": null,
+    "countryCode": "SAU",
+    "capacity": 25000,
+    "tenantClubs": [
+      "al-nassr"
+    ]
+  },
+  {
+    "id": "tsk-stadion",
+    "name": "TSK stadion",
+    "city": null,
+    "countryCode": "RUS",
+    "capacity": 25000,
+    "tenantClubs": [
+      "fc-ryazan"
+    ]
+  },
+  {
+    "id": "bir-shreshtha-mustafa-kamal-stadium",
+    "name": "Bir Shreshtha Mustafa Kamal Stadium",
+    "city": null,
+    "countryCode": "BGD",
+    "capacity": 25000,
+    "tenantClubs": []
+  },
+  {
+    "id": "mandala-krida-stadium",
+    "name": "Mandala Krida Stadium",
+    "city": "Yogyakarta",
+    "countryCode": "IDN",
+    "capacity": 25000,
+    "tenantClubs": []
+  },
+  {
+    "id": "stadion",
+    "name": "Stadion",
+    "city": null,
+    "countryCode": "DEU",
+    "capacity": 25000,
+    "tenantClubs": []
+  },
+  {
+    "id": "obafemi-awolowo-stadium",
+    "name": "Obafemi Awolowo Stadium",
+    "city": null,
+    "countryCode": "NGA",
+    "capacity": 25000,
+    "tenantClubs": [
+      "shooting-stars-sc"
+    ]
+  },
+  {
+    "id": "sporting-park",
+    "name": "Sporting Park",
+    "city": "Kansas City",
+    "countryCode": "USA",
+    "capacity": 25000,
+    "tenantClubs": [
+      "fc-kansas-city",
+      "kansas-city-current",
+      "sporting-kansas-city",
+      "sporting-kansas-city-ii"
+    ]
+  },
+  {
+    "id": "shohada-stadium-qods",
+    "name": "Shohada Stadium (Qods)",
+    "city": "Qods",
+    "countryCode": "IRN",
+    "capacity": 25000,
+    "tenantClubs": [
+      "paykan-f-c"
+    ]
+  },
+  {
+    "id": "kaharudin-nasution-rumbai-stadium",
+    "name": "Kaharudin Nasution Rumbai Stadium",
+    "city": "Pekanbaru",
+    "countryCode": "IDN",
+    "capacity": 25000,
+    "tenantClubs": [
+      "psps-riau",
+      "tornado-f-c"
+    ]
+  },
+  {
+    "id": "lithuania-national-stadium",
+    "name": "Lithuania National Stadium",
+    "city": null,
+    "countryCode": "LTU",
+    "capacity": 25000,
+    "tenantClubs": []
+  },
+  {
+    "id": "abubarkar-tafawa-balewa-stadium",
+    "name": "Abubarkar Tafawa Balewa Stadium",
+    "city": null,
+    "countryCode": "NGA",
+    "capacity": 25000,
+    "tenantClubs": [
+      "wikki-tourists-f-c"
+    ]
+  },
+  {
+    "id": "estadio-fragata-presidente-sarmiento",
+    "name": "Estadio Fragata Presidente Sarmiento",
+    "city": null,
+    "countryCode": "ARG",
+    "capacity": 25000,
+    "tenantClubs": [
+      "club-almirante-brown"
+    ]
+  },
+  {
+    "id": "dsc-cricket-stadium",
+    "name": "DSC Cricket Stadium",
+    "city": "Dubai Sports City",
+    "countryCode": "ARE",
+    "capacity": 25000,
+    "tenantClubs": []
+  },
+  {
+    "id": "cramton-bowl",
+    "name": "Cramton Bowl",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 25000,
+    "tenantClubs": [
+      "salute-to-veterans-bowl"
+    ]
+  },
+  {
+    "id": "centennial-stadium-resistencia",
+    "name": "Centennial Stadium, Resistencia",
+    "city": null,
+    "countryCode": "ARG",
+    "capacity": 25000,
+    "tenantClubs": [
+      "club-atletico-sarmiento-resistencia"
+    ]
+  },
+  {
+    "id": "benteng-stadium",
+    "name": "Benteng Stadium",
+    "city": null,
+    "countryCode": "IDN",
+    "capacity": 25000,
+    "tenantClubs": [
+      "persikota-tangerang"
+    ]
+  },
+  {
+    "id": "suez-stadium",
+    "name": "Suez Stadium",
+    "city": "Suez",
+    "countryCode": "EGY",
+    "capacity": 25000,
+    "tenantClubs": [
+      "petrojet-fc"
+    ]
+  },
+  {
+    "id": "hasakah-municipal-stadium",
+    "name": "Hasakah Municipal Stadium",
+    "city": null,
+    "countryCode": "SYR",
+    "capacity": 25000,
+    "tenantClubs": [
+      "al-jazeera-sc-hasakah"
+    ]
+  },
+  {
+    "id": "asiut-university-stadium",
+    "name": "Asiut University Stadium",
+    "city": null,
+    "countryCode": "EGY",
+    "capacity": 25000,
+    "tenantClubs": [
+      "asyut-petroleum"
+    ]
+  },
+  {
+    "id": "stade-mohamed-boumezrag",
+    "name": "Stade Mohamed Boumezrag",
+    "city": null,
+    "countryCode": "DZA",
+    "capacity": 25000,
+    "tenantClubs": [
+      "aso-chlef"
+    ]
+  },
+  {
+    "id": "siliwangi-stadium",
+    "name": "Siliwangi Stadium",
+    "city": "Bandung",
+    "countryCode": "IDN",
+    "capacity": 25000,
+    "tenantClubs": [
+      "persib-bandung"
+    ]
+  },
+  {
+    "id": "sydney-showground-stadium",
+    "name": "Sydney Showground Stadium",
+    "city": "Sydney Olympic Park",
+    "countryCode": "AUS",
+    "capacity": 25000,
+    "tenantClubs": [
+      "greater-western-sydney-giants",
+      "sydney-royal-easter-show",
+      "sydney-thunder"
+    ]
+  },
+  {
+    "id": "akita-prefectural-baseball-stadium",
+    "name": "Akita Prefectural Baseball Stadium",
+    "city": null,
+    "countryCode": "JPN",
+    "capacity": 25000,
+    "tenantClubs": [
+      "japanese-high-school-baseball-championship"
+    ]
+  },
+  {
+    "id": "estadio-juan-carlos-duran",
+    "name": "Estadio Juan Carlos Durán",
+    "city": "Santa Cruz de la Sierra",
+    "countryCode": "BOL",
+    "capacity": 25000,
+    "tenantClubs": [
+      "real-santa-cruz"
+    ]
+  },
+  {
+    "id": "20-years-of-independence-stadium",
+    "name": "20 Years of Independence Stadium",
+    "city": null,
+    "countryCode": "TJK",
+    "capacity": 25000,
+    "tenantClubs": [
+      "fk-khujand"
+    ]
+  },
+  {
+    "id": "independence-stadium-nam",
+    "name": "Independence Stadium",
+    "city": null,
+    "countryCode": "NAM",
+    "capacity": 25000,
+    "tenantClubs": []
+  },
+  {
+    "id": "bo-stadium",
+    "name": "Bo Stadium",
+    "city": "Bo",
+    "countryCode": "SLE",
+    "capacity": 25000,
+    "tenantClubs": [
+      "sierra-leone-men-s-national-football-team"
+    ]
+  },
+  {
+    "id": "pohang-steel-yard",
+    "name": "Pohang Steel Yard",
+    "city": null,
+    "countryCode": "KOR",
+    "capacity": 25000,
+    "tenantClubs": [
+      "fc-pohang-steelers"
+    ]
+  },
+  {
+    "id": "belmore-sports-ground",
+    "name": "Belmore Sports Ground",
+    "city": "Belmore",
+    "countryCode": "AUS",
+    "capacity": 25000,
+    "tenantClubs": [
+      "canterbury-bankstown-bulldogs",
+      "sydney-olympic-fc"
+    ]
+  },
+  {
+    "id": "stadio-flaminio",
+    "name": "Stadio Flaminio",
+    "city": "Rome",
+    "countryCode": "ITA",
+    "capacity": 24973,
+    "tenantClubs": [
+      "a-s-lodigiani",
+      "as-roma",
+      "atletico-roma-f-c",
+      "italian-football-federation",
+      "italian-rugby-federation",
+      "rugby-roma",
+      "s-s-lazio-marines",
+      "ss-lazio",
+      "unione-rugby-capitolina"
+    ]
+  },
+  {
+    "id": "stadio-atleti-azzurri-d-italia",
+    "name": "Stadio Atleti Azzurri d'Italia",
+    "city": null,
+    "countryCode": "ITA",
+    "capacity": 24950,
+    "tenantClubs": [
+      "atalanta-bc"
+    ]
+  },
+  {
+    "id": "estadio-olimpico",
+    "name": "Estadio Olímpico",
+    "city": null,
+    "countryCode": "VEN",
+    "capacity": 24900,
+    "tenantClubs": [
+      "caracas-futbol-club",
+      "deportivo-la-guaira-f-c",
+      "metropolitanos-fc",
+      "universidad-central-de-venezuela-futbol-club"
+    ]
+  },
+  {
+    "id": "estadio-de-la-ceramica",
+    "name": "Estadio de la Cerámica",
+    "city": "Villarreal",
+    "countryCode": "ESP",
+    "capacity": 24891,
+    "tenantClubs": [
+      "villarreal-cf"
+    ]
+  },
+  {
+    "id": "bridgeforth-stadium-and-zane-showker-field",
+    "name": "Bridgeforth Stadium and Zane Showker Field",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 24877,
+    "tenantClubs": [
+      "james-madison-dukes"
+    ]
+  },
+  {
+    "id": "chichibunomiya-rugby-stadium",
+    "name": "Chichibunomiya Rugby Stadium",
+    "city": "Meiji Shrine Outer Garden",
+    "countryCode": "JPN",
+    "capacity": 24871,
+    "tenantClubs": [
+      "japan-national-rugby-union-team"
+    ]
+  },
+  {
+    "id": "oleksiy-butovskyi-vorskla-stadium",
+    "name": "Oleksiy Butovskyi Vorskla Stadium",
+    "city": "Poltava",
+    "countryCode": "UKR",
+    "capacity": 24795,
+    "tenantClubs": [
+      "fc-vorskla-poltava"
+    ]
+  },
+  {
+    "id": "estadio-jose-rico-perez",
+    "name": "Estadio José Rico Pérez",
+    "city": "Alicante",
+    "countryCode": "ESP",
+    "capacity": 24704,
+    "tenantClubs": [
+      "hercules-cf"
+    ]
+  },
+  {
+    "id": "estadio-max-augustin",
+    "name": "Estadio Max Augustín",
+    "city": null,
+    "countryCode": "PER",
+    "capacity": 24576,
+    "tenantClubs": [
+      "colegio-nacional-iquitos"
+    ]
+  },
+  {
+    "id": "charles-schwab-field-omaha",
+    "name": "Charles Schwab Field Omaha",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 24505,
+    "tenantClubs": [
+      "men-s-college-world-series"
+    ]
+  },
+  {
+    "id": "estadio-elias-aguirre",
+    "name": "Estadio Elías Aguirre",
+    "city": "Chiclayo",
+    "countryCode": "PER",
+    "capacity": 24500,
+    "tenantClubs": [
+      "club-juan-aurich"
+    ]
+  },
+  {
+    "id": "kirklees-stadium",
+    "name": "Kirklees Stadium",
+    "city": "Huddersfield",
+    "countryCode": "GBR",
+    "capacity": 24500,
+    "tenantClubs": [
+      "huddersfield-giants",
+      "huddersfield-town-a-f-c"
+    ]
+  },
+  {
+    "id": "kimiidera-athletic-stadium",
+    "name": "Kimiidera Athletic Stadium",
+    "city": "Wakayama",
+    "countryCode": "JPN",
+    "capacity": 24500,
+    "tenantClubs": []
+  },
+  {
+    "id": "deepdale",
+    "name": "Deepdale",
+    "city": null,
+    "countryCode": "GBR",
+    "capacity": 24500,
+    "tenantClubs": [
+      "chorley-lynx",
+      "preston-north-end-f-c"
+    ]
+  },
+  {
+    "id": "tosu-stadium",
+    "name": "Tosu Stadium",
+    "city": null,
+    "countryCode": "JPN",
+    "capacity": 24490,
+    "tenantClubs": [
+      "sagan-tosu"
+    ]
+  },
+  {
+    "id": "estadio-huancayo",
+    "name": "Estadio Huancayo",
+    "city": null,
+    "countryCode": "PER",
+    "capacity": 24450,
+    "tenantClubs": [
+      "sport-huancayo"
+    ]
+  },
+  {
+    "id": "ferro-carril-oeste-stadium",
+    "name": "Ferro Carril Oeste Stadium",
+    "city": "Caballito",
+    "countryCode": "ARG",
+    "capacity": 24442,
+    "tenantClubs": [
+      "argentina-national-rugby-union-team",
+      "argentinos-juniors",
+      "ferro-carril-oeste",
+      "ferro-carril-oeste-women"
+    ]
+  },
+  {
+    "id": "eintracht-stadion",
+    "name": "Eintracht-Stadion",
+    "city": "Brunswick",
+    "countryCode": "DEU",
+    "capacity": 24406,
+    "tenantClubs": [
+      "eintracht-braunschweig"
+    ]
+  },
+  {
+    "id": "stadium-meteor",
+    "name": "Stadium Meteor",
+    "city": null,
+    "countryCode": "UKR",
+    "capacity": 24381,
+    "tenantClubs": [
+      "fc-dnipro",
+      "fc-dnipro-75"
+    ]
+  },
+  {
+    "id": "busan-gudeok-stadium",
+    "name": "Busan Gudeok Stadium",
+    "city": null,
+    "countryCode": "KOR",
+    "capacity": 24363,
+    "tenantClubs": [
+      "football-at-the-1988-summer-olympics"
+    ]
+  },
+  {
+    "id": "center-parc-stadium",
+    "name": "Center Parc Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 24333,
+    "tenantClubs": [
+      "atlanta-legends",
+      "georgia-state-panthers",
+      "georgia-state-panthers-football"
+    ]
+  },
+  {
+    "id": "teslim-balogun-stadium",
+    "name": "Teslim Balogun Stadium",
+    "city": null,
+    "countryCode": "NGA",
+    "capacity": 24325,
+    "tenantClubs": []
+  },
+  {
+    "id": "paulson-stadium",
+    "name": "Paulson Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 24300,
+    "tenantClubs": [
+      "georgia-southern-eagles"
+    ]
+  },
+  {
+    "id": "argentine",
+    "name": "Argentine",
+    "city": "Salta",
+    "countryCode": "ARG",
+    "capacity": 24300,
+    "tenantClubs": [
+      "gimnasia-y-tiro"
+    ]
+  },
+  {
+    "id": "yager-stadium",
+    "name": "Yager Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 24286,
+    "tenantClubs": [
+      "miami-redhawks",
+      "miami-redhawks-football"
+    ]
+  },
+  {
+    "id": "huseyin-avni-aker-stadium",
+    "name": "Hüseyin Avni Aker Stadium",
+    "city": null,
+    "countryCode": "TUR",
+    "capacity": 24169,
+    "tenantClubs": [
+      "trabzonspor"
+    ]
+  },
+  {
+    "id": "madejski-stadium",
+    "name": "Madejski Stadium",
+    "city": null,
+    "countryCode": "GBR",
+    "capacity": 24161,
+    "tenantClubs": [
+      "reading-f-c",
+      "reading-f-c-women"
+    ]
+  },
+  {
+    "id": "diego-armando-maradona-stadium",
+    "name": "Diego Armando Maradona Stadium",
+    "city": "Villa General Mitre",
+    "countryCode": "ARG",
+    "capacity": 24000,
+    "tenantClubs": [
+      "argentinos-juniors",
+      "argentinos-juniors-women"
+    ]
+  },
+  {
+    "id": "audi-field",
+    "name": "Audi Field",
+    "city": "Buzzard Point",
+    "countryCode": "USA",
+    "capacity": 24000,
+    "tenantClubs": [
+      "d-c-united",
+      "dc-defenders",
+      "washington-spirit"
+    ]
+  },
+  {
+    "id": "q125963312",
+    "name": "Q125963312",
+    "city": null,
+    "countryCode": "BOL",
+    "capacity": 24000,
+    "tenantClubs": []
+  },
+  {
+    "id": "dreisamstadion",
+    "name": "Dreisamstadion",
+    "city": null,
+    "countryCode": "DEU",
+    "capacity": 24000,
+    "tenantClubs": [
+      "sc-freiburg",
+      "sc-freiburg-ii"
+    ]
+  },
+  {
+    "id": "pamir-stadium",
+    "name": "Pamir Stadium",
+    "city": null,
+    "countryCode": "TJK",
+    "capacity": 24000,
+    "tenantClubs": [
+      "tajikistan-men-s-national-football-team"
+    ]
+  },
+  {
+    "id": "coliseo-live",
+    "name": "Coliseo Live",
+    "city": null,
+    "countryCode": "COL",
+    "capacity": 24000,
+    "tenantClubs": []
+  },
+  {
+    "id": "matsue-athletic-stadium",
+    "name": "Matsue Athletic Stadium",
+    "city": null,
+    "countryCode": "JPN",
+    "capacity": 24000,
+    "tenantClubs": []
+  },
+  {
+    "id": "23-de-agosto-stadium",
+    "name": "23 de Agosto Stadium",
+    "city": null,
+    "countryCode": "ARG",
+    "capacity": 24000,
+    "tenantClubs": [
+      "gimnasia-y-esgrima-de-jujuy"
+    ]
+  },
+  {
+    "id": "jsu-stadium",
+    "name": "JSU Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 24000,
+    "tenantClubs": [
+      "jacksonville-state-gamecocks",
+      "jacksonville-state-gamecocks-football"
+    ]
+  },
+  {
+    "id": "stade-24-novembre",
+    "name": "Stade 24 Novembre",
+    "city": null,
+    "countryCode": "COD",
+    "capacity": 24000,
+    "tenantClubs": [
+      "daring-club-motema-pembe"
+    ]
+  },
+  {
+    "id": "bahrain-national-stadium",
+    "name": "Bahrain National Stadium",
+    "city": "Riffa",
+    "countryCode": "BHR",
+    "capacity": 24000,
+    "tenantClubs": [
+      "bahrain-men-s-national-football-team"
+    ]
+  },
+  {
+    "id": "stadio-silvio-appiani",
+    "name": "Stadio Silvio Appiani",
+    "city": null,
+    "countryCode": "ITA",
+    "capacity": 24000,
+    "tenantClubs": [
+      "calcio-padova"
+    ]
+  },
+  {
+    "id": "kenan-memorial-stadium",
+    "name": "Kenan Memorial Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 24000,
+    "tenantClubs": [
+      "north-carolina-tar-heels"
+    ]
+  },
+  {
+    "id": "peden-stadium",
+    "name": "Peden Stadium",
+    "city": "Ohio University",
+    "countryCode": "USA",
+    "capacity": 24000,
+    "tenantClubs": [
+      "ohio-bobcats"
+    ]
+  },
+  {
+    "id": "dobsonville-stadium",
+    "name": "Dobsonville Stadium",
+    "city": null,
+    "countryCode": "ZAF",
+    "capacity": 24000,
+    "tenantClubs": [
+      "moroka-swallows-f-c"
+    ]
+  },
+  {
+    "id": "estadio-mansiche",
+    "name": "Estadio Mansiche",
+    "city": null,
+    "countryCode": "PER",
+    "capacity": 24000,
+    "tenantClubs": [
+      "cd-universidad-cesar-vallejo"
+    ]
+  },
+  {
+    "id": "mie-prefecture-arena",
+    "name": "Mie Prefecture Arena",
+    "city": null,
+    "countryCode": "JPN",
+    "capacity": 24000,
+    "tenantClubs": []
+  },
+  {
+    "id": "shimonoseki-stadium",
+    "name": "Shimonoseki Stadium",
+    "city": null,
+    "countryCode": "JPN",
+    "capacity": 23939,
+    "tenantClubs": []
+  },
+  {
+    "id": "estadio-dr-magalhaes-pessoa",
+    "name": "Estádio Dr. Magalhães Pessoa",
+    "city": "Leiria",
+    "countryCode": "PRT",
+    "capacity": 23888,
+    "tenantClubs": [
+      "u-d-leiria"
+    ]
+  },
+  {
+    "id": "stadio-dino-manuzzi",
+    "name": "Stadio Dino Manuzzi",
+    "city": null,
+    "countryCode": "ITA",
+    "capacity": 23860,
+    "tenantClubs": [
+      "cesena-fc"
+    ]
+  },
+  {
+    "id": "kurt-wabbel-stadion",
+    "name": "Kurt-Wabbel-Stadion",
+    "city": null,
+    "countryCode": "DEU",
+    "capacity": 23860,
+    "tenantClubs": [
+      "hallescher-fc"
+    ]
+  },
+  {
+    "id": "almaty-central-stadium",
+    "name": "Almaty Central Stadium",
+    "city": null,
+    "countryCode": "KAZ",
+    "capacity": 23804,
+    "tenantClubs": [
+      "fc-kairat"
+    ]
+  },
+  {
+    "id": "las-ventas",
+    "name": "Las Ventas",
+    "city": null,
+    "countryCode": "ESP",
+    "capacity": 23798,
+    "tenantClubs": []
+  },
+  {
+    "id": "stadion-galgenwaard",
+    "name": "Stadion Galgenwaard",
+    "city": null,
+    "countryCode": null,
+    "capacity": 23750,
+    "tenantClubs": [
+      "fc-utrecht",
+      "velox"
+    ]
+  },
+  {
+    "id": "kaz-m-karabekir-stadium",
+    "name": "Kazım Karabekir Stadium",
+    "city": null,
+    "countryCode": "TUR",
+    "capacity": 23700,
+    "tenantClubs": []
+  },
+  {
+    "id": "huskie-stadium",
+    "name": "Huskie Stadium",
+    "city": "Northern Illinois University",
+    "countryCode": "USA",
+    "capacity": 23595,
+    "tenantClubs": [
+      "northern-illinois-huskies-football"
+    ]
+  },
+  {
+    "id": "pampeloponnisiako-stadium",
+    "name": "Pampeloponnisiako Stadium",
+    "city": "Koukouli, Patras",
+    "countryCode": "GRC",
+    "capacity": 23588,
+    "tenantClubs": [
+      "panachaiki-f-c"
+    ]
+  },
+  {
+    "id": "el-sadar-stadium",
+    "name": "El Sadar Stadium",
+    "city": "Pamplona",
+    "countryCode": "ESP",
+    "capacity": 23576,
+    "tenantClubs": [
+      "club-atletico-osasuna"
+    ]
+  },
+  {
+    "id": "ismailia-stadium",
+    "name": "Ismailia Stadium",
+    "city": null,
+    "countryCode": "EGY",
+    "capacity": 23525,
+    "tenantClubs": [
+      "ismaily-sc"
+    ]
+  },
+  {
+    "id": "united-center",
+    "name": "United Center",
+    "city": "Chicago",
+    "countryCode": "USA",
+    "capacity": 23500,
+    "tenantClubs": [
+      "chicago-blackhawks",
+      "chicago-bulls"
+    ]
+  },
+  {
+    "id": "stadionul-dr-constantin-radulescu",
+    "name": "Stadionul Dr. Constantin Rădulescu",
+    "city": null,
+    "countryCode": "ROU",
+    "capacity": 23500,
+    "tenantClubs": [
+      "cfr-cluj"
+    ]
+  },
+  {
+    "id": "east-bengal-ground",
+    "name": "East Bengal Ground",
+    "city": "Maidan",
+    "countryCode": "IND",
+    "capacity": 23500,
+    "tenantClubs": [
+      "east-bengal-club"
+    ]
+  },
+  {
+    "id": "fitton-field",
+    "name": "Fitton Field",
+    "city": "Worcester",
+    "countryCode": "USA",
+    "capacity": 23500,
+    "tenantClubs": [
+      "holy-cross-crusaders-football"
+    ]
+  },
+  {
+    "id": "presbyter-bartolome-grella-grella",
+    "name": "Presbyter Bartolomé Grella Grella",
+    "city": "Paraná",
+    "countryCode": "ARG",
+    "capacity": 23500,
+    "tenantClubs": [
+      "club-atletico-patronato"
+    ]
+  },
+  {
+    "id": "estadio-major-jose-levy-sobrinho",
+    "name": "Estádio Major José Levy Sobrinho",
+    "city": "Limeira",
+    "countryCode": "BRA",
+    "capacity": 23475,
+    "tenantClubs": [
+      "associacao-atletica-internacional"
+    ]
+  },
+  {
+    "id": "miyagi-baseball-stadium",
+    "name": "Miyagi Baseball Stadium",
+    "city": null,
+    "countryCode": "JPN",
+    "capacity": 23451,
+    "tenantClubs": [
+      "chiba-lotte-marines",
+      "tohoku-rakuten-golden-eagles"
+    ]
+  },
+  {
+    "id": "stadio-angelo-massimino",
+    "name": "Stadio Angelo Massimino",
+    "city": null,
+    "countryCode": "ITA",
+    "capacity": 23420,
+    "tenantClubs": [
+      "catania-fc"
+    ]
+  },
+  {
+    "id": "ellenfeldstadion",
+    "name": "Ellenfeldstadion",
+    "city": null,
+    "countryCode": "DEU",
+    "capacity": 23400,
+    "tenantClubs": [
+      "borussia-neunkirchen"
+    ]
+  },
+  {
+    "id": "doyt-perry-stadium",
+    "name": "Doyt Perry Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 23232,
+    "tenantClubs": [
+      "bowling-green-falcons-football"
+    ]
+  },
+  {
+    "id": "stade-louis-dugauguez",
+    "name": "Stade Louis Dugauguez",
+    "city": null,
+    "countryCode": "FRA",
+    "capacity": 23189,
+    "tenantClubs": [
+      "cs-sedan-ardennes"
+    ]
+  },
+  {
+    "id": "estadio-florencio-sola",
+    "name": "Estadio Florencio Sola",
+    "city": null,
+    "countryCode": "ARG",
+    "capacity": 23101,
+    "tenantClubs": [
+      "club-atletico-banfield"
+    ]
+  },
+  {
+    "id": "stadion-am-zoo",
+    "name": "Stadion am Zoo",
+    "city": null,
+    "countryCode": "DEU",
+    "capacity": 23067,
+    "tenantClubs": [
+      "wuppertaler-sv"
+    ]
+  },
+  {
+    "id": "army-sports-club-stadium",
+    "name": "Army Sports Club Stadium",
+    "city": null,
+    "countryCode": "UKR",
+    "capacity": 23040,
+    "tenantClubs": [
+      "fc-karpaty-2-lviv"
+    ]
+  },
+  {
+    "id": "estadio-independencia",
+    "name": "Estádio Independência",
+    "city": "Belo Horizonte",
+    "countryCode": "BRA",
+    "capacity": 23018,
+    "tenantClubs": [
+      "america-futebol-clube",
+      "clube-atletico-mineiro"
+    ]
+  },
+  {
+    "id": "oakwell",
+    "name": "Oakwell",
+    "city": null,
+    "countryCode": "GBR",
+    "capacity": 23009,
+    "tenantClubs": [
+      "barnsley-f-c",
+      "sheffield-eagles"
+    ]
+  },
+  {
+    "id": "brookvale-oval",
+    "name": "Brookvale Oval",
+    "city": "Pittwater Road",
+    "countryCode": "AUS",
+    "capacity": 23000,
+    "tenantClubs": [
+      "manly-warringah-sea-eagles"
+    ]
+  },
+  {
+    "id": "suphanburi-municipality-stadium",
+    "name": "Suphanburi Municipality Stadium",
+    "city": null,
+    "countryCode": "THA",
+    "capacity": 23000,
+    "tenantClubs": [
+      "suphanburi-f-c"
+    ]
+  },
+  {
+    "id": "oppenheimer-stadium",
+    "name": "Oppenheimer Stadium",
+    "city": null,
+    "countryCode": "ZAF",
+    "capacity": 23000,
+    "tenantClubs": []
+  },
+  {
+    "id": "q2147912",
+    "name": "Q2147912",
+    "city": null,
+    "countryCode": "DEU",
+    "capacity": 23000,
+    "tenantClubs": [
+      "msv-moers"
+    ]
+  },
+  {
+    "id": "q5847768",
+    "name": "Q5847768",
+    "city": null,
+    "countryCode": "ARG",
+    "capacity": 23000,
+    "tenantClubs": []
+  },
+  {
+    "id": "estadio-carlos-gonzalez",
+    "name": "Estadio Carlos González",
+    "city": null,
+    "countryCode": "MEX",
+    "capacity": 23000,
+    "tenantClubs": [
+      "dorados-de-sinaloa"
+    ]
+  },
+  {
+    "id": "alamo-stadium",
+    "name": "Alamo Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 23000,
+    "tenantClubs": []
+  },
+  {
+    "id": "nicolae-rainea-stadium",
+    "name": "Nicolae Rainea Stadium",
+    "city": "Galați County",
+    "countryCode": "ROU",
+    "capacity": 23000,
+    "tenantClubs": [
+      "sc-otelul-galati"
+    ]
+  },
+  {
+    "id": "spartak-stadium",
+    "name": "Spartak Stadium",
+    "city": null,
+    "countryCode": "KGZ",
+    "capacity": 23000,
+    "tenantClubs": [
+      "kyrgyzstan-men-s-national-football-team"
+    ]
+  },
+  {
+    "id": "estadio-elias-figueroa-brander",
+    "name": "Estadio Elías Figueroa Brander",
+    "city": null,
+    "countryCode": "CHL",
+    "capacity": 23000,
+    "tenantClubs": [
+      "santiago-wanderers"
+    ]
+  },
+  {
+    "id": "estadio-eduardo-santos",
+    "name": "Estadio Eduardo Santos",
+    "city": "Santa Marta",
+    "countryCode": "COL",
+    "capacity": 23000,
+    "tenantClubs": [
+      "union-magdalena"
+    ]
+  },
+  {
+    "id": "amphitheater-of-nimes",
+    "name": "Amphitheater of Nîmes",
+    "city": null,
+    "countryCode": "FRA",
+    "capacity": 23000,
+    "tenantClubs": []
+  },
+  {
+    "id": "estadio-parque-artigas",
+    "name": "Estadio Parque Artigas",
+    "city": null,
+    "countryCode": "URY",
+    "capacity": 23000,
+    "tenantClubs": [
+      "paysandu-f-c"
+    ]
+  },
+  {
+    "id": "eva-peron-stadium",
+    "name": "Eva Perón Stadium",
+    "city": "Junín",
+    "countryCode": "ARG",
+    "capacity": 23000,
+    "tenantClubs": [
+      "club-atletico-sarmiento"
+    ]
+  },
+  {
+    "id": "shinnik-stadium",
+    "name": "Shinnik Stadium",
+    "city": null,
+    "countryCode": "RUS",
+    "capacity": 22990,
+    "tenantClubs": [
+      "fc-shinnik-yaroslavl"
+    ]
+  },
+  {
+    "id": "stade-mohamed-hamlaoui",
+    "name": "Stade Mohamed Hamlaoui",
+    "city": "Constantine",
+    "countryCode": "DZA",
+    "capacity": 22968,
+    "tenantClubs": [
+      "cs-constantine"
+    ]
+  },
+  {
+    "id": "abanca-balaidos-stadium",
+    "name": "Abanca Balaídos Stadium",
+    "city": null,
+    "countryCode": "ESP",
+    "capacity": 22803,
+    "tenantClubs": [
+      "rc-celta-de-vigo"
+    ]
+  },
+  {
+    "id": "q1483145",
+    "name": "Q1483145",
+    "city": null,
+    "countryCode": "DEU",
+    "capacity": 22800,
+    "tenantClubs": [
+      "stv-horst-emscher"
+    ]
+  },
+  {
+    "id": "duhok-stadium",
+    "name": "Duhok Stadium",
+    "city": null,
+    "countryCode": "IRQ",
+    "capacity": 22800,
+    "tenantClubs": [
+      "duhok-sc"
+    ]
+  },
+  {
+    "id": "kleanthis-vikelidis-stadium",
+    "name": "Kleanthis Vikelidis Stadium",
+    "city": "Thessaloniki",
+    "countryCode": "GRC",
+    "capacity": 22800,
+    "tenantClubs": [
+      "aris-thessaloniki-f-c"
+    ]
+  },
+  {
+    "id": "gsp-stadium",
+    "name": "GSP Stadium",
+    "city": "Strovolos",
+    "countryCode": "CYP",
+    "capacity": 22709,
+    "tenantClubs": [
+      "ac-omonia",
+      "apoel-f-c",
+      "cyprus-men-s-national-football-team",
+      "olympiakos-nicosia-fc"
+    ]
+  },
+  {
+    "id": "panthessaliko-stadium",
+    "name": "Panthessaliko Stadium",
+    "city": "Nea Ionia",
+    "countryCode": "GRC",
+    "capacity": 22700,
+    "tenantClubs": [
+      "volos-n-f-c"
+    ]
+  },
+  {
+    "id": "saida-municipal-stadium",
+    "name": "Saida Municipal Stadium",
+    "city": null,
+    "countryCode": "LBN",
+    "capacity": 22600,
+    "tenantClubs": []
+  },
+  {
+    "id": "arena-conda",
+    "name": "Arena Condá",
+    "city": null,
+    "countryCode": "BRA",
+    "capacity": 22600,
+    "tenantClubs": [
+      "associacao-chapecoense-de-futebol"
+    ]
+  },
+  {
+    "id": "historic-crew-stadium",
+    "name": "Historic Crew Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 22555,
+    "tenantClubs": [
+      "columbus-crew",
+      "columbus-crew-2"
+    ]
+  },
+  {
+    "id": "euroborg",
+    "name": "Euroborg",
+    "city": "Groningen",
+    "countryCode": null,
+    "capacity": 22550,
+    "tenantClubs": [
+      "fc-groningen"
+    ]
+  },
+  {
+    "id": "arthur-ashe-stadium",
+    "name": "Arthur Ashe Stadium",
+    "city": "USTA Billie Jean King National Tennis Center",
+    "countryCode": "USA",
+    "capacity": 22547,
+    "tenantClubs": [
+      "us-open"
+    ]
+  },
+  {
+    "id": "turf-moor",
+    "name": "Turf Moor",
+    "city": null,
+    "countryCode": "GBR",
+    "capacity": 22546,
+    "tenantClubs": [
+      "burnley-f-c"
+    ]
+  },
+  {
+    "id": "leag-energie-stadion",
+    "name": "LEAG Energie Stadion",
+    "city": "Sandow",
+    "countryCode": "DEU",
+    "capacity": 22528,
+    "tenantClubs": [
+      "fc-energie-cottbus"
+    ]
+  },
+  {
+    "id": "estadio-gonzalo-pozo-ripalda",
+    "name": "Estadio Gonzalo Pozo Ripalda",
+    "city": null,
+    "countryCode": "ECU",
+    "capacity": 22500,
+    "tenantClubs": []
+  },
+  {
+    "id": "eleda-stadion",
+    "name": "Eleda Stadion",
+    "city": "Stadionområdet",
+    "countryCode": "SWE",
+    "capacity": 22500,
+    "tenantClubs": [
+      "malmo-ff-herr"
+    ]
+  },
+  {
+    "id": "energizer-park",
+    "name": "Energizer Park",
+    "city": "Downtown West",
+    "countryCode": "USA",
+    "capacity": 22500,
+    "tenantClubs": [
+      "st-louis-city-sc"
+    ]
+  },
+  {
+    "id": "estadio-chamartin",
+    "name": "Estadio Chamartín",
+    "city": null,
+    "countryCode": "ESP",
+    "capacity": 22500,
+    "tenantClubs": [
+      "real-madrid-club-de-futbol"
+    ]
+  },
+  {
+    "id": "hamilton-stadium",
+    "name": "Hamilton Stadium",
+    "city": "Hamilton",
+    "countryCode": "CAN",
+    "capacity": 22500,
+    "tenantClubs": [
+      "forge-fc",
+      "hamilton-tiger-cats"
+    ]
+  },
+  {
+    "id": "jack-spinks-stadium",
+    "name": "Jack Spinks Stadium",
+    "city": "Lorman",
+    "countryCode": "USA",
+    "capacity": 22500,
+    "tenantClubs": []
+  },
+  {
+    "id": "air-albania-stadium",
+    "name": "Air Albania Stadium",
+    "city": null,
+    "countryCode": "ALB",
+    "capacity": 22500,
+    "tenantClubs": []
+  },
+  {
+    "id": "penrith-stadium",
+    "name": "Penrith Stadium",
+    "city": null,
+    "countryCode": "AUS",
+    "capacity": 22500,
+    "tenantClubs": [
+      "penrith-panthers"
+    ]
+  },
+  {
+    "id": "tripoli-international-olympic-stadium",
+    "name": "Tripoli International Olympic Stadium",
+    "city": null,
+    "countryCode": "LBN",
+    "capacity": 22400,
+    "tenantClubs": []
+  },
+  {
+    "id": "tom-benson-hall-of-fame-stadium",
+    "name": "Tom Benson Hall of Fame Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 22375,
+    "tenantClubs": [
+      "canton-mckinley-high-school",
+      "malone-pioneers-football"
+    ]
+  },
+  {
+    "id": "bia-ystok-city-stadium",
+    "name": "Białystok City Stadium",
+    "city": null,
+    "countryCode": "POL",
+    "capacity": 22372,
+    "tenantClubs": [
+      "jagiellonia-bia-ystok"
+    ]
+  },
+  {
+    "id": "stadio-ennio-tardini",
+    "name": "Stadio Ennio Tardini",
+    "city": null,
+    "countryCode": "ITA",
+    "capacity": 22352,
+    "tenantClubs": [
+      "parma-calcio-1913",
+      "parma-calcio-2022"
+    ]
+  },
+  {
+    "id": "ska-arena",
+    "name": "SKA Arena",
+    "city": null,
+    "countryCode": "RUS",
+    "capacity": 22300,
+    "tenantClubs": []
+  },
+  {
+    "id": "estadio-olimpico-benito-juarez",
+    "name": "Estadio Olímpico Benito Juárez",
+    "city": null,
+    "countryCode": "MEX",
+    "capacity": 22300,
+    "tenantClubs": [
+      "fc-juarez",
+      "fc-juarez-women",
+      "indios-de-ciudad-juarez"
+    ]
+  },
+  {
+    "id": "olympic-stadium-x",
+    "name": "Olympic Stadium",
+    "city": "Amsterdam Oud-Zuid",
+    "countryCode": null,
+    "capacity": 22288,
+    "tenantClubs": [
+      "afc-ajax",
+      "blauw-wit-amsterdam",
+      "bvc-amsterdam",
+      "hera-united",
+      "phanos"
+    ]
+  },
+  {
+    "id": "prince-faisal-bin-fahd-sports-city",
+    "name": "Prince Faisal bin Fahd Sports City",
+    "city": null,
+    "countryCode": "SAU",
+    "capacity": 22250,
+    "tenantClubs": [
+      "al-hilal-sfc"
+    ]
+  },
+  {
+    "id": "houchens-industries-l-t-smith-stadium",
+    "name": "Houchens Industries–L. T. Smith Stadium",
+    "city": "Bowling Green",
+    "countryCode": "USA",
+    "capacity": 22113,
+    "tenantClubs": [
+      "western-kentucky-hilltoppers-and-lady-toppers",
+      "western-kentucky-hilltoppers-football"
+    ]
+  },
+  {
+    "id": "gradski-vrt-stadium",
+    "name": "Gradski Vrt Stadium",
+    "city": "Novi grad (Osijek)",
+    "countryCode": "HRV",
+    "capacity": 22050,
+    "tenantClubs": [
+      "nk-osijek"
+    ]
+  },
+  {
+    "id": "shell-energy-stadium",
+    "name": "Shell Energy Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 22039,
+    "tenantClubs": [
+      "houston-dash",
+      "houston-dynamo-fc",
+      "texas-southern-tigers-football"
+    ]
+  },
+  {
+    "id": "balgarska-armia-stadium",
+    "name": "Balgarska Armia Stadium",
+    "city": "Sofia",
+    "countryCode": "BGR",
+    "capacity": 22015,
+    "tenantClubs": [
+      "as-23-sofia"
+    ]
+  },
+  {
+    "id": "kasamatsu-stadium",
+    "name": "Kasamatsu Stadium",
+    "city": null,
+    "countryCode": "JPN",
+    "capacity": 22002,
+    "tenantClubs": [
+      "mito-hollyhock"
+    ]
+  },
+  {
+    "id": "barasat-stadium",
+    "name": "Barasat Stadium",
+    "city": "Barasat",
+    "countryCode": "IND",
+    "capacity": 22000,
+    "tenantClubs": [
+      "mohun-bagan-ac"
+    ]
+  },
+  {
+    "id": "q10276944",
+    "name": "Q10276944",
+    "city": null,
+    "countryCode": "BRA",
+    "capacity": 22000,
+    "tenantClubs": []
+  },
+  {
+    "id": "olen-park",
+    "name": "Olën Park",
+    "city": null,
+    "countryCode": "ZAF",
+    "capacity": 22000,
+    "tenantClubs": [
+      "platinum-city-f-c"
+    ]
+  },
+  {
+    "id": "mohammed-al-hamad-stadium",
+    "name": "Mohammed Al-Hamad Stadium",
+    "city": "Hawally",
+    "countryCode": "KWT",
+    "capacity": 22000,
+    "tenantClubs": [
+      "qadsia-sc"
+    ]
+  },
+  {
+    "id": "stade-de-franceville",
+    "name": "Stade de Franceville",
+    "city": null,
+    "countryCode": "GAB",
+    "capacity": 22000,
+    "tenantClubs": []
+  },
+  {
+    "id": "stade-de-la-cavee-verte",
+    "name": "Stade de la Cavée Verte",
+    "city": null,
+    "countryCode": "FRA",
+    "capacity": 22000,
+    "tenantClubs": [
+      "le-havre-ac"
+    ]
+  },
+  {
+    "id": "fossetts-farm-stadium",
+    "name": "Fossetts Farm Stadium",
+    "city": null,
+    "countryCode": "GBR",
+    "capacity": 22000,
+    "tenantClubs": [
+      "southend-united-f-c"
+    ]
+  },
+  {
+    "id": "intwari-stadium",
+    "name": "Intwari Stadium",
+    "city": null,
+    "countryCode": "BDI",
+    "capacity": 22000,
+    "tenantClubs": [
+      "prince-louis-f-c",
+      "vital-o-fc"
+    ]
+  },
+  {
+    "id": "botswana-national-stadium",
+    "name": "Botswana National Stadium",
+    "city": "Gaborone",
+    "countryCode": "BWA",
+    "capacity": 22000,
+    "tenantClubs": []
+  },
+  {
+    "id": "roy-kidd-stadium",
+    "name": "Roy Kidd Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 22000,
+    "tenantClubs": [
+      "eastern-kentucky-colonels-football"
+    ]
+  },
+  {
+    "id": "evgrapi-shevardnadze-stadium",
+    "name": "Evgrapi Shevardnadze Stadium",
+    "city": null,
+    "countryCode": "GEO",
+    "capacity": 22000,
+    "tenantClubs": [
+      "fc-guria-lanchkhuti"
+    ]
+  },
+  {
+    "id": "pam-brink-stadium",
+    "name": "PAM Brink Stadium",
+    "city": null,
+    "countryCode": "ZAF",
+    "capacity": 22000,
+    "tenantClubs": [
+      "thanda-royal-zulu-f-c"
+    ]
+  },
+  {
+    "id": "vicarage-road",
+    "name": "Vicarage Road",
+    "city": null,
+    "countryCode": "GBR",
+    "capacity": 22000,
+    "tenantClubs": [
+      "watford-f-c"
+    ]
+  },
+  {
+    "id": "arena-vfg",
+    "name": "Arena VFG",
+    "city": null,
+    "countryCode": "MEX",
+    "capacity": 22000,
+    "tenantClubs": []
+  },
+  {
+    "id": "cairo-military-academy-stadium",
+    "name": "Cairo Military Academy Stadium",
+    "city": null,
+    "countryCode": "EGY",
+    "capacity": 22000,
+    "tenantClubs": [
+      "tala-ea-el-gaish-sc"
+    ]
+  },
+  {
+    "id": "estadio-de-los-juegos-mediterraneos",
+    "name": "Estadio de los Juegos Mediterraneos",
+    "city": null,
+    "countryCode": "ESP",
+    "capacity": 22000,
+    "tenantClubs": [
+      "union-deportiva-almeria"
+    ]
+  },
+  {
+    "id": "estadio-guillermo-plazas-alcid",
+    "name": "Estadio Guillermo Plazas Alcid",
+    "city": "Neiva",
+    "countryCode": "COL",
+    "capacity": 22000,
+    "tenantClubs": [
+      "atletico-huila"
+    ]
+  },
+  {
+    "id": "hang-ay-stadium",
+    "name": "Hàng Đẫy Stadium",
+    "city": null,
+    "countryCode": "VNM",
+    "capacity": 22000,
+    "tenantClubs": [
+      "hanoi-fc"
+    ]
+  },
+  {
+    "id": "dinamo-stadium",
+    "name": "Dinamo Stadium",
+    "city": null,
+    "countryCode": "BLR",
+    "capacity": 22000,
+    "tenantClubs": [
+      "belarus-men-s-national-football-team",
+      "fc-dinamo-minsk"
+    ]
+  },
+  {
+    "id": "roumde-adjia-stadium",
+    "name": "Roumdé Adjia Stadium",
+    "city": "Garoua",
+    "countryCode": "CMR",
+    "capacity": 22000,
+    "tenantClubs": [
+      "coton-sport-fc-de-garoua"
+    ]
+  },
+  {
+    "id": "sabah-al-salem-stadium",
+    "name": "Sabah Al Salem Stadium",
+    "city": null,
+    "countryCode": "KWT",
+    "capacity": 22000,
+    "tenantClubs": [
+      "al-arabi-sc"
+    ]
+  },
+  {
+    "id": "parque-necaxa",
+    "name": "Parque Necaxa",
+    "city": null,
+    "countryCode": "MEX",
+    "capacity": 22000,
+    "tenantClubs": [
+      "club-necaxa"
+    ]
+  },
+  {
+    "id": "lokomotiv-stadium",
+    "name": "Lokomotiv Stadium",
+    "city": null,
+    "countryCode": "BGR",
+    "capacity": 22000,
+    "tenantClubs": [
+      "fc-lokomotiv-1929-sofia"
+    ]
+  },
+  {
+    "id": "mohun-bagan-ground",
+    "name": "Mohun Bagan Ground",
+    "city": null,
+    "countryCode": "IND",
+    "capacity": 22000,
+    "tenantClubs": [
+      "mohun-bagan-ac"
+    ]
+  },
+  {
+    "id": "estadio-doutor-herminio-ometto",
+    "name": "Estádio Doutor Hermínio Ometto",
+    "city": null,
+    "countryCode": "BRA",
+    "capacity": 22000,
+    "tenantClubs": []
+  },
+  {
+    "id": "stade-regional-nyamirambo",
+    "name": "Stade Régional Nyamirambo",
+    "city": null,
+    "countryCode": "RWA",
+    "capacity": 22000,
+    "tenantClubs": [
+      "as-kigali",
+      "gorilla-f-c",
+      "q111979186",
+      "q125149128",
+      "s-c-kiyovu-sports"
+    ]
+  },
+  {
+    "id": "guru-gobind-singh-stadium",
+    "name": "Guru Gobind Singh Stadium",
+    "city": null,
+    "countryCode": "IND",
+    "capacity": 22000,
+    "tenantClubs": [
+      "national-games-of-india"
+    ]
+  },
+  {
+    "id": "bullring-by-the-sea",
+    "name": "Bullring by the Sea",
+    "city": null,
+    "countryCode": "MEX",
+    "capacity": 22000,
+    "tenantClubs": []
+  },
+  {
+    "id": "estadio-zequinha-roriz",
+    "name": "Estádio Zequinha Roriz",
+    "city": "Luziânia",
+    "countryCode": "BRA",
+    "capacity": 22000,
+    "tenantClubs": [
+      "associacao-atletica-luziania"
+    ]
+  },
+  {
+    "id": "oliver-c-dawson-stadium",
+    "name": "Oliver C. Dawson Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 22000,
+    "tenantClubs": [
+      "south-carolina-state-university"
+    ]
+  },
+  {
+    "id": "kitakami-stadium",
+    "name": "Kitakami Stadium",
+    "city": "Kitakami",
+    "countryCode": "JPN",
+    "capacity": 22000,
+    "tenantClubs": []
+  },
+  {
+    "id": "takhti-stadium-abadan",
+    "name": "Takhti Stadium (Abadan)",
+    "city": null,
+    "countryCode": "IRN",
+    "capacity": 22000,
+    "tenantClubs": [
+      "sanat-naft-f-c"
+    ]
+  },
+  {
+    "id": "delaware-stadium",
+    "name": "Delaware Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 22000,
+    "tenantClubs": [
+      "delaware-fightin-blue-hens-football"
+    ]
+  },
+  {
+    "id": "juan-ramon-loubriel-stadium",
+    "name": "Juan Ramón Loubriel Stadium",
+    "city": "Cerro Gordo",
+    "countryCode": "USA",
+    "capacity": 22000,
+    "tenantClubs": [
+      "bayamon-fc"
+    ]
+  },
+  {
+    "id": "norwood-oval",
+    "name": "Norwood Oval",
+    "city": null,
+    "countryCode": "AUS",
+    "capacity": 22000,
+    "tenantClubs": [
+      "adelaide-football-club",
+      "adelaide-football-club-aflw",
+      "norwood-football-club"
+    ]
+  },
+  {
+    "id": "belite-orli-stadium",
+    "name": "Belite Orli Stadium",
+    "city": "Pleven",
+    "countryCode": "BGR",
+    "capacity": 22000,
+    "tenantClubs": []
+  },
+  {
+    "id": "lobatse-stadium",
+    "name": "Lobatse Stadium",
+    "city": null,
+    "countryCode": "BWA",
+    "capacity": 22000,
+    "tenantClubs": []
+  },
+  {
+    "id": "fuling-stadium",
+    "name": "Fuling Stadium",
+    "city": null,
+    "countryCode": "CHN",
+    "capacity": 22000,
+    "tenantClubs": []
+  },
+  {
+    "id": "ninh-binh-stadium",
+    "name": "Ninh Binh Stadium",
+    "city": null,
+    "countryCode": "VNM",
+    "capacity": 22000,
+    "tenantClubs": [
+      "vissai-ninh-binh-f-c"
+    ]
+  },
+  {
+    "id": "stephen-keshi-stadium",
+    "name": "Stephen Keshi Stadium",
+    "city": null,
+    "countryCode": "NGA",
+    "capacity": 22000,
+    "tenantClubs": []
+  },
+  {
+    "id": "chernomorets-stadium",
+    "name": "Chernomorets Stadium",
+    "city": null,
+    "countryCode": "BGR",
+    "capacity": 22000,
+    "tenantClubs": [
+      "fc-chernomorets-burgas"
+    ]
+  },
+  {
+    "id": "city-stadium",
+    "name": "City Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 22000,
+    "tenantClubs": [
+      "richmond-kickers",
+      "richmond-spiders"
+    ]
+  },
+  {
+    "id": "bmo-stadium",
+    "name": "BMO Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 22000,
+    "tenantClubs": [
+      "angel-city-fc",
+      "los-angeles-fc"
+    ]
+  },
+  {
+    "id": "estadio-ignacio-zaragoza",
+    "name": "Estadio Ignacio Zaragoza",
+    "city": null,
+    "countryCode": "MEX",
+    "capacity": 22000,
+    "tenantClubs": [
+      "pericos-de-puebla"
+    ]
+  },
+  {
+    "id": "estadio-olimpico-de-la-uach",
+    "name": "Estadio Olímpico de la UACH",
+    "city": null,
+    "countryCode": "MEX",
+    "capacity": 22000,
+    "tenantClubs": [
+      "aguilas-uach",
+      "caudillos",
+      "chihuahua-f-c"
+    ]
+  },
+  {
+    "id": "mahamasina-municipal-stadium",
+    "name": "Mahamasina Municipal Stadium",
+    "city": null,
+    "countryCode": "MDG",
+    "capacity": 22000,
+    "tenantClubs": [
+      "madagascar-men-s-national-football-team",
+      "madagascar-national-rugby-union-team"
+    ]
+  },
+  {
+    "id": "estadio-venustiano-carranza",
+    "name": "Estadio Venustiano Carranza",
+    "city": "Morelia",
+    "countryCode": "MEX",
+    "capacity": 22000,
+    "tenantClubs": [
+      "club-atletico-morelia"
+    ]
+  },
+  {
+    "id": "akita-prefectural-central-park-athletic-stadium",
+    "name": "Akita Prefectural Central Park Athletic Stadium",
+    "city": null,
+    "countryCode": "JPN",
+    "capacity": 22000,
+    "tenantClubs": []
+  },
+  {
+    "id": "estadio-del-bicentenario",
+    "name": "Estadio del Bicentenario",
+    "city": "Tepic",
+    "countryCode": "MEX",
+    "capacity": 22000,
+    "tenantClubs": []
+  },
+  {
+    "id": "moulay-el-hassan-stadium",
+    "name": "Moulay El Hassan Stadium",
+    "city": null,
+    "countryCode": "MAR",
+    "capacity": 22000,
+    "tenantClubs": [
+      "fus-de-rabat"
+    ]
+  },
+  {
+    "id": "estadio-santa-laura-universidad-sek",
+    "name": "Estadio Santa Laura-Universidad SEK",
+    "city": null,
+    "countryCode": "CHL",
+    "capacity": 22000,
+    "tenantClubs": [
+      "union-espanola"
+    ]
+  },
+  {
+    "id": "bassendean-oval",
+    "name": "Bassendean Oval",
+    "city": "Bassendean",
+    "countryCode": "AUS",
+    "capacity": 22000,
+    "tenantClubs": [
+      "swan-districts-football-club"
+    ]
+  },
+  {
+    "id": "haras-el-hodoud-stadium",
+    "name": "Haras El Hodoud Stadium",
+    "city": null,
+    "countryCode": "EGY",
+    "capacity": 22000,
+    "tenantClubs": [
+      "el-raja-marsa-matruh",
+      "haras-el-hodood-sc"
+    ]
+  },
+  {
+    "id": "chatsworth-stadium",
+    "name": "Chatsworth Stadium",
+    "city": "Chatsworth",
+    "countryCode": "ZAF",
+    "capacity": 22000,
+    "tenantClubs": [
+      "lamontville-golden-arrows-f-c",
+      "real-kings-f-c"
+    ]
+  },
+  {
+    "id": "konya-ataturk-stadium",
+    "name": "Konya Atatürk Stadium",
+    "city": null,
+    "countryCode": "TUR",
+    "capacity": 21968,
+    "tenantClubs": [
+      "konyaspor"
+    ]
+  },
+  {
+    "id": "pleven-stadium",
+    "name": "Pleven Stadium",
+    "city": null,
+    "countryCode": "BGR",
+    "capacity": 21940,
+    "tenantClubs": []
+  },
+  {
+    "id": "central-stadium-ukr",
+    "name": "Central Stadium",
+    "city": null,
+    "countryCode": "UKR",
+    "capacity": 21928,
+    "tenantClubs": [
+      "fc-polissya-zhytomyr"
+    ]
+  },
+  {
+    "id": "estadio-nuevo-arcangel",
+    "name": "Estadio Nuevo Arcángel",
+    "city": null,
+    "countryCode": "ESP",
+    "capacity": 21822,
+    "tenantClubs": [
+      "cordoba-cf"
+    ]
+  },
+  {
+    "id": "waldstadion-homburg",
+    "name": "Waldstadion Homburg",
+    "city": null,
+    "countryCode": "DEU",
+    "capacity": 21813,
+    "tenantClubs": [
+      "fc-08-homburg"
+    ]
+  },
+  {
+    "id": "varsity-stadium",
+    "name": "Varsity Stadium",
+    "city": null,
+    "countryCode": "CAN",
+    "capacity": 21767,
+    "tenantClubs": [
+      "toronto-argonauts",
+      "toronto-varsity-blues",
+      "toronto-varsity-blues-football",
+      "toronto-varsity-blues-men-s-soccer"
+    ]
+  },
+  {
+    "id": "sausalito-stadium",
+    "name": "Sausalito Stadium",
+    "city": "Viña del Mar",
+    "countryCode": "CHL",
+    "capacity": 21739,
+    "tenantClubs": [
+      "everton-de-vina-del-mar"
+    ]
+  },
+  {
+    "id": "estadio-heliodoro-rodriguez-lopez",
+    "name": "Estadio Heliodoro Rodríguez López",
+    "city": null,
+    "countryCode": "ESP",
+    "capacity": 21732,
+    "tenantClubs": [
+      "c-d-tenerife"
+    ]
+  },
+  {
+    "id": "stadion-an-der-alten-forsterei",
+    "name": "Stadion An der Alten Försterei",
+    "city": "Köpenick",
+    "countryCode": "DEU",
+    "capacity": 21704,
+    "tenantClubs": [
+      "1-fc-union-berlin"
+    ]
+  },
+  {
+    "id": "campos-de-sport-de-el-sardinero",
+    "name": "Campos de Sport de El Sardinero",
+    "city": null,
+    "countryCode": "ESP",
+    "capacity": 21700,
+    "tenantClubs": [
+      "racing-de-santander",
+      "real-racing-de-santander-women"
+    ]
+  },
+  {
+    "id": "stade-auguste-delaune",
+    "name": "Stade Auguste Delaune",
+    "city": null,
+    "countryCode": "FRA",
+    "capacity": 21684,
+    "tenantClubs": [
+      "stade-de-reims"
+    ]
+  },
+  {
+    "id": "estadio-nuevo-colombino",
+    "name": "Estadio Nuevo Colombino",
+    "city": "Huelva city",
+    "countryCode": "ESP",
+    "capacity": 21670,
+    "tenantClubs": [
+      "recreativo-de-huelva"
+    ]
+  },
+  {
+    "id": "estadio-willie-davids",
+    "name": "Estádio Willie Davids",
+    "city": "Maringá",
+    "countryCode": "BRA",
+    "capacity": 21600,
+    "tenantClubs": [
+      "aruko-sports-brasil",
+      "gremio-de-esportes-maringa"
+    ]
+  },
+  {
+    "id": "kyoto-stadium",
+    "name": "Kyoto Stadium",
+    "city": "Kameoka",
+    "countryCode": "JPN",
+    "capacity": 21600,
+    "tenantClubs": [
+      "kyoto-sanga-fc"
+    ]
+  },
+  {
+    "id": "bmo-field",
+    "name": "BMO Field",
+    "city": "Toronto",
+    "countryCode": "CAN",
+    "capacity": 21566,
+    "tenantClubs": [
+      "canadian-men-s-national-soccer-team",
+      "toronto-argonauts",
+      "toronto-fc"
+    ]
+  },
+  {
+    "id": "mapei-stadium-citta-del-tricolore",
+    "name": "Mapei Stadium - Città del Tricolore",
+    "city": null,
+    "countryCode": "ITA",
+    "capacity": 21525,
+    "tenantClubs": [
+      "us-sassuolo-calcio"
+    ]
+  },
+  {
+    "id": "lotto-park",
+    "name": "Lotto Park",
+    "city": "Astrid Park",
+    "countryCode": "BEL",
+    "capacity": 21500,
+    "tenantClubs": [
+      "r-s-c-anderlecht"
+    ]
+  },
+  {
+    "id": "juan-carmelo-zerillo-stadium",
+    "name": "Juan Carmelo Zerillo Stadium",
+    "city": null,
+    "countryCode": "ARG",
+    "capacity": 21500,
+    "tenantClubs": [
+      "club-de-gimnasia-y-esgrima-la-plata",
+      "gimnasia-y-esgrima-la-plata-women"
+    ]
+  },
+  {
+    "id": "gemeentelijk-sportpark-kaalheide",
+    "name": "Gemeentelijk Sportpark Kaalheide",
+    "city": null,
+    "countryCode": null,
+    "capacity": 21500,
+    "tenantClubs": [
+      "roda-jc",
+      "roda-jc-kerkrade"
+    ]
+  },
+  {
+    "id": "hans-walter-wild-stadion",
+    "name": "Hans-Walter-Wild-Stadion",
+    "city": null,
+    "countryCode": "DEU",
+    "capacity": 21500,
+    "tenantClubs": [
+      "spvgg-bayreuth"
+    ]
+  },
+  {
+    "id": "brec-memorial-stadium",
+    "name": "BREC Memorial Stadium",
+    "city": "Baton Rouge",
+    "countryCode": "USA",
+    "capacity": 21500,
+    "tenantClubs": [
+      "louisiana-bayou-storm-surge",
+      "louisiana-high-school-athletic-association"
+    ]
+  },
+  {
+    "id": "estadio-alfredo-da-silva",
+    "name": "Estádio Alfredo da Silva",
+    "city": null,
+    "countryCode": "PRT",
+    "capacity": 21498,
+    "tenantClubs": []
+  },
+  {
+    "id": "murbat-stadium",
+    "name": "Murbat Stadium",
+    "city": null,
+    "countryCode": "LBY",
+    "capacity": 21442,
+    "tenantClubs": []
+  },
+  {
+    "id": "lerkendal-stadion",
+    "name": "Lerkendal Stadion",
+    "city": "Trondheim",
+    "countryCode": "NOR",
+    "capacity": 21423,
+    "tenantClubs": [
+      "rosenborg-bk"
+    ]
+  },
+  {
+    "id": "pittodrie-stadium",
+    "name": "Pittodrie Stadium",
+    "city": "Aberdeen",
+    "countryCode": "GBR",
+    "capacity": 21421,
+    "tenantClubs": [
+      "aberdeen-f-c"
+    ]
+  },
+  {
+    "id": "nilphamari-stadium",
+    "name": "Nilphamari Stadium",
+    "city": "Nilphamari District",
+    "countryCode": "BGD",
+    "capacity": 21359,
+    "tenantClubs": [
+      "bashundhara-kings"
+    ]
+  },
+  {
+    "id": "niederrheinstadion",
+    "name": "Niederrheinstadion",
+    "city": null,
+    "countryCode": "DEU",
+    "capacity": 21318,
+    "tenantClubs": [
+      "rot-wei-oberhausen"
+    ]
+  },
+  {
+    "id": "old-tivoli",
+    "name": "Old Tivoli",
+    "city": null,
+    "countryCode": "DEU",
+    "capacity": 21300,
+    "tenantClubs": [
+      "alemannia-aachen"
+    ]
+  },
+  {
+    "id": "nd-soft-stadium-yamagata",
+    "name": "ND Soft Stadium Yamagata",
+    "city": "Tendō-shi",
+    "countryCode": "JPN",
+    "capacity": 21292,
+    "tenantClubs": [
+      "montedio-yamagata"
+    ]
+  },
+  {
+    "id": "estadio-nabi-abi-chedid",
+    "name": "Estádio Nabi Abi Chedid",
+    "city": "Bragança Paulista",
+    "countryCode": "BRA",
+    "capacity": 21209,
+    "tenantClubs": [
+      "red-bull-bragantino"
+    ]
+  },
+  {
+    "id": "hornet-stadium-usa",
+    "name": "Hornet Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 21195,
+    "tenantClubs": [
+      "california-state-university-sacramento",
+      "sacramento-state-hornets-football"
+    ]
+  },
+  {
+    "id": "estadio-regional-de-antofagasta",
+    "name": "Estadio Regional de Antofagasta",
+    "city": null,
+    "countryCode": "CHL",
+    "capacity": 21178,
+    "tenantClubs": [
+      "club-deportes-antofagasta"
+    ]
+  },
+  {
+    "id": "stadion-florian-kryger",
+    "name": "Stadion Florian Kryger",
+    "city": null,
+    "countryCode": "POL",
+    "capacity": 21163,
+    "tenantClubs": [
+      "pogon-szczecin"
+    ]
+  },
+  {
+    "id": "stadio-alberto-braglia",
+    "name": "Stadio Alberto Braglia",
+    "city": null,
+    "countryCode": "ITA",
+    "capacity": 21151,
+    "tenantClubs": [
+      "a-c-carpi",
+      "modena-f-c",
+      "us-sassuolo-calcio"
+    ]
+  },
+  {
+    "id": "fratton-park",
+    "name": "Fratton Park",
+    "city": "Milton",
+    "countryCode": "GBR",
+    "capacity": 21100,
+    "tenantClubs": [
+      "portsmouth-f-c"
+    ]
+  },
+  {
+    "id": "nemesio-diez-stadium",
+    "name": "Nemesio Díez Stadium",
+    "city": "Toluca de Lerdo",
+    "countryCode": "MEX",
+    "capacity": 21091,
+    "tenantClubs": [
+      "deportivo-toluca-f-c"
+    ]
+  },
+  {
+    "id": "stade-michel-d-ornano",
+    "name": "Stade Michel d'Ornano",
+    "city": null,
+    "countryCode": "FRA",
+    "capacity": 21068,
+    "tenantClubs": [
+      "stade-malherbe-caen"
+    ]
+  },
+  {
+    "id": "technoport-fukui-stadium",
+    "name": "Technoport Fukui Stadium",
+    "city": null,
+    "countryCode": "JPN",
+    "capacity": 21053,
+    "tenantClubs": []
+  },
+  {
+    "id": "aliu-mahama-sports-stadium",
+    "name": "Aliu Mahama Sports Stadium",
+    "city": null,
+    "countryCode": "GHA",
+    "capacity": 21017,
+    "tenantClubs": [
+      "karela-united-fc",
+      "real-tamale-united"
+    ]
+  },
+  {
+    "id": "prince-sultan-bin-fahd-stadium",
+    "name": "Prince Sultan bin Fahd Stadium",
+    "city": null,
+    "countryCode": "SAU",
+    "capacity": 21000,
+    "tenantClubs": [
+      "al-ahli-fc"
+    ]
+  },
+  {
+    "id": "estadio-25-de-noviembre",
+    "name": "Estadio 25 de Noviembre",
+    "city": "Moquegua",
+    "countryCode": "PER",
+    "capacity": 21000,
+    "tenantClubs": [
+      "san-simon-de-moquegua"
+    ]
+  },
+  {
+    "id": "railyards-stadium",
+    "name": "Railyards Stadium",
+    "city": "Sacramento Railyards",
+    "countryCode": "USA",
+    "capacity": 21000,
+    "tenantClubs": []
+  },
+  {
+    "id": "cooks-gardens",
+    "name": "Cooks Gardens",
+    "city": null,
+    "countryCode": "NZL",
+    "capacity": 21000,
+    "tenantClubs": [
+      "wanganui-rugby-football-union"
+    ]
+  },
+  {
+    "id": "osaka-expo-70-stadium",
+    "name": "Osaka Expo '70 Stadium",
+    "city": "Expo '70 Commemorative Park",
+    "countryCode": "JPN",
+    "capacity": 21000,
+    "tenantClubs": [
+      "gamba-osaka"
+    ]
+  },
+  {
+    "id": "sydney-superdome",
+    "name": "Sydney SuperDome",
+    "city": "Sydney Olympic Park",
+    "countryCode": "AUS",
+    "capacity": 21000,
+    "tenantClubs": [
+      "sydney-kings"
+    ]
+  },
+  {
+    "id": "suez-canal-stadium",
+    "name": "Suez Canal Stadium",
+    "city": null,
+    "countryCode": "EGY",
+    "capacity": 21000,
+    "tenantClubs": []
+  },
+  {
+    "id": "prince-moulay-abdellah-olympic-annex-stadium",
+    "name": "Prince Moulay Abdellah Olympic Annex Stadium",
+    "city": null,
+    "countryCode": "MAR",
+    "capacity": 21000,
+    "tenantClubs": []
+  },
+  {
+    "id": "alerus-center",
+    "name": "Alerus Center",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 21000,
+    "tenantClubs": [
+      "north-dakota-fighting-hawks-football"
+    ]
+  },
+  {
+    "id": "louis-crews-stadium",
+    "name": "Louis Crews Stadium",
+    "city": "Normal",
+    "countryCode": "USA",
+    "capacity": 21000,
+    "tenantClubs": [
+      "national-collegiate-athletic-association"
+    ]
+  },
+  {
+    "id": "new-aberdeen-stadium",
+    "name": "New Aberdeen Stadium",
+    "city": "Aberdeen",
+    "countryCode": "GBR",
+    "capacity": 21000,
+    "tenantClubs": [
+      "aberdeen-f-c"
+    ]
+  },
+  {
+    "id": "american-legion-memorial-stadium",
+    "name": "American Legion Memorial Stadium",
+    "city": "Charlotte",
+    "countryCode": "USA",
+    "capacity": 21000,
+    "tenantClubs": [
+      "anthem-rugby-carolina",
+      "carolina-ascent-fc",
+      "carolina-chaos",
+      "charlotte-hornets",
+      "charlotte-hounds",
+      "charlotte-independence",
+      "myers-park-high-school"
+    ]
+  },
+  {
+    "id": "bell-field",
+    "name": "Bell Field",
+    "city": "Oregon State University",
+    "countryCode": "USA",
+    "capacity": 21000,
+    "tenantClubs": [
+      "oregon-state-beavers-football"
+    ]
+  },
+  {
+    "id": "estadio-joel-gutierrez",
+    "name": "Estadio Joel Gutiérrez",
+    "city": null,
+    "countryCode": "PER",
+    "capacity": 21000,
+    "tenantClubs": []
+  },
+  {
+    "id": "doctores-jose-y-antonio-castiglione-stadium",
+    "name": "Doctores José y Antonio Castiglione Stadium",
+    "city": null,
+    "countryCode": "ARG",
+    "capacity": 21000,
+    "tenantClubs": [
+      "club-atletico-mitre"
+    ]
+  },
+  {
+    "id": "estadio-raulino-de-oliveira",
+    "name": "Estádio Raulino de Oliveira",
+    "city": null,
+    "countryCode": "BRA",
+    "capacity": 21000,
+    "tenantClubs": [
+      "volta-redonda-futebol-clube"
+    ]
+  },
+  {
+    "id": "stadler-stadion",
+    "name": "Stadler Stadion",
+    "city": null,
+    "countryCode": "HUN",
+    "capacity": 21000,
+    "tenantClubs": [
+      "kiskorosi-fc"
+    ]
+  },
+  {
+    "id": "stadio-san-vito",
+    "name": "Stadio San Vito",
+    "city": null,
+    "countryCode": "ITA",
+    "capacity": 20987,
+    "tenantClubs": [
+      "2021-22-cosenza-calcio-season",
+      "cosenza-calcio"
+    ]
+  },
+  {
+    "id": "incheon-football-stadium",
+    "name": "Incheon Football Stadium",
+    "city": "Old downtown area of Jung District, Incheon",
+    "countryCode": "KOR",
+    "capacity": 20891,
+    "tenantClubs": [
+      "incheon-united-fc"
+    ]
+  },
+  {
+    "id": "sapporo-atsubetsu-park-stadium",
+    "name": "Sapporo Atsubetsu Park Stadium",
+    "city": null,
+    "countryCode": "JPN",
+    "capacity": 20861,
+    "tenantClubs": []
+  },
+  {
+    "id": "fortuna-arena",
+    "name": "Fortuna Arena",
+    "city": "Vršovice",
+    "countryCode": "CZE",
+    "capacity": 20800,
+    "tenantClubs": [
+      "sk-slavia-prague"
+    ]
+  },
+  {
+    "id": "estadio-el-cobre",
+    "name": "Estadio El Cobre",
+    "city": "El Salvador",
+    "countryCode": "CHL",
+    "capacity": 20752,
+    "tenantClubs": [
+      "cobresal"
+    ]
+  },
+  {
+    "id": "liberty-stadium",
+    "name": "Liberty Stadium",
+    "city": null,
+    "countryCode": "GBR",
+    "capacity": 20750,
+    "tenantClubs": [
+      "ospreys",
+      "swansea-city-a-f-c"
+    ]
+  },
+  {
+    "id": "amerant-bank-arena",
+    "name": "Amerant Bank Arena",
+    "city": "Sunrise",
+    "countryCode": "USA",
+    "capacity": 20737,
+    "tenantClubs": [
+      "florida-panthers"
+    ]
+  },
+  {
+    "id": "q16303221",
+    "name": "Q16303221",
+    "city": null,
+    "countryCode": "ARG",
+    "capacity": 20704,
+    "tenantClubs": [
+      "altos-hornos-zapla"
+    ]
+  },
+  {
+    "id": "estadio-olimpico-de-c-u",
+    "name": "Estadio Olímpico de C.U.",
+    "city": null,
+    "countryCode": "MEX",
+    "capacity": 20700,
+    "tenantClubs": [
+      "lobos-de-la-buap"
+    ]
+  },
+  {
+    "id": "finley-stadium",
+    "name": "Finley Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 20668,
+    "tenantClubs": [
+      "chattanooga-mocs-football"
+    ]
+  },
+  {
+    "id": "stadion-essen",
+    "name": "Stadion Essen",
+    "city": null,
+    "countryCode": "DEU",
+    "capacity": 20650,
+    "tenantClubs": [
+      "rot-weiss-essen",
+      "sgs-essen"
+    ]
+  },
+  {
+    "id": "stambaugh-stadium",
+    "name": "Stambaugh Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 20630,
+    "tenantClubs": [
+      "youngstown-state-penguins-football"
+    ]
+  },
+  {
+    "id": "estadio-presidente-vargas",
+    "name": "Estádio Presidente Vargas",
+    "city": null,
+    "countryCode": "BRA",
+    "capacity": 20600,
+    "tenantClubs": [
+      "america-football-club"
+    ]
+  },
+  {
+    "id": "nishikyogoku-athletic-stadium",
+    "name": "Nishikyogoku Athletic Stadium",
+    "city": "Kyoto",
+    "countryCode": "JPN",
+    "capacity": 20588,
+    "tenantClubs": [
+      "kyoto-sanga-fc"
+    ]
+  },
+  {
+    "id": "zdzis-aw-krzyszkowiak-stadium",
+    "name": "Zdzisław Krzyszkowiak Stadium",
+    "city": "Gdanska Street",
+    "countryCode": "POL",
+    "capacity": 20559,
+    "tenantClubs": [
+      "zawisza-bydgoszcz"
+    ]
+  },
+  {
+    "id": "estadio-rei-pele",
+    "name": "Estádio Rei Pelé",
+    "city": null,
+    "countryCode": "BRA",
+    "capacity": 20551,
+    "tenantClubs": [
+      "clube-de-regatas-brasil"
+    ]
+  },
+  {
+    "id": "qingdao-tiantai-stadium",
+    "name": "Qingdao Tiantai Stadium",
+    "city": "Qingdao",
+    "countryCode": "CHN",
+    "capacity": 20525,
+    "tenantClubs": [
+      "qingdao-hainiu-f-c"
+    ]
+  },
+  {
+    "id": "estadio-municipal-de-chapin",
+    "name": "Estadio Municipal de Chapín",
+    "city": null,
+    "countryCode": "ESP",
+    "capacity": 20523,
+    "tenantClubs": [
+      "xerez-c-d"
+    ]
+  },
+  {
+    "id": "stadio-adriatico",
+    "name": "Stadio Adriatico",
+    "city": null,
+    "countryCode": "ITA",
+    "capacity": 20515,
+    "tenantClubs": [
+      "2023-24-a-s-d-pineto-calcio-season",
+      "delfino-pescara-1936"
+    ]
+  },
+  {
+    "id": "stadion-des-friedens-leipzig",
+    "name": "Stadion des Friedens (Leipzig)",
+    "city": null,
+    "countryCode": "DEU",
+    "capacity": 20500,
+    "tenantClubs": [
+      "sg-motor-gohlis-nord"
+    ]
+  },
+  {
+    "id": "estadio-municipal-joao-lamego-netto",
+    "name": "Estádio Municipal João Lamego Netto",
+    "city": null,
+    "countryCode": "BRA",
+    "capacity": 20500,
+    "tenantClubs": [
+      "ipatinga-futebol-clube"
+    ]
+  },
+  {
+    "id": "q2-stadium",
+    "name": "Q2 Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 20500,
+    "tenantClubs": [
+      "austin-fc"
+    ]
+  },
+  {
+    "id": "yodoko-sakura-stadium",
+    "name": "Yodoko Sakura Stadium",
+    "city": "Nagai Park",
+    "countryCode": "JPN",
+    "capacity": 20500,
+    "tenantClubs": [
+      "cerezo-osaka",
+      "fc-osaka"
+    ]
+  },
+  {
+    "id": "stade-d-oyem",
+    "name": "Stade d'Oyem",
+    "city": "Oyem",
+    "countryCode": "GAB",
+    "capacity": 20500,
+    "tenantClubs": [
+      "2017-africa-cup-of-nations"
+    ]
+  },
+  {
+    "id": "toyota-stadium-usa",
+    "name": "Toyota Stadium",
+    "city": "Frisco",
+    "countryCode": "USA",
+    "capacity": 20500,
+    "tenantClubs": [
+      "fc-dallas",
+      "frisco-independent-school-district",
+      "north-texas-sc"
+    ]
+  },
+  {
+    "id": "perth-rectangular-stadium",
+    "name": "Perth Rectangular Stadium",
+    "city": "Perth",
+    "countryCode": "AUS",
+    "capacity": 20441,
+    "tenantClubs": [
+      "east-perth-football-club"
+    ]
+  },
+  {
+    "id": "pocarisweat-stadium",
+    "name": "Pocarisweat Stadium",
+    "city": "Naruto",
+    "countryCode": "JPN",
+    "capacity": 20441,
+    "tenantClubs": [
+      "tokushima-vortis"
+    ]
+  },
+  {
+    "id": "easter-road",
+    "name": "Easter Road",
+    "city": "Edinburgh",
+    "countryCode": "GBR",
+    "capacity": 20421,
+    "tenantClubs": [
+      "hibernian-f-c",
+      "scotland-women-s-national-football-team"
+    ]
+  },
+  {
+    "id": "estadio-padre-ernesto-martearena",
+    "name": "Estadio Padre Ernesto Martearena",
+    "city": "Salta",
+    "countryCode": "ARG",
+    "capacity": 20408,
+    "tenantClubs": [
+      "juventud-antoniana"
+    ]
+  },
+  {
+    "id": "stade-de-l-aube",
+    "name": "Stade de l'Aube",
+    "city": null,
+    "countryCode": "FRA",
+    "capacity": 20400,
+    "tenantClubs": [
+      "es-troyes-ac"
+    ]
+  },
+  {
+    "id": "matsumotodaira-football-stadium",
+    "name": "Matsumotodaira Football Stadium",
+    "city": "Matsumotodaira Park",
+    "countryCode": "JPN",
+    "capacity": 20396,
+    "tenantClubs": [
+      "matsumoto-yamaga-fc"
+    ]
+  },
+  {
+    "id": "weingart-stadium",
+    "name": "Weingart Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 20355,
+    "tenantClubs": [
+      "east-los-angeles-college"
+    ]
+  },
+  {
+    "id": "iai-stadium-nihondaira",
+    "name": "IAI Stadium Nihondaira",
+    "city": null,
+    "countryCode": "JPN",
+    "capacity": 20339,
+    "tenantClubs": [
+      "shimizu-s-pulse"
+    ]
+  },
+  {
+    "id": "charles-c-hughes-stadium",
+    "name": "Charles C. Hughes Stadium",
+    "city": "Sacramento",
+    "countryCode": "USA",
+    "capacity": 20311,
+    "tenantClubs": [
+      "sacramento-city-college",
+      "sacramento-republic-fc"
+    ]
+  },
+  {
+    "id": "stadion-am-bruchweg",
+    "name": "Stadion am Bruchweg",
+    "city": "Q137375049",
+    "countryCode": "DEU",
+    "capacity": 20300,
+    "tenantClubs": [
+      "1-fsv-mainz-05"
+    ]
+  },
+  {
+    "id": "estadio-fonte-luminosa",
+    "name": "Estádio Fonte Luminosa",
+    "city": "Araraquara",
+    "countryCode": "BRA",
+    "capacity": 20287,
+    "tenantClubs": [
+      "associacao-ferroviaria-de-esportes"
+    ]
+  },
+  {
+    "id": "estadio-municipal-14-de-dezembro",
+    "name": "Estádio Municipal 14 de Dezembro",
+    "city": "Toledo",
+    "countryCode": "BRA",
+    "capacity": 20280,
+    "tenantClubs": [
+      "toledo-colonia-work"
+    ]
+  },
+  {
+    "id": "mokdong-stadium",
+    "name": "Mokdong Stadium",
+    "city": null,
+    "countryCode": "KOR",
+    "capacity": 20236,
+    "tenantClubs": [
+      "seoul-e-land-fc"
+    ]
+  },
+  {
+    "id": "meadow-lane",
+    "name": "Meadow Lane",
+    "city": "Nottingham",
+    "countryCode": "GBR",
+    "capacity": 20229,
+    "tenantClubs": [
+      "nottingham-r-f-c",
+      "notts-county-f-c"
+    ]
+  },
+  {
+    "id": "america-first-field",
+    "name": "America First Field",
+    "city": "Sandy",
+    "countryCode": "USA",
+    "capacity": 20213,
+    "tenantClubs": [
+      "real-monarchs",
+      "real-salt-lake",
+      "utah-royals-fc"
+    ]
+  },
+  {
+    "id": "airberlin-world",
+    "name": "AirBerlin World",
+    "city": null,
+    "countryCode": "DEU",
+    "capacity": 20168,
+    "tenantClubs": [
+      "fortuna-dusseldorf"
+    ]
+  },
+  {
+    "id": "the-den",
+    "name": "The Den",
+    "city": "Bermondsey",
+    "countryCode": "GBR",
+    "capacity": 20146,
+    "tenantClubs": [
+      "millwall-f-c"
+    ]
+  },
+  {
+    "id": "80th-birthday-stadium",
+    "name": "80th Birthday Stadium",
+    "city": null,
+    "countryCode": "THA",
+    "capacity": 20141,
+    "tenantClubs": [
+      "nakhon-ratchasima-f-c"
+    ]
+  },
+  {
+    "id": "scottsmiracle-gro-field",
+    "name": "ScottsMiracle-Gro Field",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 20139,
+    "tenantClubs": [
+      "columbus-crew"
+    ]
+  },
+  {
+    "id": "soyu-stadium",
+    "name": "Soyu Stadium",
+    "city": null,
+    "countryCode": "JPN",
+    "capacity": 20125,
+    "tenantClubs": [
+      "blaublitz-akita"
+    ]
+  },
+  {
+    "id": "kornblau-field-at-s-b-ballard-stadium",
+    "name": "Kornblau Field at S.B. Ballard Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 20118,
+    "tenantClubs": [
+      "old-dominion-monarchs",
+      "old-dominion-monarchs-football",
+      "oyster-bowl"
+    ]
+  },
+  {
+    "id": "jinju-stadium",
+    "name": "Jinju Stadium",
+    "city": null,
+    "countryCode": "KOR",
+    "capacity": 20116,
+    "tenantClubs": []
+  },
+  {
+    "id": "stade-marcel-picot",
+    "name": "Stade Marcel Picot",
+    "city": null,
+    "countryCode": "FRA",
+    "capacity": 20087,
+    "tenantClubs": [
+      "a-s-nancy-lorraine",
+      "fc-nancy"
+    ]
+  },
+  {
+    "id": "stade-des-alpes",
+    "name": "Stade des Alpes",
+    "city": null,
+    "countryCode": "FRA",
+    "capacity": 20068,
+    "tenantClubs": [
+      "football-club-grenoble-rugby",
+      "grenoble-foot-38"
+    ]
+  },
+  {
+    "id": "central-coast-stadium",
+    "name": "Central Coast Stadium",
+    "city": "Gosford",
+    "countryCode": "AUS",
+    "capacity": 20059,
+    "tenantClubs": [
+      "central-coast-mariners-fc"
+    ]
+  },
+  {
+    "id": "stadionul-municipal",
+    "name": "Stadionul Municipal",
+    "city": "Drobeta-Turnu Severin",
+    "countryCode": "ROU",
+    "capacity": 20054,
+    "tenantClubs": [
+      "fc-drobeta-turnu-severin"
+    ]
+  },
+  {
+    "id": "jeju-sports-complex",
+    "name": "Jeju Sports Complex",
+    "city": null,
+    "countryCode": "KOR",
+    "capacity": 20053,
+    "tenantClubs": [
+      "jeju-sk-fc"
+    ]
+  },
+  {
+    "id": "arsenal-stadium",
+    "name": "Arsenal Stadium",
+    "city": null,
+    "countryCode": "RUS",
+    "capacity": 20048,
+    "tenantClubs": [
+      "fc-arsenal-tula"
+    ]
+  },
+  {
+    "id": "gursel-aksel-stadium",
+    "name": "Gürsel Aksel Stadium",
+    "city": "Mehmet Ali Akman",
+    "countryCode": "TUR",
+    "capacity": 20040,
+    "tenantClubs": [
+      "goztepe-s-k"
+    ]
+  },
+  {
+    "id": "batumi-stadium",
+    "name": "Batumi Stadium",
+    "city": null,
+    "countryCode": "GEO",
+    "capacity": 20035,
+    "tenantClubs": [
+      "fc-dinamo-batumi"
+    ]
+  },
+  {
+    "id": "stade-auguste-bonal",
+    "name": "Stade Auguste Bonal",
+    "city": null,
+    "countryCode": "FRA",
+    "capacity": 20025,
+    "tenantClubs": [
+      "fc-sochaux-montbeliard"
+    ]
+  },
+  {
+    "id": "debrecen-stadion",
+    "name": "Debrecen Stadion",
+    "city": null,
+    "countryCode": "HUN",
+    "capacity": 20020,
+    "tenantClubs": [
+      "debreceni-vsc"
+    ]
+  },
+  {
+    "id": "daren-sammy-cricket-ground",
+    "name": "Daren Sammy Cricket Ground",
+    "city": "Gros Islet",
+    "countryCode": "LCA",
+    "capacity": 20000,
+    "tenantClubs": [
+      "saint-lucia-men-s-national-football-team",
+      "west-indies-cricket-team"
+    ]
+  },
+  {
+    "id": "wheater-s-field",
+    "name": "Wheater's Field",
+    "city": "Broughton",
+    "countryCode": "GBR",
+    "capacity": 20000,
+    "tenantClubs": [
+      "broughton-rangers"
+    ]
+  },
+  {
+    "id": "kazhimukan-munaitpasov-stadium",
+    "name": "Kazhimukan Munaitpasov Stadium",
+    "city": null,
+    "countryCode": "KAZ",
+    "capacity": 20000,
+    "tenantClubs": [
+      "fc-ordabasy"
+    ]
+  },
+  {
+    "id": "n-stved-stadion",
+    "name": "Næstved Stadion",
+    "city": "Næstved",
+    "countryCode": "DNK",
+    "capacity": 20000,
+    "tenantClubs": [
+      "n-stved-bk"
+    ]
+  },
+  {
+    "id": "el-kraken",
+    "name": "El Kraken",
+    "city": "Mazatlán",
+    "countryCode": "MEX",
+    "capacity": 20000,
+    "tenantClubs": [
+      "mazatlan-futbol-club"
+    ]
+  },
+  {
+    "id": "stadion-lublinianki",
+    "name": "Stadion Lublinianki",
+    "city": null,
+    "countryCode": "POL",
+    "capacity": 20000,
+    "tenantClubs": [
+      "ks-lublinianka"
+    ]
+  },
+  {
+    "id": "chulalongkorn-university-stadium",
+    "name": "Chulalongkorn University Stadium",
+    "city": null,
+    "countryCode": "THA",
+    "capacity": 20000,
+    "tenantClubs": [
+      "bbcu-f-c"
+    ]
+  },
+  {
+    "id": "yamaguchi-ishin-park-stadium",
+    "name": "Yamaguchi Ishin Park Stadium",
+    "city": "Yamaguchi",
+    "countryCode": "JPN",
+    "capacity": 20000,
+    "tenantClubs": []
+  },
+  {
+    "id": "yangquan-stadium",
+    "name": "Yangquan Stadium",
+    "city": "Yangquan",
+    "countryCode": "CHN",
+    "capacity": 20000,
+    "tenantClubs": []
+  },
+  {
+    "id": "yulin-stadium",
+    "name": "Yulin Stadium",
+    "city": null,
+    "countryCode": "CHN",
+    "capacity": 20000,
+    "tenantClubs": []
+  },
+  {
+    "id": "aliu-mahama-sports-stadium-gha",
+    "name": "Aliu Mahama Sports Stadium",
+    "city": "Tamale",
+    "countryCode": "GHA",
+    "capacity": 20000,
+    "tenantClubs": [
+      "real-tamale-united",
+      "steadfast-f-c"
+    ]
+  },
+  {
+    "id": "q9255273",
+    "name": "Q9255273",
+    "city": null,
+    "countryCode": "BRA",
+    "capacity": 20000,
+    "tenantClubs": []
+  },
+  {
+    "id": "estadio-da-curuzu",
+    "name": "Estádio da Curuzú",
+    "city": "Belém",
+    "countryCode": "BRA",
+    "capacity": 20000,
+    "tenantClubs": [
+      "paysandu-sport-club"
+    ]
+  },
+  {
+    "id": "wonju-stadium",
+    "name": "Wonju Stadium",
+    "city": null,
+    "countryCode": "KOR",
+    "capacity": 20000,
+    "tenantClubs": [
+      "gangwon-fc"
+    ]
+  },
+  {
+    "id": "stade-de-marchan",
+    "name": "Stade de Marchan",
+    "city": null,
+    "countryCode": "MAR",
+    "capacity": 20000,
+    "tenantClubs": [
+      "ir-tanger"
+    ]
+  },
+  {
+    "id": "stade-buffalo",
+    "name": "Stade Buffalo",
+    "city": null,
+    "countryCode": "FRA",
+    "capacity": 20000,
+    "tenantClubs": []
+  },
+  {
+    "id": "olympic-stadium-of-nouakchott",
+    "name": "Olympic Stadium of Nouakchott",
+    "city": "Nouakchott",
+    "countryCode": "MRT",
+    "capacity": 20000,
+    "tenantClubs": [
+      "mauritania-men-s-national-football-team"
+    ]
+  },
+  {
+    "id": "estadio-plan-de-san-luis-potosi",
+    "name": "Estadio Plan de San Luis Potosí",
+    "city": "San Luis Potosí",
+    "countryCode": "MEX",
+    "capacity": 20000,
+    "tenantClubs": [
+      "san-luis-f-c"
+    ]
+  },
+  {
+    "id": "villareal-anaya-stadium",
+    "name": "Villareal Anaya Stadium",
+    "city": null,
+    "countryCode": "MEX",
+    "capacity": 20000,
+    "tenantClubs": [
+      "correcaminos-uat"
+    ]
+  },
+  {
+    "id": "stade-omnisports-idriss-mahamat-ouya",
+    "name": "Stade Omnisports Idriss Mahamat Ouya",
+    "city": "N'Djamena",
+    "countryCode": "TCD",
+    "capacity": 20000,
+    "tenantClubs": [
+      "chad-men-s-national-football-team"
+    ]
+  },
+  {
+    "id": "stade-de-port-gentil",
+    "name": "Stade de Port-Gentil",
+    "city": "Port-Gentil",
+    "countryCode": "GAB",
+    "capacity": 20000,
+    "tenantClubs": [
+      "2017-africa-cup-of-nations"
+    ]
+  },
+  {
+    "id": "ramadan-ben-abdelmalek-stadium",
+    "name": "Ramadan Ben-Abdelmalek Stadium",
+    "city": null,
+    "countryCode": "DZA",
+    "capacity": 20000,
+    "tenantClubs": [
+      "mo-constantine"
+    ]
+  },
+  {
+    "id": "stadium-15-october",
+    "name": "Stadium 15 October",
+    "city": null,
+    "countryCode": "TUN",
+    "capacity": 20000,
+    "tenantClubs": [
+      "ca-bizertine"
+    ]
+  },
+  {
+    "id": "drei-flusse-stadion",
+    "name": "Drei Flüsse Stadion",
+    "city": null,
+    "countryCode": "DEU",
+    "capacity": 20000,
+    "tenantClubs": [
+      "1-fc-passau"
+    ]
+  },
+  {
+    "id": "stade-mustapha-ben-jannet",
+    "name": "Stade Mustapha Ben Jannet",
+    "city": null,
+    "countryCode": "TUN",
+    "capacity": 20000,
+    "tenantClubs": [
+      "us-monastir"
+    ]
+  },
+  {
+    "id": "warri-stadium",
+    "name": "Warri Stadium",
+    "city": null,
+    "countryCode": "NGA",
+    "capacity": 20000,
+    "tenantClubs": []
+  },
+  {
+    "id": "nehru-stadium-tumkur",
+    "name": "Nehru Stadium, Tumkur",
+    "city": null,
+    "countryCode": "IND",
+    "capacity": 20000,
+    "tenantClubs": []
+  },
+  {
+    "id": "thammasat-stadium",
+    "name": "Thammasat Stadium",
+    "city": "Thammasat University",
+    "countryCode": "THA",
+    "capacity": 20000,
+    "tenantClubs": [
+      "police-united-f-c"
+    ]
+  },
+  {
+    "id": "rn-shetty-stadium",
+    "name": "RN Shetty Stadium",
+    "city": "Dharwad",
+    "countryCode": "IND",
+    "capacity": 20000,
+    "tenantClubs": []
+  },
+  {
+    "id": "phillips-field",
+    "name": "Phillips Field",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 20000,
+    "tenantClubs": [
+      "tampa-spartans-football"
+    ]
+  },
+  {
+    "id": "q21660604",
+    "name": "Q21660604",
+    "city": null,
+    "countryCode": "UZB",
+    "capacity": 20000,
+    "tenantClubs": [
+      "fc-neftchi-fergana"
+    ]
+  },
+  {
+    "id": "bafoussam-omnisports-stadium",
+    "name": "Bafoussam omnisports stadium",
+    "city": "Bafoussam",
+    "countryCode": "CMR",
+    "capacity": 20000,
+    "tenantClubs": []
+  },
+  {
+    "id": "stade-larbi-benbarek",
+    "name": "Stade Larbi Benbarek",
+    "city": null,
+    "countryCode": "MAR",
+    "capacity": 20000,
+    "tenantClubs": [
+      "wydad-athletic-club"
+    ]
+  },
+  {
+    "id": "stadion-msk-povazska-bystrica",
+    "name": "Štadión MŠK Považská Bystrica",
+    "city": null,
+    "countryCode": "SVK",
+    "capacity": 20000,
+    "tenantClubs": [
+      "fk-raven-povazska-bystrica"
+    ]
+  },
+  {
+    "id": "krishnagiri-stadium",
+    "name": "Krishnagiri Stadium",
+    "city": "Krishnagiri Village",
+    "countryCode": "IND",
+    "capacity": 20000,
+    "tenantClubs": []
+  },
+  {
+    "id": "utama-negeri-stadium",
+    "name": "Utama Negeri Stadium",
+    "city": "Kangar",
+    "countryCode": "MYS",
+    "capacity": 20000,
+    "tenantClubs": [
+      "perlis-fa"
+    ]
+  },
+  {
+    "id": "helmy-zamora-stadium",
+    "name": "Helmy Zamora Stadium",
+    "city": null,
+    "countryCode": "EGY",
+    "capacity": 20000,
+    "tenantClubs": [
+      "zamalek-sc"
+    ]
+  },
+  {
+    "id": "stade-d-honneur",
+    "name": "Stade d'Honneur",
+    "city": null,
+    "countryCode": "MAR",
+    "capacity": 20000,
+    "tenantClubs": [
+      "cod-meknes"
+    ]
+  },
+  {
+    "id": "el-mahalla-stadium",
+    "name": "El Mahalla Stadium",
+    "city": null,
+    "countryCode": "EGY",
+    "capacity": 20000,
+    "tenantClubs": [
+      "ghazl-el-mahalla-sc"
+    ]
+  },
+  {
+    "id": "q3495900",
+    "name": "Q3495900",
+    "city": null,
+    "countryCode": "CIV",
+    "capacity": 20000,
+    "tenantClubs": [
+      "sporting-club-de-gagnoa"
+    ]
+  },
+  {
+    "id": "habib-bouakeul-stadium",
+    "name": "Habib Bouakeul Stadium",
+    "city": null,
+    "countryCode": "DZA",
+    "capacity": 20000,
+    "tenantClubs": [
+      "asm-oran",
+      "scm-oran"
+    ]
+  },
+  {
+    "id": "stade-el-harti",
+    "name": "Stade El Harti",
+    "city": null,
+    "countryCode": "MAR",
+    "capacity": 20000,
+    "tenantClubs": [
+      "kacm"
+    ]
+  },
+  {
+    "id": "stade-barema-bocoum",
+    "name": "Stade Baréma Bocoum",
+    "city": null,
+    "countryCode": "MLI",
+    "capacity": 20000,
+    "tenantClubs": []
+  },
+  {
+    "id": "somhlolo-national-stadium",
+    "name": "Somhlolo National Stadium",
+    "city": null,
+    "countryCode": "SWZ",
+    "capacity": 20000,
+    "tenantClubs": [
+      "eswatini-men-s-national-football-team"
+    ]
+  },
+  {
+    "id": "lanxess-arena",
+    "name": "Lanxess Arena",
+    "city": null,
+    "countryCode": "DEU",
+    "capacity": 20000,
+    "tenantClubs": [
+      "kolner-haie"
+    ]
+  },
+  {
+    "id": "pairc-esler",
+    "name": "Páirc Esler",
+    "city": null,
+    "countryCode": "GBR",
+    "capacity": 20000,
+    "tenantClubs": []
+  },
+  {
+    "id": "thai-army-sports-stadium",
+    "name": "Thai Army Sports Stadium",
+    "city": "Phaya Thai",
+    "countryCode": "THA",
+    "capacity": 20000,
+    "tenantClubs": [
+      "army-united-f-c"
+    ]
+  },
+  {
+    "id": "brawijaya-stadium",
+    "name": "Brawijaya Stadium",
+    "city": null,
+    "countryCode": "IDN",
+    "capacity": 20000,
+    "tenantClubs": [
+      "persik-kediri"
+    ]
+  },
+  {
+    "id": "shenzhen-bay-sports-center",
+    "name": "Shenzhen Bay Sports Center",
+    "city": "Nanshan District",
+    "countryCode": "CHN",
+    "capacity": 20000,
+    "tenantClubs": [
+      "2011-summer-universiade"
+    ]
+  },
+  {
+    "id": "king-abdullah-stadium",
+    "name": "King Abdullah Stadium",
+    "city": null,
+    "countryCode": "JOR",
+    "capacity": 20000,
+    "tenantClubs": [
+      "jordan-men-s-national-football-team"
+    ]
+  },
+  {
+    "id": "yuanshen-sports-centre-stadium",
+    "name": "Yuanshen Sports Centre Stadium",
+    "city": "Pudong",
+    "countryCode": "CHN",
+    "capacity": 20000,
+    "tenantClubs": [
+      "shanghai-shenxin-f-c"
+    ]
+  },
+  {
+    "id": "alfred-kunze-sportpark",
+    "name": "Alfred-Kunze-Sportpark",
+    "city": null,
+    "countryCode": "DEU",
+    "capacity": 20000,
+    "tenantClubs": [
+      "bsg-chemie-leipzig",
+      "fc-sachsen-leipzig",
+      "q14855286",
+      "q22813494",
+      "sc-lokomotive-leipzig",
+      "tura-leipzig"
+    ]
+  },
+  {
+    "id": "witbank-stadium",
+    "name": "Witbank Stadium",
+    "city": null,
+    "countryCode": "ZAF",
+    "capacity": 20000,
+    "tenantClubs": [
+      "mpumalanga-black-aces-f-c"
+    ]
+  },
+  {
+    "id": "estadio-municipal-de-la-linea-de-la-concepcion",
+    "name": "Estadio Municipal de La Línea de la Concepción",
+    "city": null,
+    "countryCode": "ESP",
+    "capacity": 20000,
+    "tenantClubs": [
+      "rb-linense"
+    ]
+  },
+  {
+    "id": "paul-greifzu-stadium",
+    "name": "Paul Greifzu Stadium",
+    "city": "Dessau",
+    "countryCode": "DEU",
+    "capacity": 20000,
+    "tenantClubs": [
+      "1-lac-dessau",
+      "sv-dessau-05"
+    ]
+  },
+  {
+    "id": "sylvie-becaert-biathlon-stadium",
+    "name": "Sylvie Becaert Biathlon Stadium",
+    "city": null,
+    "countryCode": "FRA",
+    "capacity": 20000,
+    "tenantClubs": []
+  },
+  {
+    "id": "zhongshan-soccer-stadium",
+    "name": "Zhongshan Soccer Stadium",
+    "city": null,
+    "countryCode": "TWN",
+    "capacity": 20000,
+    "tenantClubs": [
+      "chinese-taipei-men-s-national-football-team"
+    ]
+  },
+  {
+    "id": "claro-arena",
+    "name": "Claro Arena",
+    "city": null,
+    "countryCode": "CHL",
+    "capacity": 20000,
+    "tenantClubs": [
+      "club-deportivo-universidad-catolica"
+    ]
+  },
+  {
+    "id": "estadio-roberto-natalio-carminatti",
+    "name": "Estadio Roberto Natalio Carminatti",
+    "city": null,
+    "countryCode": "ARG",
+    "capacity": 20000,
+    "tenantClubs": [
+      "club-olimpo"
+    ]
+  },
+  {
+    "id": "ibercaja-stadium",
+    "name": "Ibercaja Stadium",
+    "city": null,
+    "countryCode": "ESP",
+    "capacity": 20000,
+    "tenantClubs": [
+      "real-zaragoza"
+    ]
+  },
+  {
+    "id": "q135438868",
+    "name": "Q135438868",
+    "city": "Phú Trinh",
+    "countryCode": "VNM",
+    "capacity": 20000,
+    "tenantClubs": []
+  },
+  {
+    "id": "tundavala-national-stadium",
+    "name": "Tundavala National Stadium",
+    "city": null,
+    "countryCode": "AGO",
+    "capacity": 20000,
+    "tenantClubs": []
+  },
+  {
+    "id": "estadio-nacional-do-chiazi",
+    "name": "Estádio Nacional do Chiazi",
+    "city": "Cabinda",
+    "countryCode": "AGO",
+    "capacity": 20000,
+    "tenantClubs": []
+  },
+  {
+    "id": "hoegeng-stadium",
+    "name": "Hoegeng Stadium",
+    "city": null,
+    "countryCode": "IDN",
+    "capacity": 20000,
+    "tenantClubs": [
+      "persip-pekalongan"
+    ]
+  },
+  {
+    "id": "estadio-vila-capanema",
+    "name": "Estádio Vila Capanema",
+    "city": null,
+    "countryCode": "BRA",
+    "capacity": 20000,
+    "tenantClubs": [
+      "clube-atletico-ferroviario",
+      "parana-clube"
+    ]
+  },
+  {
+    "id": "yatta-international-stadium",
+    "name": "Yatta International Stadium",
+    "city": null,
+    "countryCode": "PSE",
+    "capacity": 20000,
+    "tenantClubs": [
+      "shabab-yatta"
+    ]
+  },
+  {
+    "id": "pingguo-stadium",
+    "name": "Pingguo Stadium",
+    "city": "Pingguo City",
+    "countryCode": "CHN",
+    "capacity": 20000,
+    "tenantClubs": [
+      "guangxi-pingguo-haliao-f-c"
+    ]
+  },
+  {
+    "id": "iwate-morioka-ballpark",
+    "name": "Iwate Morioka Ballpark",
+    "city": null,
+    "countryCode": "JPN",
+    "capacity": 20000,
+    "tenantClubs": [
+      "north-tohoku-university-baseball-federation"
+    ]
+  },
+  {
+    "id": "otunba-dipo-dina-international-stadium",
+    "name": "Otunba Dipo Dina International Stadium",
+    "city": "Ijebu Ode",
+    "countryCode": "NGA",
+    "capacity": 20000,
+    "tenantClubs": []
+  },
+  {
+    "id": "ashdod-stadium",
+    "name": "Ashdod Stadium",
+    "city": "Rova Park Lakhish",
+    "countryCode": "ISR",
+    "capacity": 20000,
+    "tenantClubs": [
+      "f-c-ashdod"
+    ]
+  },
+  {
+    "id": "miki-athletic-stadium",
+    "name": "Miki Athletic Stadium",
+    "city": null,
+    "countryCode": "JPN",
+    "capacity": 20000,
+    "tenantClubs": []
+  },
+  {
+    "id": "abdelkrim-kerroum-stadium",
+    "name": "Abdelkrim Kerroum Stadium",
+    "city": null,
+    "countryCode": "DZA",
+    "capacity": 20000,
+    "tenantClubs": [
+      "cc-sig"
+    ]
+  },
+  {
+    "id": "sekondi-takoradi-stadium",
+    "name": "Sekondi-Takoradi Stadium",
+    "city": "Sekondi-Takoradi",
+    "countryCode": "GHA",
+    "capacity": 20000,
+    "tenantClubs": [
+      "sekondi-hasaacas-f-c"
+    ]
+  },
+  {
+    "id": "seisa-ramabodu-stadium",
+    "name": "Seisa Ramabodu Stadium",
+    "city": null,
+    "countryCode": "ZAF",
+    "capacity": 20000,
+    "tenantClubs": [
+      "bloemfontein-celtic-f-c"
+    ]
+  },
+  {
+    "id": "pitbull-stadium",
+    "name": "Pitbull Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 20000,
+    "tenantClubs": [
+      "fiu-panthers",
+      "fiu-panthers-football",
+      "miami-fc"
+    ]
+  },
+  {
+    "id": "national-sports-stadium-mng",
+    "name": "National Sports Stadium",
+    "city": null,
+    "countryCode": "MNG",
+    "capacity": 20000,
+    "tenantClubs": [
+      "mongolia-men-s-national-football-team"
+    ]
+  },
+  {
+    "id": "polonia-bydgoszcz-stadium",
+    "name": "Polonia Bydgoszcz Stadium",
+    "city": null,
+    "countryCode": "POL",
+    "capacity": 20000,
+    "tenantClubs": [
+      "motorcycle-speedway"
+    ]
+  },
+  {
+    "id": "rondong-demang-stadium",
+    "name": "Rondong Demang Stadium",
+    "city": "Tenggarong",
+    "countryCode": "IDN",
+    "capacity": 20000,
+    "tenantClubs": [
+      "mitra-kukar-f-c"
+    ]
+  },
+  {
+    "id": "providence-stadium",
+    "name": "Providence Stadium",
+    "city": "Providence",
+    "countryCode": "GUY",
+    "capacity": 20000,
+    "tenantClubs": [
+      "west-indies-cricket-team"
+    ]
+  },
+  {
+    "id": "stadium-lichtenberg",
+    "name": "Stadium Lichtenberg",
+    "city": "Lichtenberg",
+    "countryCode": "DEU",
+    "capacity": 20000,
+    "tenantClubs": []
+  },
+  {
+    "id": "andres-quintana-roo-olympic-stadium",
+    "name": "Andrés Quintana Roo Olympic Stadium",
+    "city": null,
+    "countryCode": "MEX",
+    "capacity": 20000,
+    "tenantClubs": [
+      "atlante-f-c"
+    ]
+  },
+  {
+    "id": "district-stadium-chattogram",
+    "name": "District Stadium, Chattogram",
+    "city": "Chittagong",
+    "countryCode": "BGD",
+    "capacity": 20000,
+    "tenantClubs": []
+  },
+  {
+    "id": "planet-group-arena",
+    "name": "Planet Group arena",
+    "city": null,
+    "countryCode": "BEL",
+    "capacity": 20000,
+    "tenantClubs": [
+      "kaa-gent"
+    ]
+  },
+  {
+    "id": "sunset-stadium",
+    "name": "Sunset Stadium",
+    "city": null,
+    "countryCode": "ZMB",
+    "capacity": 20000,
+    "tenantClubs": [
+      "zanaco-f-c"
+    ]
+  },
+  {
+    "id": "limbe-stadium",
+    "name": "Limbe Stadium",
+    "city": null,
+    "countryCode": "CMR",
+    "capacity": 20000,
+    "tenantClubs": []
+  },
+  {
+    "id": "philippine-stadium",
+    "name": "Philippine Stadium",
+    "city": null,
+    "countryCode": "PHL",
+    "capacity": 20000,
+    "tenantClubs": [
+      "philippines-men-s-national-association-football-team"
+    ]
+  },
+  {
+    "id": "silli-stadium",
+    "name": "Silli Stadium",
+    "city": null,
+    "countryCode": "IND",
+    "capacity": 20000,
+    "tenantClubs": []
+  },
+  {
+    "id": "kalyani-stadium",
+    "name": "Kalyani Stadium",
+    "city": "Kalyani",
+    "countryCode": "IND",
+    "capacity": 20000,
+    "tenantClubs": [
+      "prayag-united-s-c"
+    ]
+  },
+  {
+    "id": "q16557592",
+    "name": "Q16557592",
+    "city": null,
+    "countryCode": "AFG",
+    "capacity": 20000,
+    "tenantClubs": []
+  },
+  {
+    "id": "stade-20-aout-1955",
+    "name": "Stade 20 Août 1955",
+    "city": null,
+    "countryCode": "DZA",
+    "capacity": 20000,
+    "tenantClubs": [
+      "ca-bordj-bou-arreridj"
+    ]
+  },
+  {
+    "id": "university-of-tehran-stadium",
+    "name": "University of Tehran Stadium",
+    "city": "Amir Abad",
+    "countryCode": "IRN",
+    "capacity": 20000,
+    "tenantClubs": []
+  },
+  {
+    "id": "dr-akhilesh-das-stadium",
+    "name": "Dr. Akhilesh Das Stadium",
+    "city": null,
+    "countryCode": "IND",
+    "capacity": 20000,
+    "tenantClubs": [
+      "uttar-pradesh-cricket-team"
+    ]
+  },
+  {
+    "id": "ptt-stadium",
+    "name": "PTT Stadium",
+    "city": "Mueang Rayong",
+    "countryCode": "THA",
+    "capacity": 20000,
+    "tenantClubs": [
+      "ptt-rayong"
+    ]
+  },
+  {
+    "id": "muhoroni-stadium",
+    "name": "Muhoroni Stadium",
+    "city": null,
+    "countryCode": "KEN",
+    "capacity": 20000,
+    "tenantClubs": []
+  },
+  {
+    "id": "stadion-stari-plac",
+    "name": "Stadion Stari plac",
+    "city": null,
+    "countryCode": "HRV",
+    "capacity": 20000,
+    "tenantClubs": [
+      "hnk-hajduk-split"
+    ]
+  },
+  {
+    "id": "tunas-bangsa-stadium",
+    "name": "Tunas Bangsa Stadium",
+    "city": null,
+    "countryCode": "IDN",
+    "capacity": 20000,
+    "tenantClubs": [
+      "psls-lhokseumawe"
+    ]
+  },
+  {
+    "id": "national-cricket-stadium",
+    "name": "National Cricket Stadium",
+    "city": "Grenada",
+    "countryCode": "GRD",
+    "capacity": 20000,
+    "tenantClubs": []
+  },
+  {
+    "id": "campos-de-sports-de-nunoa",
+    "name": "Campos de Sports de Ñuñoa",
+    "city": null,
+    "countryCode": "CHL",
+    "capacity": 20000,
+    "tenantClubs": [
+      "chile-men-s-national-football-team"
+    ]
+  },
+  {
+    "id": "len-clay-stadium",
+    "name": "Len Clay Stadium",
+    "city": "Obuasi",
+    "countryCode": "GHA",
+    "capacity": 20000,
+    "tenantClubs": [
+      "ashanti-gold-sc"
+    ]
+  },
+  {
+    "id": "new-clark-city-athletics-stadium",
+    "name": "New Clark City Athletics Stadium",
+    "city": "New Clark City",
+    "countryCode": "PHL",
+    "capacity": 20000,
+    "tenantClubs": []
+  },
+  {
+    "id": "langari-langarieva-stadium",
+    "name": "Langari Langarieva Stadium",
+    "city": null,
+    "countryCode": "TJK",
+    "capacity": 20000,
+    "tenantClubs": [
+      "ravshan-kulob"
+    ]
+  },
+  {
+    "id": "lake-tanganyika-stadium",
+    "name": "Lake Tanganyika Stadium",
+    "city": null,
+    "countryCode": "TZA",
+    "capacity": 20000,
+    "tenantClubs": []
+  },
+  {
+    "id": "kimbrough-memorial-stadium",
+    "name": "Kimbrough Memorial Stadium",
+    "city": "Canyon",
+    "countryCode": "USA",
+    "capacity": 20000,
+    "tenantClubs": [
+      "west-texas-a-m-buffaloes-football"
+    ]
+  },
+  {
+    "id": "kashiwanoha-park-stadium",
+    "name": "Kashiwanoha Park Stadium",
+    "city": "Kashiwanoha Park",
+    "countryCode": "JPN",
+    "capacity": 20000,
+    "tenantClubs": [
+      "kashiwa-reysol",
+      "nec-green-rockets-tokatsu"
+    ]
+  },
+  {
+    "id": "stadionul-municipal-rou",
+    "name": "Stadionul Municipal",
+    "city": null,
+    "countryCode": "ROU",
+    "capacity": 20000,
+    "tenantClubs": [
+      "afc-dacia-unirea-braila"
+    ]
+  },
+  {
+    "id": "shahid-beheshti-stadium",
+    "name": "Shahid Beheshti Stadium",
+    "city": null,
+    "countryCode": "IRN",
+    "capacity": 20000,
+    "tenantClubs": [
+      "iranjavan-f-c"
+    ]
+  },
+  {
+    "id": "jinju-public-stadium",
+    "name": "Jinju Public Stadium",
+    "city": null,
+    "countryCode": "KOR",
+    "capacity": 20000,
+    "tenantClubs": []
+  },
+  {
+    "id": "jamhuri-stadium",
+    "name": "Jamhuri Stadium",
+    "city": "Morogoro",
+    "countryCode": "TZA",
+    "capacity": 20000,
+    "tenantClubs": []
+  },
+  {
+    "id": "stadium-metallurg-1st-district",
+    "name": "Stadium Metallurg 1st District",
+    "city": null,
+    "countryCode": "TJK",
+    "capacity": 20000,
+    "tenantClubs": [
+      "regar-tadaz-tursunzoda"
+    ]
+  },
+  {
+    "id": "estadio-luiz-viana-filho-itabuna",
+    "name": "Estádio Luiz Viana Filho, Itabuna",
+    "city": null,
+    "countryCode": "BRA",
+    "capacity": 20000,
+    "tenantClubs": []
+  },
+  {
+    "id": "hama-municipal-stadium",
+    "name": "Hama Municipal Stadium",
+    "city": null,
+    "countryCode": "SYR",
+    "capacity": 20000,
+    "tenantClubs": [
+      "nawair-sc"
+    ]
+  },
+  {
+    "id": "lincoln-yards-stadium",
+    "name": "Lincoln Yards Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 20000,
+    "tenantClubs": [
+      "usl-chicago"
+    ]
+  },
+  {
+    "id": "gelora-bumi-kartini-stadium",
+    "name": "Gelora Bumi Kartini Stadium",
+    "city": "Jepara",
+    "countryCode": "IDN",
+    "capacity": 20000,
+    "tenantClubs": [
+      "persijap-jepara"
+    ]
+  },
+  {
+    "id": "gmr-stadium",
+    "name": "GMR Stadium",
+    "city": null,
+    "countryCode": "LBY",
+    "capacity": 20000,
+    "tenantClubs": []
+  },
+  {
+    "id": "la-peineta",
+    "name": "La Peineta",
+    "city": null,
+    "countryCode": "ESP",
+    "capacity": 20000,
+    "tenantClubs": []
+  },
+  {
+    "id": "stade-charlety",
+    "name": "Stade Charléty",
+    "city": "13th arrondissement of Paris",
+    "countryCode": "FRA",
+    "capacity": 20000,
+    "tenantClubs": [
+      "paris-fc",
+      "paris-saint-germain-rugby-league"
+    ]
+  },
+  {
+    "id": "mike-a-myers-stadium",
+    "name": "Mike A. Myers Stadium",
+    "city": "Austin",
+    "countryCode": "USA",
+    "capacity": 20000,
+    "tenantClubs": [
+      "texas-longhorns-men-s-track-and-field",
+      "texas-longhorns-women-s-soccer",
+      "texas-longhorns-women-s-track-and-field",
+      "texas-relays"
+    ]
+  },
+  {
+    "id": "stade-municipale",
+    "name": "Stade Municipale",
+    "city": null,
+    "countryCode": "BEN",
+    "capacity": 20000,
+    "tenantClubs": []
+  },
+  {
+    "id": "stade-paul-sayal-moukila",
+    "name": "Stade Paul Sayal Moukila",
+    "city": null,
+    "countryCode": "COG",
+    "capacity": 20000,
+    "tenantClubs": [
+      "ac-leopards"
+    ]
+  },
+  {
+    "id": "snow-harp",
+    "name": "Snow Harp",
+    "city": null,
+    "countryCode": "JPN",
+    "capacity": 20000,
+    "tenantClubs": []
+  },
+  {
+    "id": "silver-stadium-lilongwe",
+    "name": "Silver Stadium, Lilongwe",
+    "city": "Lilongwe",
+    "countryCode": "MWI",
+    "capacity": 20000,
+    "tenantClubs": [
+      "silver-strikers-f-c"
+    ]
+  },
+  {
+    "id": "sheikh-zayed-cricket-stadium",
+    "name": "Sheikh Zayed Cricket Stadium",
+    "city": "Abu Dhabi",
+    "countryCode": "ARE",
+    "capacity": 20000,
+    "tenantClubs": []
+  },
+  {
+    "id": "sheikh-amri-abeid-memorial-stadium",
+    "name": "Sheikh Amri Abeid Memorial Stadium",
+    "city": null,
+    "countryCode": "TZA",
+    "capacity": 20000,
+    "tenantClubs": []
+  },
+  {
+    "id": "cicero-stadium",
+    "name": "Cicero Stadium",
+    "city": "Asmara",
+    "countryCode": "ERI",
+    "capacity": 20000,
+    "tenantClubs": [
+      "adulis-club",
+      "asmara-calcio",
+      "edaga-hamus",
+      "eritrea-men-s-national-football-team",
+      "hintsa-fc",
+      "red-sea-fc"
+    ]
+  },
+  {
+    "id": "samuel-ogbemudia-stadium",
+    "name": "Samuel Ogbemudia Stadium",
+    "city": null,
+    "countryCode": "NGA",
+    "capacity": 20000,
+    "tenantClubs": [
+      "bendel-insurance-f-c"
+    ]
+  },
+  {
+    "id": "rajiv-gandhi-stadium-mualpui",
+    "name": "Rajiv Gandhi Stadium Mualpui",
+    "city": null,
+    "countryCode": "IND",
+    "capacity": 20000,
+    "tenantClubs": [
+      "aizawl-f-c"
+    ]
+  },
+  {
+    "id": "pilditch-stadium",
+    "name": "Pilditch Stadium",
+    "city": null,
+    "countryCode": "ZAF",
+    "capacity": 20000,
+    "tenantClubs": [
+      "supersport-united-f-c"
+    ]
+  },
+  {
+    "id": "philsports-football-and-athletics-stadium",
+    "name": "PhilSports Football and Athletics Stadium",
+    "city": "Pasig",
+    "countryCode": "PHL",
+    "capacity": 20000,
+    "tenantClubs": [
+      "national-capital-region-f-a"
+    ]
+  },
+  {
+    "id": "estadio-neza-86",
+    "name": "Estadio Neza 86",
+    "city": null,
+    "countryCode": "MEX",
+    "capacity": 20000,
+    "tenantClubs": [
+      "deportivo-neza"
+    ]
+  },
+  {
+    "id": "ningineer-stadium",
+    "name": "Ningineer Stadium",
+    "city": "Matsuyama",
+    "countryCode": "JPN",
+    "capacity": 20000,
+    "tenantClubs": [
+      "ehime-fc"
+    ]
+  },
+  {
+    "id": "nagoya-city-minato-soccer-stadium",
+    "name": "Nagoya City Minato Soccer Stadium",
+    "city": null,
+    "countryCode": "JPN",
+    "capacity": 20000,
+    "tenantClubs": [
+      "fc-maruyasu-okazaki"
+    ]
+  },
+  {
+    "id": "moruleng-stadium",
+    "name": "Moruleng Stadium",
+    "city": null,
+    "countryCode": "ZAF",
+    "capacity": 20000,
+    "tenantClubs": [
+      "platinum-stars-f-c"
+    ]
+  },
+  {
+    "id": "hinata-athletic-stadium",
+    "name": "Hinata Athletic Stadium",
+    "city": null,
+    "countryCode": "JPN",
+    "capacity": 20000,
+    "tenantClubs": [
+      "minebea-mitsumi-fc"
+    ]
+  },
+  {
+    "id": "ashgabat-stadium",
+    "name": "Ashgabat Stadium",
+    "city": null,
+    "countryCode": "TKM",
+    "capacity": 20000,
+    "tenantClubs": [
+      "fc-asgabat"
+    ]
+  },
+  {
+    "id": "estadio-do-lumiar",
+    "name": "Estádio do Lumiar",
+    "city": null,
+    "countryCode": "PRT",
+    "capacity": 20000,
+    "tenantClubs": []
+  },
+  {
+    "id": "estadio-juca-ribeiro",
+    "name": "Estádio Juca Ribeiro",
+    "city": "Uberlândia",
+    "countryCode": "BRA",
+    "capacity": 20000,
+    "tenantClubs": [
+      "uberlandia-e-c"
+    ]
+  },
+  {
+    "id": "estadio-jonas-duarte",
+    "name": "Estádio Jonas Duarte",
+    "city": null,
+    "countryCode": "BRA",
+    "capacity": 20000,
+    "tenantClubs": [
+      "associacao-atletica-anapolina"
+    ]
+  },
+  {
+    "id": "rotorua-international-stadium",
+    "name": "Rotorua International Stadium",
+    "city": "Westbrook",
+    "countryCode": "NZL",
+    "capacity": 20000,
+    "tenantClubs": [
+      "bay-of-plenty-ru"
+    ]
+  },
+  {
+    "id": "ali-daei-stadium",
+    "name": "Ali Daei Stadium",
+    "city": null,
+    "countryCode": "IRN",
+    "capacity": 20000,
+    "tenantClubs": [
+      "zob-ahan-ardabil-f-c"
+    ]
+  },
+  {
+    "id": "shijingshan-stadium",
+    "name": "Shijingshan Stadium",
+    "city": null,
+    "countryCode": "CHN",
+    "capacity": 20000,
+    "tenantClubs": []
+  },
+  {
+    "id": "hamad-bin-khalifa-stadium",
+    "name": "Hamad bin Khalifa Stadium",
+    "city": null,
+    "countryCode": "QAT",
+    "capacity": 20000,
+    "tenantClubs": [
+      "al-ahli-sc"
+    ]
+  },
+  {
+    "id": "al-kut-olympic-stadium",
+    "name": "Al-Kut Olympic Stadium",
+    "city": "Kut",
+    "countryCode": "IRQ",
+    "capacity": 20000,
+    "tenantClubs": []
+  },
+  {
+    "id": "teladan-stadium",
+    "name": "Teladan Stadium",
+    "city": null,
+    "countryCode": "IDN",
+    "capacity": 20000,
+    "tenantClubs": [
+      "psms-medan"
+    ]
+  },
+  {
+    "id": "al-muharraq-stadium",
+    "name": "Al Muharraq Stadium",
+    "city": "Arad",
+    "countryCode": "BHR",
+    "capacity": 20000,
+    "tenantClubs": [
+      "al-muharraq-sc"
+    ]
+  },
+  {
+    "id": "aswan-stadium",
+    "name": "Aswan Stadium",
+    "city": null,
+    "countryCode": "EGY",
+    "capacity": 20000,
+    "tenantClubs": [
+      "aswan-sc"
+    ]
+  },
+  {
+    "id": "huadu-sports-centre",
+    "name": "Huadu Sports Centre",
+    "city": null,
+    "countryCode": "CHN",
+    "capacity": 20000,
+    "tenantClubs": []
+  },
+  {
+    "id": "estadio-24-de-setembro",
+    "name": "Estádio 24 de Setembro",
+    "city": null,
+    "countryCode": "GNB",
+    "capacity": 20000,
+    "tenantClubs": [
+      "guinea-bissau-men-s-national-football-team"
+    ]
+  },
+  {
+    "id": "setsoto-stadium",
+    "name": "Setsoto Stadium",
+    "city": null,
+    "countryCode": "LSO",
+    "capacity": 20000,
+    "tenantClubs": [
+      "lesotho-men-s-national-football-team"
+    ]
+  },
+  {
+    "id": "prince-sultan-bin-abdulaziz-sports-city",
+    "name": "Prince Sultan bin Abdulaziz Sports City",
+    "city": "Abha",
+    "countryCode": "SAU",
+    "capacity": 20000,
+    "tenantClubs": []
+  },
+  {
+    "id": "avanhard-stadium",
+    "name": "Avanhard Stadium",
+    "city": null,
+    "countryCode": "UKR",
+    "capacity": 20000,
+    "tenantClubs": [
+      "nk-veres-rivne"
+    ]
+  },
+  {
+    "id": "yuexiushan-stadium",
+    "name": "Yuexiushan Stadium",
+    "city": null,
+    "countryCode": "CHN",
+    "capacity": 20000,
+    "tenantClubs": [
+      "guangdong-gz-power-f-c",
+      "guangzhou-city-f-c",
+      "guangzhou-f-c"
+    ]
+  },
+  {
+    "id": "q3967962",
+    "name": "Q3967962",
+    "city": null,
+    "countryCode": "POL",
+    "capacity": 20000,
+    "tenantClubs": [
+      "olimpia-poznan"
+    ]
+  },
+  {
+    "id": "bezerrao",
+    "name": "Bezerrão",
+    "city": null,
+    "countryCode": "BRA",
+    "capacity": 20000,
+    "tenantClubs": [
+      "sociedade-esportiva-do-gama"
+    ]
+  },
+  {
+    "id": "city-stadium-mys",
+    "name": "City Stadium",
+    "city": null,
+    "countryCode": "MYS",
+    "capacity": 20000,
+    "tenantClubs": [
+      "penang-f-c"
+    ]
+  },
+  {
+    "id": "suwon-baseball-stadium",
+    "name": "Suwon Baseball Stadium",
+    "city": null,
+    "countryCode": "KOR",
+    "capacity": 20000,
+    "tenantClubs": [
+      "kt-wiz"
+    ]
+  },
+  {
+    "id": "barikadimy-stadium",
+    "name": "Barikadimy Stadium",
+    "city": null,
+    "countryCode": "MDG",
+    "capacity": 20000,
+    "tenantClubs": [
+      "as-fortior"
+    ]
+  },
+  {
+    "id": "charles-konan-banny-stadium",
+    "name": "Charles Konan Banny Stadium",
+    "city": null,
+    "countryCode": "CIV",
+    "capacity": 20000,
+    "tenantClubs": [
+      "ivory-coast-men-s-national-football-team"
+    ]
+  },
+  {
+    "id": "estadio-de-nervion",
+    "name": "Estadio de Nervión",
+    "city": null,
+    "countryCode": "ESP",
+    "capacity": 20000,
+    "tenantClubs": [
+      "sevilla-fc"
+    ]
+  },
+  {
+    "id": "estadio-heraclio-tapia",
+    "name": "Estadio Heraclio Tapia",
+    "city": null,
+    "countryCode": "PER",
+    "capacity": 20000,
+    "tenantClubs": [
+      "leon-de-huanuco"
+    ]
+  },
+  {
+    "id": "the-o2-arena",
+    "name": "The O2 Arena",
+    "city": "Greenwich Peninsula",
+    "countryCode": "GBR",
+    "capacity": 20000,
+    "tenantClubs": []
+  },
+  {
+    "id": "kanko-stadium",
+    "name": "Kanko Stadium",
+    "city": "Okayama",
+    "countryCode": "JPN",
+    "capacity": 20000,
+    "tenantClubs": [
+      "fagiano-okayama"
+    ]
+  },
+  {
+    "id": "trinity-health-stadium",
+    "name": "Trinity Health Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 20000,
+    "tenantClubs": [
+      "connecticut-bicentennials",
+      "hartford-athletic"
+    ]
+  },
+  {
+    "id": "denden-stadium",
+    "name": "Denden Stadium",
+    "city": null,
+    "countryCode": "ERI",
+    "capacity": 20000,
+    "tenantClubs": []
+  },
+  {
+    "id": "clarke-stadium",
+    "name": "Clarke Stadium",
+    "city": null,
+    "countryCode": "CAN",
+    "capacity": 20000,
+    "tenantClubs": [
+      "edmonton-elks",
+      "fc-edmonton"
+    ]
+  },
+  {
+    "id": "clark-field",
+    "name": "Clark Field",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 20000,
+    "tenantClubs": [
+      "texas-longhorns-football"
+    ]
+  },
+  {
+    "id": "chuncheon-songam-sports-town",
+    "name": "Chuncheon Songam Sports Town",
+    "city": null,
+    "countryCode": "KOR",
+    "capacity": 20000,
+    "tenantClubs": [
+      "gangwon-fc"
+    ]
+  },
+  {
+    "id": "campbelltown-stadium",
+    "name": "Campbelltown Stadium",
+    "city": null,
+    "countryCode": "AUS",
+    "capacity": 20000,
+    "tenantClubs": [
+      "western-suburbs-magpies",
+      "wests-tigers-women"
+    ]
+  },
+  {
+    "id": "bumi-sriwijaya-stadium",
+    "name": "Bumi Sriwijaya Stadium",
+    "city": null,
+    "countryCode": "IDN",
+    "capacity": 20000,
+    "tenantClubs": [
+      "ps-palembang"
+    ]
+  },
+  {
+    "id": "brown-stadium",
+    "name": "Brown Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 20000,
+    "tenantClubs": [
+      "brown-bears"
+    ]
+  },
+  {
+    "id": "brooks-stadium",
+    "name": "Brooks Stadium",
+    "city": "Conway",
+    "countryCode": "USA",
+    "capacity": 20000,
+    "tenantClubs": [
+      "coastal-carolina-chanticleers-football"
+    ]
+  },
+  {
+    "id": "brentford-community-stadium",
+    "name": "Brentford Community Stadium",
+    "city": null,
+    "countryCode": "GBR",
+    "capacity": 20000,
+    "tenantClubs": [
+      "brentford-f-c",
+      "london-irish-rfc"
+    ]
+  },
+  {
+    "id": "botshabelo-stadium",
+    "name": "Botshabelo Stadium",
+    "city": null,
+    "countryCode": "ZAF",
+    "capacity": 20000,
+    "tenantClubs": []
+  },
+  {
+    "id": "laurent-pokou-stadium",
+    "name": "Laurent Pokou Stadium",
+    "city": "San-Pédro",
+    "countryCode": "CIV",
+    "capacity": 20000,
+    "tenantClubs": [
+      "ivory-coast-men-s-national-football-team"
+    ]
+  },
+  {
+    "id": "amadou-gon-coulibaly-stadium",
+    "name": "Amadou Gon Coulibaly Stadium",
+    "city": null,
+    "countryCode": "CIV",
+    "capacity": 20000,
+    "tenantClubs": [
+      "ivory-coast-men-s-national-football-team"
+    ]
+  },
+  {
+    "id": "estadio-la-barranquita",
+    "name": "Estadio La Barranquita",
+    "city": null,
+    "countryCode": "DOM",
+    "capacity": 20000,
+    "tenantClubs": [
+      "club-barcelona-atletico"
+    ]
+  },
+  {
+    "id": "seatgeek-stadium",
+    "name": "SeatGeek Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 20000,
+    "tenantClubs": [
+      "chicago-fire-fc",
+      "chicago-hounds",
+      "chicago-stars-fc"
+    ]
+  }
+]

--- a/src/FantasyFootball.Core/Services/EmbeddedVenueRegistry.cs
+++ b/src/FantasyFootball.Core/Services/EmbeddedVenueRegistry.cs
@@ -1,0 +1,30 @@
+using System.Reflection;
+using System.Text.Json;
+using FantasyFootball.Models;
+
+namespace FantasyFootball.Services;
+
+/// <summary>
+/// Loads the bundled <c>venues.json</c> (embedded resource at
+/// <c>FantasyFootball.Resources.Data.venues.json</c>) once and serves
+/// lookups from an in-memory dictionary. Same loading shape as
+/// <see cref="EmbeddedCompetitionDefinitionStore"/> — single-pass deserialize
+/// at construction, no caching layer or invalidation.
+/// </summary>
+public sealed class EmbeddedVenueRegistry : IVenueRegistry
+{
+	const string VenuesResource = "FantasyFootball.Resources.Data.venues.json";
+
+	readonly Dictionary<string, Venue> _byId;
+
+	public EmbeddedVenueRegistry()
+	{
+		using var stream = typeof(EmbeddedVenueRegistry).Assembly.GetManifestResourceStream(VenuesResource)
+			?? throw new FileNotFoundException($"{VenuesResource} not found in embedded resources");
+		var venues = JsonSerializer.Deserialize<Venue[]>(stream, FlatJson.Options)
+			?? throw new FormatException("venues.json deserialized to null");
+		_byId = venues.ToDictionary(v => v.Id, v => v);
+	}
+
+	public Venue? Get(string id) => _byId.TryGetValue(id, out var v) ? v : null;
+}

--- a/src/FantasyFootball.Core/Services/IVenueRegistry.cs
+++ b/src/FantasyFootball.Core/Services/IVenueRegistry.cs
@@ -1,0 +1,15 @@
+using FantasyFootball.Models;
+
+namespace FantasyFootball.Services;
+
+/// <summary>
+/// Lookup surface for the global venue catalog (~1700 stadiums bundled from
+/// Wikidata SPARQL; see tools/fetch-venues.ps1). Resolves a venue by its slug
+/// id — e.g. <c>"metlife-stadium"</c> — to the full Venue record. Returns
+/// null for unknown ids so callers can render games whose <c>VenueId</c>
+/// references a stadium not in the bundled set.
+/// </summary>
+public interface IVenueRegistry
+{
+	Venue? Get(string id);
+}

--- a/src/FantasyFootball.UI/Components/GameViewRow.razor
+++ b/src/FantasyFootball.UI/Components/GameViewRow.razor
@@ -4,6 +4,7 @@
 @using FantasyFootball.Services
 @inject IDataService DataService
 @inject ICompetitionRepository Repo
+@inject IVenueRegistry VenueRegistry
 
 <div class="scoreboard-row-wrapper" id="@(ShowSim ? "current-game" : ShowUndo ? "just-finished-game" : null)">
 <div class="scoreboard-row @(IsJustFinished ? "scoreboard-row-just-finished" : "") @(DetailsOpen ? "scoreboard-row-open" : "")"
@@ -72,6 +73,20 @@
             Class="game-details-popover">
   @if (DetailsOpen)
   {
+    @if (_venue is not null)
+    {
+      <div class="game-details-row">
+        <span class="game-details-label">Venue</span>
+        <span class="game-details-value game-details-value-text">@_venue.Name@(_venue.City is { } c ? $" · {c}" : "") · cap. @_venue.Capacity.ToString("N0")</span>
+      </div>
+    }
+    @if (Game.Attendance is { } att)
+    {
+      <div class="game-details-row">
+        <span class="game-details-label">Attendance</span>
+        <span class="game-details-value">@att.ToString("N0")</span>
+      </div>
+    }
     @if (_homeTeam is null || _awayTeam is null)
     {
       <MudText Typo="Typo.body2">Teams not yet decided.</MudText>
@@ -136,6 +151,7 @@
 
   Team? _homeTeam;
   Team? _awayTeam;
+  Venue? _venue;
   string _homeLabel = "";
   string _awayLabel = "";
   string _groupLetter = "";
@@ -151,6 +167,7 @@
     var awayId = CompetitionExtensions.AwayTeamIdOf(Game);
     _homeTeam = homeId is null ? null : DataService.AllTeams.FirstOrDefault(t => t.ShortName == homeId);
     _awayTeam = awayId is null ? null : DataService.AllTeams.FirstOrDefault(t => t.ShortName == awayId);
+    _venue = Game.VenueId is { } vid ? VenueRegistry.Get(vid) : null;
 
     // Resolved team → Name; unresolved KO slot → "Winner of R16 #1"; otherwise raw id.
     _homeLabel = _homeTeam?.Name ?? LabelForUnresolved(Game, isHome: true) ?? homeId ?? "?";

--- a/src/FantasyFootball.Web/Program.cs
+++ b/src/FantasyFootball.Web/Program.cs
@@ -34,6 +34,7 @@ builder.Services.AddScoped<ISettingsService, LocalStorageSettingsService>();
 builder.Services.AddScoped<IDataService, CsvDataService>();
 
 builder.Services.AddSingleton<ICompetitionDefinitionStore, EmbeddedCompetitionDefinitionStore>();
+builder.Services.AddSingleton<IVenueRegistry, EmbeddedVenueRegistry>();
 builder.Services.AddScoped<ITeamRegistry, DataServiceTeamRegistry>();
 builder.Services.AddScoped<ICompetitionRepository, LocalStorageCompetitionRepository>();
 builder.Services.AddScoped<CompetitionFactory>();

--- a/src/FantasyFootball.Web/wwwroot/app.css
+++ b/src/FantasyFootball.Web/wwwroot/app.css
@@ -300,17 +300,27 @@ body {
 
 .game-details-popover {
   padding: 0.75rem 1rem;
-  min-width: 18rem;
-  max-width: 22rem;
+  min-width: 20rem;
+  max-width: 28rem;
 }
 
 .game-details-row {
   display: flex;
   justify-content: space-between;
   align-items: baseline;
+  gap: 1rem;
   font-size: 0.85rem;
   padding: 0.15rem 0;
   font-variant-numeric: tabular-nums;
+}
+
+/* Long-text value (e.g. Venue) — allow wrap to a second line from the right edge rather than running into the label. */
+.game-details-value-text {
+  text-align: right;
+  white-space: normal;
+  overflow-wrap: anywhere;
+  flex: 1 1 auto;
+  min-width: 0;
 }
 
 .game-details-label {

--- a/tools/fetch-venues.ps1
+++ b/tools/fetch-venues.ps1
@@ -1,0 +1,118 @@
+# Bulk-fetch football venue data from Wikidata's public SPARQL endpoint.
+# One-time refresh; output bundled at src/FantasyFootball.Core/Resources/Data/venues.json.
+#
+# Run from repo root:  pwsh ./tools/fetch-venues.ps1
+#
+# Same pattern as tools/refresh-elo.awk and tools/fetch-logos.sh: pinned source,
+# deterministic output. PowerShell is used here (instead of bash) because the
+# SPARQL response needs JSON aggregation across multi-tenant venues — bash
+# without jq is painful, PowerShell's ConvertFrom-Json handles it cleanly.
+
+$ErrorActionPreference = 'Stop'
+
+$Endpoint = 'https://query.wikidata.org/sparql'
+$UA = 'FantasyFootball-VenueFetch/0.1 (https://github.com/StepKie/FantasyFootball)'
+$OutPath = 'src/FantasyFootball.Core/Resources/Data/venues.json'
+$MinCapacity = 20000
+
+# Football stadiums (Q483110 and subclasses) with a known capacity, optional city,
+# country (via ISO-3166-1 alpha-3 code), and tenant club. Multi-tenant venues
+# return multiple rows we coalesce in post-processing.
+$Query = @"
+SELECT ?stadium ?stadiumLabel ?cityLabel ?countryCode ?capacity ?clubLabel WHERE {
+  ?stadium wdt:P31/wdt:P279* wd:Q483110 .
+  ?stadium wdt:P1083 ?capacity .
+  FILTER(?capacity >= $MinCapacity)
+  FILTER NOT EXISTS { ?stadium wdt:P576 ?dissolved . }   # exclude demolished / dissolved stadiums
+  OPTIONAL { ?stadium wdt:P276 ?city. }
+  OPTIONAL { ?stadium wdt:P17 ?country. ?country wdt:P298 ?countryCode. }
+  OPTIONAL { ?stadium wdt:P466 ?club. }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "en". }
+}
+ORDER BY DESC(?capacity)
+"@
+
+Write-Host "Querying Wikidata SPARQL endpoint (min capacity $MinCapacity)..."
+$response = Invoke-RestMethod -Uri $Endpoint `
+                              -Headers @{ 'User-Agent' = $UA; 'Accept' = 'application/sparql-results+json' } `
+                              -Method Post `
+                              -Body @{ query = $Query } `
+                              -ContentType 'application/x-www-form-urlencoded'
+
+$rows = $response.results.bindings
+Write-Host "  $($rows.Count) result rows (one per stadium-club pair)."
+
+function Slugify($name) {
+    if ([string]::IsNullOrWhiteSpace($name)) { return $null }
+    $normalized = $name.Normalize([System.Text.NormalizationForm]::FormD)
+    $sb = New-Object System.Text.StringBuilder
+    foreach ($c in $normalized.ToCharArray()) {
+        $cat = [System.Globalization.CharUnicodeInfo]::GetUnicodeCategory($c)
+        if ($cat -ne [System.Globalization.UnicodeCategory]::NonSpacingMark) { [void]$sb.Append($c) }
+    }
+    $ascii = $sb.ToString().Normalize([System.Text.NormalizationForm]::FormC)
+    $slug = ($ascii.ToLowerInvariant() -replace '[^a-z0-9]+', '-').Trim('-')
+    return $slug
+}
+
+# Group by stadium URI, then take the highest-capacity row as the canonical entry
+# and aggregate club tenants across rows.
+$venues = $rows | Group-Object { $_.stadium.value } | ForEach-Object {
+    $stadium = $_.Group[0]
+    $stadiumName = $stadium.stadiumLabel.value
+    $stadiumId = Slugify $stadiumName
+    if (-not $stadiumId) { return }
+
+    $cityName = $stadium.cityLabel.value
+    if ([string]::IsNullOrWhiteSpace($cityName)) { $cityName = $null }
+
+    $countryCode = $stadium.countryCode.value
+    if ([string]::IsNullOrWhiteSpace($countryCode)) { $countryCode = $null }
+
+    $capacity = [int]$stadium.capacity.value
+
+    $tenantClubs = @($_.Group |
+        Where-Object { $_.clubLabel -and $_.clubLabel.value } |
+        ForEach-Object { Slugify $_.clubLabel.value } |
+        Where-Object { $_ } |
+        Sort-Object -Unique)
+
+    [PSCustomObject]@{
+        id           = $stadiumId
+        name         = $stadiumName
+        city         = $cityName
+        countryCode  = $countryCode
+        capacity     = $capacity
+        tenantClubs  = $tenantClubs
+    }
+} | Where-Object {
+    # Drop venues whose only/primary tenant is a Nazi-era site (e.g. the never-built 400k-cap "Deutsches Stadion" with tenant `nazi-party-rally-grounds`). Substring match on slugified tenants — unrelated names with "ss-" prefixes (S.S. Lazio, PSS Sleman, SGS Essen, holy-cross-crusaders) are not affected.
+    -not ($_.tenantClubs | Where-Object { $_ -match 'nazi' })
+} | Sort-Object capacity -Descending
+
+# Dedupe by slug. Stadiums with identical names occur in two flavors:
+#   (a) Different countries → first occurrence keeps the base slug, others get a country-code suffix.
+#   (b) Same country (e.g. three Russian "Central Stadium"s with city=null) → fall through to a numeric tiebreaker.
+# Order is capacity-desc, so the largest venue keeps the cleanest slug — stable across refreshes
+# unless a higher-capacity entrant appears.
+$bySlug = @{}
+$final = New-Object System.Collections.Generic.List[Object]
+foreach ($v in $venues) {
+    $base = $v.id
+    $cc = if ($v.countryCode) { $v.countryCode.ToLowerInvariant() } else { 'x' }
+    $candidates = @($base, "$base-$cc") + (2..99 | ForEach-Object { "$base-$cc-$_" })
+    $picked = $candidates | Where-Object { -not $bySlug.ContainsKey($_) } | Select-Object -First 1
+    if (-not $picked) { throw "Could not disambiguate $base (too many collisions)" }
+    if ($picked -ne $v.id) {
+        $v = $v | Select-Object id, name, city, countryCode, capacity, tenantClubs
+        $v.id = $picked
+    }
+    $bySlug[$picked] = $true
+    $final.Add($v)
+}
+
+Write-Host "  $($final.Count) unique stadiums after dedup."
+
+$json = $final | ConvertTo-Json -Depth 4
+Set-Content -Path $OutPath -Value $json -Encoding UTF8
+Write-Host "Wrote $OutPath"


### PR DESCRIPTION
## Summary

- Adds a global venue registry (`IVenueRegistry` + `EmbeddedVenueRegistry`) backed by a bundled `venues.json` of ~1,744 stadiums from Wikidata SPARQL, plus `tools/fetch-venues.ps1` as the reproducible refresh.
- Wires venue + attendance into the game-details popover (click a row to open). Always shows the Venue row when a `Game.VenueId` is set — including KO games whose teams aren't resolved yet.
- Annotates all 3 bundled competitions end-to-end: **WC 2026** (104 games × venues), **WC 2022** (64 games × venues + attendance + real kickoff times), **Euro 2024** (51 games — file was stale Euro-2016/2020 dates + Greece in Group F; rewritten to real 2024 dates, GEO swap, venues, attendance).
- `Game.Attendance` (nullable int) added to the model; populated for historical competitions only.

## What's in each commit

1. `Add Venue model + global registry + Game.Attendance` — model, interface, DI registration, embedded-resource setup.
2. `Add bundled venues.json + Wikidata SPARQL refresh tool` — data + tooling. Berlin Olympiastadion hand-added (Wikidata record falls outside the SPARQL filter). 21 cities used by the three competitions hand-canonicalized to override Wikidata's borough-level `P276` (Allianz Arena was 'Freimann', Volksparkstadion 'Bahrenfeld', etc.). A SPARQL-side fix that walks `P131*` to find the city-level entity is a planned follow-up.
3. `Display venue + attendance in the game-details popover` — popover widening, gap, wrap.
4. `Annotate WC 2026 fixtures with venues` — Yahoo + Sky cross-checked; venue conflicts resolved 2-of-3.
5. `Annotate WC 2022 fixtures: venues, attendance, kickoffs` — `(matchup, date)` keyed mapping to preserve our existing IDs through matchdays with simultaneous games. AST→UTC.
6. `Rewrite em-2024.json to the real Euro 2024 schedule` — GEO substitution, real dates, CEST→UTC kickoffs, venues, attendance.

## Test plan

- [ ] All 161 tests pass locally (`dotnet test`).
- [ ] Verify popover shows the Venue + Attendance row on a few games per competition.
- [ ] WC 2026: every game has a venue, no attendance (future).
- [ ] WC 2022: every game has venue + attendance; opening QAT-ECU at Al Bayt 67,372; final ARG-FRA at Lusail 88,966.
- [ ] Euro 2024: every game has venue + attendance + real 2024 date; Group F shows Georgia not Greece; final ESP-ENG at Berlin Olympiastadion 65,600.

## Known caveats

- WC 2026 venue attributions are research-quality (Yahoo + Sky), not pulled from a FIFA API. ~6 venues had source disagreements; resolved 2-of-3.
- Wikidata uses Estadio Azteca's sponsor name (Banorte Stadium) and Estadio BBVA's neutral name (Estadio Monterrey).
- The Berlin Olympiastadion add and the 21 hand-canonicalized cities are local overrides; a future SPARQL-side fix in `fetch-venues.ps1` (walk `P131*` to city-level entity) will supersede them.