### PR TITLE
Resolve venue cities via SPARQL P131* walk + hand-supplement gaps

### DIFF
--- a/src/FantasyFootball.Core/Resources/Data/venues.json
+++ b/src/FantasyFootball.Core/Resources/Data/venues.json
@@ -20,6 +20,14 @@
     ]
   },
   {
+    "id": "hassan-ii-stadium",
+    "name": "Hassan II Stadium",
+    "city": null,
+    "countryCode": "MAR",
+    "capacity": 115000,
+    "tenantClubs": []
+  },
+  {
     "id": "banorte-stadium",
     "name": "Banorte Stadium",
     "city": "Mexico City",
@@ -30,14 +38,6 @@
       "cruz-azul",
       "mexico-men-s-national-football-team"
     ]
-  },
-  {
-    "id": "hassan-ii-stadium",
-    "name": "Hassan II Stadium",
-    "city": null,
-    "countryCode": "MAR",
-    "capacity": 115000,
-    "tenantClubs": []
   },
   {
     "id": "michigan-stadium",
@@ -53,22 +53,12 @@
   {
     "id": "beaver-stadium",
     "name": "Beaver Stadium",
-    "city": "Pennsylvania State University",
+    "city": null,
     "countryCode": "USA",
     "capacity": 106572,
     "tenantClubs": [
       "penn-state-nittany-lions",
       "penn-state-nittany-lions-football"
-    ]
-  },
-  {
-    "id": "camp-nou",
-    "name": "Camp Nou",
-    "city": null,
-    "countryCode": "ESP",
-    "capacity": 105000,
-    "tenantClubs": [
-      "futbol-club-barcelona"
     ]
   },
   {
@@ -79,6 +69,16 @@
     "capacity": 105000,
     "tenantClubs": [
       "dallas-cowboys"
+    ]
+  },
+  {
+    "id": "camp-nou",
+    "name": "Camp Nou",
+    "city": null,
+    "countryCode": "ESP",
+    "capacity": 105000,
+    "tenantClubs": [
+      "futbol-club-barcelona"
     ]
   },
   {
@@ -139,7 +139,7 @@
   {
     "id": "cairo-international-stadium",
     "name": "Cairo International Stadium",
-    "city": "Nasr City",
+    "city": "Cairo",
     "countryCode": "EGY",
     "capacity": 100500,
     "tenantClubs": [
@@ -151,7 +151,7 @@
   {
     "id": "melbourne-cricket-ground",
     "name": "Melbourne Cricket Ground",
-    "city": "Yarra Park",
+    "city": "Melbourne",
     "countryCode": "AUS",
     "capacity": 100024,
     "tenantClubs": [
@@ -168,7 +168,7 @@
   {
     "id": "new-trafford",
     "name": "New Trafford",
-    "city": "Old Trafford",
+    "city": null,
     "countryCode": "GBR",
     "capacity": 100000,
     "tenantClubs": []
@@ -226,6 +226,14 @@
     ]
   },
   {
+    "id": "education-city-stadium",
+    "name": "Education City Stadium",
+    "city": "Al Rayyan",
+    "countryCode": "QAT",
+    "capacity": 90000,
+    "tenantClubs": []
+  },
+  {
     "id": "wembley-stadium",
     "name": "Wembley Stadium",
     "city": "London",
@@ -234,14 +242,6 @@
     "tenantClubs": [
       "england-men-s-national-association-football-team"
     ]
-  },
-  {
-    "id": "education-city-stadium",
-    "name": "Education City Stadium",
-    "city": "Al Rayyan",
-    "countryCode": "QAT",
-    "capacity": 90000,
-    "tenantClubs": []
   },
   {
     "id": "lusail-stadium",
@@ -288,7 +288,7 @@
   {
     "id": "borg-el-arab-stadium",
     "name": "Borg El Arab Stadium",
-    "city": "Second Amreya district",
+    "city": "Alexandria",
     "countryCode": "EGY",
     "capacity": 86000,
     "tenantClubs": [
@@ -318,7 +318,7 @@
   {
     "id": "mas-monumental-stadium",
     "name": "Mas Monumental Stadium",
-    "city": "Belgrano",
+    "city": "Buenos Aires",
     "countryCode": "ARG",
     "capacity": 84567,
     "tenantClubs": [
@@ -381,6 +381,17 @@
     ]
   },
   {
+    "id": "jakarta-international-stadium",
+    "name": "Jakarta International Stadium",
+    "city": "Jakarta",
+    "countryCode": "IDN",
+    "capacity": 82000,
+    "tenantClubs": [
+      "indonesia-men-s-national-football-team",
+      "persija-jakarta"
+    ]
+  },
+  {
     "id": "twickenham-stadium",
     "name": "Twickenham Stadium",
     "city": null,
@@ -388,17 +399,6 @@
     "capacity": 82000,
     "tenantClubs": [
       "england-men-s-national-rugby-union-team"
-    ]
-  },
-  {
-    "id": "jakarta-international-stadium",
-    "name": "Jakarta International Stadium",
-    "city": "Tanjung Priok",
-    "countryCode": "IDN",
-    "capacity": 82000,
-    "tenantClubs": [
-      "indonesia-men-s-national-football-team",
-      "persija-jakarta"
     ]
   },
   {
@@ -437,7 +437,7 @@
   {
     "id": "notre-dame-stadium",
     "name": "Notre Dame Stadium",
-    "city": "Notre Dame",
+    "city": null,
     "countryCode": "USA",
     "capacity": 80795,
     "tenantClubs": [
@@ -458,7 +458,7 @@
   {
     "id": "ataturk-olympic-stadium",
     "name": "Atatürk Olympic Stadium",
-    "city": "Ziya Gökalp",
+    "city": "Istanbul",
     "countryCode": "TUR",
     "capacity": 80597,
     "tenantClubs": [
@@ -498,7 +498,7 @@
   {
     "id": "estadio-monumental-u",
     "name": "Estadio Monumental U",
-    "city": "Ate",
+    "city": "Lima",
     "countryCode": "PER",
     "capacity": 80093,
     "tenantClubs": [
@@ -516,16 +516,6 @@
     ]
   },
   {
-    "id": "gazprom-arena",
-    "name": "Gazprom Arena",
-    "city": null,
-    "countryCode": "RUS",
-    "capacity": 80000,
-    "tenantClubs": [
-      "fc-zenit-saint-petersburg"
-    ]
-  },
-  {
     "id": "martyrs-stadium",
     "name": "martyrs' stadium",
     "city": null,
@@ -533,16 +523,6 @@
     "capacity": 80000,
     "tenantClubs": [
       "dr-congo-men-s-national-football-team"
-    ]
-  },
-  {
-    "id": "shanghai-stadium",
-    "name": "Shanghai Stadium",
-    "city": "Xuhui District",
-    "countryCode": "CHN",
-    "capacity": 80000,
-    "tenantClubs": [
-      "shanghai-shenhua-f-c"
     ]
   },
   {
@@ -563,6 +543,26 @@
     "capacity": 80000,
     "tenantClubs": [
       "hellenic-olympic-committee"
+    ]
+  },
+  {
+    "id": "shanghai-stadium",
+    "name": "Shanghai Stadium",
+    "city": "Shanghai",
+    "countryCode": "CHN",
+    "capacity": 80000,
+    "tenantClubs": [
+      "shanghai-shenhua-f-c"
+    ]
+  },
+  {
+    "id": "gazprom-arena",
+    "name": "Gazprom Arena",
+    "city": null,
+    "countryCode": "RUS",
+    "capacity": 80000,
+    "tenantClubs": [
+      "fc-zenit-saint-petersburg"
     ]
   },
   {
@@ -670,7 +670,7 @@
   {
     "id": "old-trafford",
     "name": "Old Trafford",
-    "city": "Old Trafford",
+    "city": null,
     "countryCode": "GBR",
     "capacity": 75731,
     "tenantClubs": [
@@ -715,19 +715,9 @@
     ]
   },
   {
-    "id": "tangier-grand-stadium",
-    "name": "Tangier Grand Stadium",
-    "city": null,
-    "countryCode": "MAR",
-    "capacity": 75000,
-    "tenantClubs": [
-      "ir-tanger"
-    ]
-  },
-  {
     "id": "estadio-gasometro",
     "name": "Estadio Gasómetro",
-    "city": "Boedo",
+    "city": "Buenos Aires",
     "countryCode": "ARG",
     "capacity": 75000,
     "tenantClubs": [
@@ -742,6 +732,16 @@
     "capacity": 75000,
     "tenantClubs": [
       "ahli-of-aleppo-sc"
+    ]
+  },
+  {
+    "id": "tangier-grand-stadium",
+    "name": "Tangier Grand Stadium",
+    "city": null,
+    "countryCode": "MAR",
+    "capacity": 75000,
+    "tenantClubs": [
+      "ir-tanger"
     ]
   },
   {
@@ -779,7 +779,7 @@
   {
     "id": "stanley-park-stadium",
     "name": "Stanley Park Stadium",
-    "city": "Stanley Park",
+    "city": null,
     "countryCode": "GBR",
     "capacity": 73000,
     "tenantClubs": [
@@ -810,7 +810,7 @@
   {
     "id": "highmark-stadium",
     "name": "Highmark Stadium",
-    "city": "Orchard Park",
+    "city": null,
     "countryCode": "USA",
     "capacity": 71608,
     "tenantClubs": [
@@ -833,7 +833,7 @@
   {
     "id": "huntington-bank-field",
     "name": "Huntington Bank Field",
-    "city": "North Coast Harbor",
+    "city": "Cleveland",
     "countryCode": "USA",
     "capacity": 71516,
     "tenantClubs": [
@@ -912,7 +912,7 @@
   {
     "id": "husky-stadium",
     "name": "Husky Stadium",
-    "city": "University of Washington",
+    "city": "Seattle",
     "countryCode": "USA",
     "capacity": 70083,
     "tenantClubs": [
@@ -931,36 +931,6 @@
     ]
   },
   {
-    "id": "ford-field",
-    "name": "Ford Field",
-    "city": null,
-    "countryCode": "USA",
-    "capacity": 70000,
-    "tenantClubs": [
-      "detroit-lions"
-    ]
-  },
-  {
-    "id": "estadio-de-la-cartuja",
-    "name": "Estadio de La Cartuja",
-    "city": null,
-    "countryCode": "ESP",
-    "capacity": 70000,
-    "tenantClubs": [
-      "spain-men-s-national-football-team"
-    ]
-  },
-  {
-    "id": "u-s-bank-stadium",
-    "name": "U.S. Bank Stadium",
-    "city": "Minneapolis",
-    "countryCode": "USA",
-    "capacity": 70000,
-    "tenantClubs": [
-      "minnesota-vikings"
-    ]
-  },
-  {
     "id": "franklin-field",
     "name": "Franklin Field",
     "city": null,
@@ -970,24 +940,6 @@
       "penn-quakers-football",
       "penn-relays"
     ]
-  },
-  {
-    "id": "burnden-park",
-    "name": "Burnden Park",
-    "city": "Burnden",
-    "countryCode": "GBR",
-    "capacity": 70000,
-    "tenantClubs": [
-      "bolton-wanderers-f-c"
-    ]
-  },
-  {
-    "id": "new-lusaka-stadium",
-    "name": "New Lusaka Stadium",
-    "city": null,
-    "countryCode": "ZMB",
-    "capacity": 70000,
-    "tenantClubs": []
   },
   {
     "id": "kim-il-sung-stadium",
@@ -1011,17 +963,57 @@
     ]
   },
   {
-    "id": "q11836159",
-    "name": "Q11836159",
+    "id": "burnden-park",
+    "name": "Burnden Park",
     "city": null,
-    "countryCode": "BEL",
+    "countryCode": "GBR",
+    "capacity": 70000,
+    "tenantClubs": [
+      "bolton-wanderers-f-c"
+    ]
+  },
+  {
+    "id": "new-lusaka-stadium",
+    "name": "New Lusaka Stadium",
+    "city": null,
+    "countryCode": "ZMB",
     "capacity": 70000,
     "tenantClubs": []
   },
   {
+    "id": "estadio-de-la-cartuja",
+    "name": "Estadio de La Cartuja",
+    "city": null,
+    "countryCode": "ESP",
+    "capacity": 70000,
+    "tenantClubs": [
+      "spain-men-s-national-football-team"
+    ]
+  },
+  {
+    "id": "ford-field",
+    "name": "Ford Field",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 70000,
+    "tenantClubs": [
+      "detroit-lions"
+    ]
+  },
+  {
+    "id": "u-s-bank-stadium",
+    "name": "U.S. Bank Stadium",
+    "city": "Minneapolis",
+    "countryCode": "USA",
+    "capacity": 70000,
+    "tenantClubs": [
+      "minnesota-vikings"
+    ]
+  },
+  {
     "id": "izmir-ataturk-stadium",
     "name": "İzmir Atatürk Stadium",
-    "city": "Atatürk Sport Complex",
+    "city": null,
     "countryCode": "TUR",
     "capacity": 70000,
     "tenantClubs": [
@@ -1128,7 +1120,7 @@
   {
     "id": "salt-lake-stadium",
     "name": "Salt Lake Stadium",
-    "city": "JB Block",
+    "city": "Bidhannagar",
     "countryCode": "IND",
     "capacity": 68000,
     "tenantClubs": [
@@ -1181,7 +1173,7 @@
   {
     "id": "puskas-arena",
     "name": "Puskás Aréna",
-    "city": "Istvánmező",
+    "city": "Budapest",
     "countryCode": "HUN",
     "capacity": 67215,
     "tenantClubs": [
@@ -1199,13 +1191,14 @@
     ]
   },
   {
-    "id": "stadium-salto-international",
-    "name": "Stadium Salto International",
+    "id": "mohammed-v-stadium",
+    "name": "Mohammed V Stadium",
     "city": null,
-    "countryCode": "LBY",
+    "countryCode": "MAR",
     "capacity": 67000,
     "tenantClubs": [
-      "libya-men-s-national-football-team"
+      "raja-club-athletic",
+      "wydad-athletic-club"
     ]
   },
   {
@@ -1224,14 +1217,13 @@
     ]
   },
   {
-    "id": "mohammed-v-stadium",
-    "name": "Mohammed V Stadium",
+    "id": "stadium-salto-international",
+    "name": "Stadium Salto International",
     "city": null,
-    "countryCode": "MAR",
+    "countryCode": "LBY",
     "capacity": 67000,
     "tenantClubs": [
-      "raja-club-athletic",
-      "wydad-athletic-club"
+      "libya-men-s-national-football-team"
     ]
   },
   {
@@ -1331,7 +1323,7 @@
   {
     "id": "acrisure-stadium",
     "name": "Acrisure Stadium",
-    "city": "North Shore",
+    "city": "Pittsburgh",
     "countryCode": "USA",
     "capacity": 65500,
     "tenantClubs": [
@@ -1379,19 +1371,17 @@
     ]
   },
   {
-    "id": "palaran-stadium",
-    "name": "Palaran Stadium",
+    "id": "colosseum",
+    "name": "Colosseum",
     "city": null,
-    "countryCode": "IDN",
+    "countryCode": "ITA",
     "capacity": 65000,
-    "tenantClubs": [
-      "bali-united-f-c"
-    ]
+    "tenantClubs": []
   },
   {
     "id": "allegiant-stadium",
     "name": "Allegiant Stadium",
-    "city": "Paradise",
+    "city": null,
     "countryCode": "USA",
     "capacity": 65000,
     "tenantClubs": [
@@ -1419,22 +1409,14 @@
     ]
   },
   {
-    "id": "q16531664",
-    "name": "Q16531664",
+    "id": "jidhe-alnakhla-stadium",
+    "name": "Jidhe Alnakhla Stadium",
     "city": null,
     "countryCode": "IRQ",
     "capacity": 65000,
     "tenantClubs": [
       "iraq-men-s-national-football-team"
     ]
-  },
-  {
-    "id": "colosseum",
-    "name": "Colosseum",
-    "city": null,
-    "countryCode": "ITA",
-    "capacity": 65000,
-    "tenantClubs": []
   },
   {
     "id": "olympic-stadium-of-rades",
@@ -1448,13 +1430,13 @@
     ]
   },
   {
-    "id": "jidhe-alnakhla-stadium",
-    "name": "Jidhe Alnakhla Stadium",
+    "id": "palaran-stadium",
+    "name": "Palaran Stadium",
     "city": null,
-    "countryCode": "IRQ",
+    "countryCode": "IDN",
     "capacity": 65000,
     "tenantClubs": [
-      "iraq-men-s-national-football-team"
+      "bali-united-f-c"
     ]
   },
   {
@@ -1484,7 +1466,7 @@
   {
     "id": "northwest-stadium",
     "name": "Northwest Stadium",
-    "city": "Landover",
+    "city": null,
     "countryCode": "USA",
     "capacity": 64000,
     "tenantClubs": [
@@ -1494,7 +1476,7 @@
   {
     "id": "saitama-stadium-2002",
     "name": "Saitama Stadium 2002",
-    "city": "Saitama Stadium 2002 Park",
+    "city": "Saitama",
     "countryCode": "JPN",
     "capacity": 63700,
     "tenantClubs": [
@@ -1560,7 +1542,7 @@
   {
     "id": "munich-olympic-stadium",
     "name": "Munich Olympic Stadium",
-    "city": "Am Riesenfeld",
+    "city": "Munich",
     "countryCode": "DEU",
     "capacity": 63118,
     "tenantClubs": [
@@ -1570,17 +1552,9 @@
     ]
   },
   {
-    "id": "q2337131",
-    "name": "Q2337131",
-    "city": null,
-    "countryCode": null,
-    "capacity": 63000,
-    "tenantClubs": []
-  },
-  {
     "id": "tottenham-hotspur-stadium",
     "name": "Tottenham Hotspur Stadium",
-    "city": "Tottenham",
+    "city": null,
     "countryCode": "GBR",
     "capacity": 62850,
     "tenantClubs": [
@@ -1803,7 +1777,7 @@
   {
     "id": "celtic-park",
     "name": "Celtic Park",
-    "city": "Parkhead",
+    "city": null,
     "countryCode": "GBR",
     "capacity": 60355,
     "tenantClubs": [
@@ -1813,7 +1787,7 @@
   {
     "id": "emirates-stadium",
     "name": "Emirates Stadium",
-    "city": "Holloway",
+    "city": null,
     "countryCode": "GBR",
     "capacity": 60338,
     "tenantClubs": [
@@ -1891,20 +1865,73 @@
     ]
   },
   {
-    "id": "jawaharlal-nehru-international-stadium",
-    "name": "Jawaharlal Nehru International Stadium",
-    "city": "Kaloor",
-    "countryCode": "IND",
+    "id": "haixia-olympic-center-stadium",
+    "name": "Haixia Olympic Center Stadium",
+    "city": null,
+    "countryCode": "CHN",
     "capacity": 60000,
     "tenantClubs": [
-      "kerala-blasters-fc"
+      "2017-china-open-badminton-championships"
     ]
   },
   {
-    "id": "sportforum-chemnitz",
-    "name": "Sportforum Chemnitz",
-    "city": "Bernsdorf",
-    "countryCode": "DEU",
+    "id": "mario-alberto-kempes-stadium",
+    "name": "Mario Alberto Kempes Stadium",
+    "city": "Córdoba",
+    "countryCode": "ARG",
+    "capacity": 60000,
+    "tenantClubs": [
+      "talleres-de-cordoba"
+    ]
+  },
+  {
+    "id": "bahir-dar-stadium",
+    "name": "Bahir Dar Stadium",
+    "city": "Bahir Dar",
+    "countryCode": "ETH",
+    "capacity": 60000,
+    "tenantClubs": [
+      "ethiopia-men-s-national-football-team"
+    ]
+  },
+  {
+    "id": "stade-leopold-sedar-senghor",
+    "name": "Stade Léopold Sédar Senghor",
+    "city": null,
+    "countryCode": "SEN",
+    "capacity": 60000,
+    "tenantClubs": [
+      "senegal-men-s-national-association-football-team"
+    ]
+  },
+  {
+    "id": "stadion-maksimir",
+    "name": "Stadion Maksimir",
+    "city": "Zagreb",
+    "countryCode": "HRV",
+    "capacity": 60000,
+    "tenantClubs": [
+      "croatia-men-s-national-football-team",
+      "gnk-dinamo-zagreb",
+      "hask",
+      "nk-lokomotiva"
+    ]
+  },
+  {
+    "id": "jinan-olympic-sports-center-stadium",
+    "name": "Jinan Olympic Sports Center Stadium",
+    "city": "Jinan",
+    "countryCode": "CHN",
+    "capacity": 60000,
+    "tenantClubs": [
+      "shandong-taishan-f-c"
+    ]
+  },
+  {
+    "id": "tajiat-olympic-stadium",
+    "name": "Tajiat Olympic Stadium",
+    "city": null,
+    "countryCode": "IRQ",
     "capacity": 60000,
     "tenantClubs": []
   },
@@ -1919,16 +1946,6 @@
     ]
   },
   {
-    "id": "edmund-szyc-stadium",
-    "name": "Edmund Szyc Stadium",
-    "city": null,
-    "countryCode": "POL",
-    "capacity": 60000,
-    "tenantClubs": [
-      "warta-poznan"
-    ]
-  },
-  {
     "id": "mogadishu-stadium",
     "name": "Mogadishu Stadium",
     "city": "Mogadishu",
@@ -1940,20 +1957,58 @@
     ]
   },
   {
-    "id": "haixia-olympic-center-stadium",
-    "name": "Haixia Olympic Center Stadium",
+    "id": "rufaro-stadium",
+    "name": "Rufaro Stadium",
+    "city": "Harare",
+    "countryCode": "ZWE",
+    "capacity": 60000,
+    "tenantClubs": []
+  },
+  {
+    "id": "wuhu-olympic-stadium",
+    "name": "Wuhu Olympic Stadium",
     "city": null,
     "countryCode": "CHN",
     "capacity": 60000,
+    "tenantClubs": []
+  },
+  {
+    "id": "perth-stadium",
+    "name": "Perth Stadium",
+    "city": null,
+    "countryCode": "AUS",
+    "capacity": 60000,
     "tenantClubs": [
-      "2017-china-open-badminton-championships"
+      "fremantle-football-club",
+      "perth-scorchers",
+      "west-coast-eagles"
     ]
   },
   {
-    "id": "gaddafi-stadium",
-    "name": "Gaddafi Stadium",
+    "id": "national-heroes-stadium",
+    "name": "National Heroes Stadium",
     "city": null,
-    "countryCode": "PAK",
+    "countryCode": "ZMB",
+    "capacity": 60000,
+    "tenantClubs": [
+      "zambia-men-s-national-football-team"
+    ]
+  },
+  {
+    "id": "alassane-ouattara-stadium",
+    "name": "Alassane Ouattara Stadium",
+    "city": null,
+    "countryCode": "CIV",
+    "capacity": 60000,
+    "tenantClubs": [
+      "ivory-coast-men-s-national-football-team"
+    ]
+  },
+  {
+    "id": "damanhour-stadium",
+    "name": "Damanhour Stadium",
+    "city": null,
+    "countryCode": "EGY",
     "capacity": 60000,
     "tenantClubs": []
   },
@@ -1969,64 +2024,30 @@
     ]
   },
   {
-    "id": "tianjin-olympic-center-stadium",
-    "name": "Tianjin Olympic Center Stadium",
-    "city": "Tianjin",
-    "countryCode": "CHN",
-    "capacity": 60000,
-    "tenantClubs": [
-      "tianjin-jinmen-tiger-f-c"
-    ]
-  },
-  {
-    "id": "mountaineer-field-at-milan-puskar-stadium",
-    "name": "Mountaineer Field at Milan Puskar Stadium",
+    "id": "gaddafi-stadium",
+    "name": "Gaddafi Stadium",
     "city": null,
-    "countryCode": "USA",
+    "countryCode": "PAK",
     "capacity": 60000,
-    "tenantClubs": [
-      "west-virginia-mountaineers-football"
-    ]
+    "tenantClubs": []
   },
   {
-    "id": "mario-alberto-kempes-stadium",
-    "name": "Mario Alberto Kempes Stadium",
-    "city": "Córdoba",
-    "countryCode": "ARG",
-    "capacity": 60000,
-    "tenantClubs": [
-      "talleres-de-cordoba"
-    ]
-  },
-  {
-    "id": "alassane-ouattara-stadium",
-    "name": "Alassane Ouattara Stadium",
+    "id": "jawaharlal-nehru-international-stadium",
+    "name": "Jawaharlal Nehru International Stadium",
     "city": null,
-    "countryCode": "CIV",
+    "countryCode": "IND",
     "capacity": 60000,
     "tenantClubs": [
-      "ivory-coast-men-s-national-football-team"
+      "kerala-blasters-fc"
     ]
   },
   {
-    "id": "hefei-olympic-sports-center-stadium",
-    "name": "Hefei Olympic Sports Center Stadium",
-    "city": "Hefei",
-    "countryCode": "CHN",
+    "id": "sportforum-chemnitz",
+    "name": "Sportforum Chemnitz",
+    "city": "Bernsdorf",
+    "countryCode": "DEU",
     "capacity": 60000,
-    "tenantClubs": [
-      "anhui-jiufang-f-c"
-    ]
-  },
-  {
-    "id": "national-sports-stadium",
-    "name": "National Sports Stadium",
-    "city": null,
-    "countryCode": "ZWE",
-    "capacity": 60000,
-    "tenantClubs": [
-      "zimbabwe-men-s-national-football-team"
-    ]
+    "tenantClubs": []
   },
   {
     "id": "shenyang-olympic-sports-center-stadium",
@@ -2039,88 +2060,10 @@
     ]
   },
   {
-    "id": "national-heroes-stadium",
-    "name": "National Heroes Stadium",
-    "city": null,
-    "countryCode": "ZMB",
-    "capacity": 60000,
-    "tenantClubs": [
-      "zambia-men-s-national-football-team"
-    ]
-  },
-  {
-    "id": "stade-leopold-sedar-senghor",
-    "name": "Stade Léopold Sédar Senghor",
-    "city": null,
-    "countryCode": "SEN",
-    "capacity": 60000,
-    "tenantClubs": [
-      "senegal-men-s-national-association-football-team"
-    ]
-  },
-  {
     "id": "guangxi-sports-centre-stadium",
     "name": "Guangxi Sports Centre Stadium",
     "city": null,
     "countryCode": "CHN",
-    "capacity": 60000,
-    "tenantClubs": []
-  },
-  {
-    "id": "jinan-olympic-sports-center-stadium",
-    "name": "Jinan Olympic Sports Center Stadium",
-    "city": "Jinan Olympic Sports Center",
-    "countryCode": "CHN",
-    "capacity": 60000,
-    "tenantClubs": [
-      "shandong-taishan-f-c"
-    ]
-  },
-  {
-    "id": "perth-stadium",
-    "name": "Perth Stadium",
-    "city": "Burswood",
-    "countryCode": "AUS",
-    "capacity": 60000,
-    "tenantClubs": [
-      "fremantle-football-club",
-      "perth-scorchers",
-      "west-coast-eagles"
-    ]
-  },
-  {
-    "id": "wuhu-olympic-stadium",
-    "name": "Wuhu Olympic Stadium",
-    "city": null,
-    "countryCode": "CHN",
-    "capacity": 60000,
-    "tenantClubs": []
-  },
-  {
-    "id": "moi-international-sports-centre",
-    "name": "Moi International Sports Centre",
-    "city": "Kasarani",
-    "countryCode": "KEN",
-    "capacity": 60000,
-    "tenantClubs": [
-      "kenya-men-s-national-football-team"
-    ]
-  },
-  {
-    "id": "bahir-dar-stadium",
-    "name": "Bahir Dar Stadium",
-    "city": "Bahir Dar",
-    "countryCode": "ETH",
-    "capacity": 60000,
-    "tenantClubs": [
-      "ethiopia-men-s-national-football-team"
-    ]
-  },
-  {
-    "id": "tajiat-olympic-stadium",
-    "name": "Tajiat Olympic Stadium",
-    "city": null,
-    "countryCode": "IRQ",
     "capacity": 60000,
     "tenantClubs": []
   },
@@ -2135,12 +2078,54 @@
     ]
   },
   {
-    "id": "damanhour-stadium",
-    "name": "Damanhour Stadium",
+    "id": "mountaineer-field-at-milan-puskar-stadium",
+    "name": "Mountaineer Field at Milan Puskar Stadium",
     "city": null,
-    "countryCode": "EGY",
+    "countryCode": "USA",
     "capacity": 60000,
-    "tenantClubs": []
+    "tenantClubs": [
+      "west-virginia-mountaineers-football"
+    ]
+  },
+  {
+    "id": "moi-international-sports-centre",
+    "name": "Moi International Sports Centre",
+    "city": null,
+    "countryCode": "KEN",
+    "capacity": 60000,
+    "tenantClubs": [
+      "kenya-men-s-national-football-team"
+    ]
+  },
+  {
+    "id": "edmund-szyc-stadium",
+    "name": "Edmund Szyc Stadium",
+    "city": null,
+    "countryCode": "POL",
+    "capacity": 60000,
+    "tenantClubs": [
+      "warta-poznan"
+    ]
+  },
+  {
+    "id": "tianjin-olympic-center-stadium",
+    "name": "Tianjin Olympic Center Stadium",
+    "city": "Tianjin",
+    "countryCode": "CHN",
+    "capacity": 60000,
+    "tenantClubs": [
+      "tianjin-jinmen-tiger-f-c"
+    ]
+  },
+  {
+    "id": "national-sports-stadium",
+    "name": "National Sports Stadium",
+    "city": null,
+    "countryCode": "ZWE",
+    "capacity": 60000,
+    "tenantClubs": [
+      "zimbabwe-men-s-national-football-team"
+    ]
   },
   {
     "id": "dsc-multi-purpose-stadium",
@@ -2151,25 +2136,14 @@
     "tenantClubs": []
   },
   {
-    "id": "stadion-maksimir",
-    "name": "Stadion Maksimir",
-    "city": "Maksimirska naselja",
-    "countryCode": "HRV",
+    "id": "hefei-olympic-sports-center-stadium",
+    "name": "Hefei Olympic Sports Center Stadium",
+    "city": "Hefei",
+    "countryCode": "CHN",
     "capacity": 60000,
     "tenantClubs": [
-      "croatia-men-s-national-football-team",
-      "gnk-dinamo-zagreb",
-      "hask",
-      "nk-lokomotiva"
+      "anhui-jiufang-f-c"
     ]
-  },
-  {
-    "id": "rufaro-stadium",
-    "name": "Rufaro Stadium",
-    "city": "Harare",
-    "countryCode": "ZWE",
-    "capacity": 60000,
-    "tenantClubs": []
   },
   {
     "id": "borussia-park",
@@ -2184,7 +2158,7 @@
   {
     "id": "parc-olympique-lyonnais",
     "name": "Parc Olympique Lyonnais",
-    "city": "Décines-Charpieu",
+    "city": "Metropolis of Lyon",
     "countryCode": "FRA",
     "capacity": 59286,
     "tenantClubs": [
@@ -2192,9 +2166,9 @@
     ]
   },
   {
-    "id": "el-inodoro",
-    "name": "El inodoro",
-    "city": "La Boca",
+    "id": "la-bombonera",
+    "name": "La Bombonera",
+    "city": "Buenos Aires",
     "countryCode": "ARG",
     "capacity": 58840,
     "tenantClubs": [
@@ -2206,7 +2180,7 @@
   {
     "id": "tianhe-stadium",
     "name": "Tianhe Stadium",
-    "city": "Tianhe District",
+    "city": "Guangzhou",
     "countryCode": "CHN",
     "capacity": 58500,
     "tenantClubs": [
@@ -2216,7 +2190,7 @@
   {
     "id": "cape-town-stadium",
     "name": "Cape Town Stadium",
-    "city": "Cape Town",
+    "city": "City of Cape Town",
     "countryCode": "ZAF",
     "capacity": 58309,
     "tenantClubs": [
@@ -2333,7 +2307,7 @@
   {
     "id": "rajko-mitic-stadium",
     "name": "Rajko Mitić Stadium",
-    "city": "Autokomanda",
+    "city": "City of Belgrade",
     "countryCode": "SRB",
     "capacity": 55538,
     "tenantClubs": [
@@ -2352,36 +2326,6 @@
     ]
   },
   {
-    "id": "etihad-stadium",
-    "name": "Etihad Stadium",
-    "city": "Manchester",
-    "countryCode": "GBR",
-    "capacity": 55017,
-    "tenantClubs": [
-      "manchester-city-f-c"
-    ]
-  },
-  {
-    "id": "helong-stadium",
-    "name": "Helong Stadium",
-    "city": null,
-    "countryCode": "CHN",
-    "capacity": 55000,
-    "tenantClubs": [
-      "hunan-billows-f-c"
-    ]
-  },
-  {
-    "id": "national-stadium",
-    "name": "National Stadium",
-    "city": "Zuoying District",
-    "countryCode": "TWN",
-    "capacity": 55000,
-    "tenantClubs": [
-      "world-games-2009"
-    ]
-  },
-  {
     "id": "plovdiv-stadium",
     "name": "Plovdiv Stadium",
     "city": null,
@@ -2389,6 +2333,79 @@
     "capacity": 55000,
     "tenantClubs": [
       "botev-plovdiv"
+    ]
+  },
+  {
+    "id": "national-stadium-sgp",
+    "name": "National Stadium",
+    "city": "Singapore",
+    "countryCode": "SGP",
+    "capacity": 55000,
+    "tenantClubs": [
+      "singapore-men-s-national-football-team"
+    ]
+  },
+  {
+    "id": "estadio-latinoamericano",
+    "name": "Estadio Latinoamericano",
+    "city": null,
+    "countryCode": "CUB",
+    "capacity": 55000,
+    "tenantClubs": [
+      "cuban-national-series",
+      "industriales"
+    ]
+  },
+  {
+    "id": "tokyo-dome",
+    "name": "Tokyo Dome",
+    "city": "Tokyo",
+    "countryCode": "JPN",
+    "capacity": 55000,
+    "tenantClubs": [
+      "hokkaido-nippon-ham-fighters",
+      "yomiuri-giants"
+    ]
+  },
+  {
+    "id": "l-n-federal-credit-union-stadium",
+    "name": "L&N Federal Credit Union Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 55000,
+    "tenantClubs": [
+      "louisville-cardinals",
+      "louisville-cardinals-football"
+    ]
+  },
+  {
+    "id": "gelora-bung-tomo-stadium",
+    "name": "Gelora Bung Tomo Stadium",
+    "city": "Surabaya",
+    "countryCode": "IDN",
+    "capacity": 55000,
+    "tenantClubs": [
+      "persebaya-surabaya"
+    ]
+  },
+  {
+    "id": "kings-park-stadium",
+    "name": "Kings Park Stadium",
+    "city": "Durban",
+    "countryCode": "ZAF",
+    "capacity": 55000,
+    "tenantClubs": [
+      "sharks"
+    ]
+  },
+  {
+    "id": "national-stadium",
+    "name": "National Stadium",
+    "city": "Kaohsiung",
+    "countryCode": "TWN",
+    "capacity": 55000,
+    "tenantClubs": [
+      "world-games-2009"
     ]
   },
   {
@@ -2404,34 +2421,13 @@
     ]
   },
   {
-    "id": "national-stadium-sgp",
-    "name": "National Stadium",
-    "city": "Kallang",
-    "countryCode": "SGP",
-    "capacity": 55000,
-    "tenantClubs": [
-      "singapore-men-s-national-football-team"
-    ]
-  },
-  {
-    "id": "kings-park-stadium",
-    "name": "Kings Park Stadium",
-    "city": "Durban",
-    "countryCode": "ZAF",
-    "capacity": 55000,
-    "tenantClubs": [
-      "sharks"
-    ]
-  },
-  {
-    "id": "l-n-federal-credit-union-stadium",
-    "name": "L&N Federal Credit Union Stadium",
+    "id": "helong-stadium",
+    "name": "Helong Stadium",
     "city": null,
-    "countryCode": "USA",
+    "countryCode": "CHN",
     "capacity": 55000,
     "tenantClubs": [
-      "louisville-cardinals",
-      "louisville-cardinals-football"
+      "hunan-billows-f-c"
     ]
   },
   {
@@ -2441,38 +2437,6 @@
     "countryCode": "NGA",
     "capacity": 55000,
     "tenantClubs": []
-  },
-  {
-    "id": "tokyo-dome",
-    "name": "Tokyo Dome",
-    "city": "Tokyo Dome City",
-    "countryCode": "JPN",
-    "capacity": 55000,
-    "tenantClubs": [
-      "hokkaido-nippon-ham-fighters",
-      "yomiuri-giants"
-    ]
-  },
-  {
-    "id": "estadio-latinoamericano",
-    "name": "Estadio Latinoamericano",
-    "city": null,
-    "countryCode": "CUB",
-    "capacity": 55000,
-    "tenantClubs": [
-      "cuban-national-series",
-      "industriales"
-    ]
-  },
-  {
-    "id": "gelora-bung-tomo-stadium",
-    "name": "Gelora Bung Tomo Stadium",
-    "city": "Surabaya",
-    "countryCode": "IDN",
-    "capacity": 55000,
-    "tenantClubs": [
-      "persebaya-surabaya"
-    ]
   },
   {
     "id": "johan-cruyff-arena",
@@ -2508,7 +2472,7 @@
   {
     "id": "silesian-stadium",
     "name": "Silesian Stadium",
-    "city": "Silesian Park",
+    "city": "Chorzów",
     "countryCode": "POL",
     "capacity": 54378,
     "tenantClubs": [
@@ -2599,6 +2563,17 @@
     ]
   },
   {
+    "id": "ems-stadium",
+    "name": "EMS Stadium",
+    "city": null,
+    "countryCode": "IND",
+    "capacity": 53000,
+    "tenantClubs": [
+      "india-men-s-national-football-team",
+      "kerala-football-team"
+    ]
+  },
+  {
     "id": "unique-diego-armando-maradona-stadium",
     "name": "Unique Diego Armando Maradona Stadium",
     "city": "La Plata",
@@ -2612,22 +2587,11 @@
   {
     "id": "semple-stadium",
     "name": "Semple Stadium",
-    "city": "Thurles",
+    "city": null,
     "countryCode": "IRL",
     "capacity": 53000,
     "tenantClubs": [
       "tipperary-gaa"
-    ]
-  },
-  {
-    "id": "ems-stadium",
-    "name": "EMS Stadium",
-    "city": null,
-    "countryCode": "IND",
-    "capacity": 53000,
-    "tenantClubs": [
-      "india-men-s-national-football-team",
-      "kerala-football-team"
     ]
   },
   {
@@ -2638,6 +2602,16 @@
     "capacity": 52929,
     "tenantClubs": [
       "indiana-hoosiers"
+    ]
+  },
+  {
+    "id": "etihad-stadium",
+    "name": "Etihad Stadium",
+    "city": "Manchester",
+    "countryCode": "GBR",
+    "capacity": 52900,
+    "tenantClubs": [
+      "manchester-city-f-c"
     ]
   },
   {
@@ -2724,16 +2698,6 @@
     "tenantClubs": []
   },
   {
-    "id": "estadio-monumental-de-maturin",
-    "name": "Estadio Monumental de Maturín",
-    "city": null,
-    "countryCode": "VEN",
-    "capacity": 52000,
-    "tenantClubs": [
-      "monagas-sport-club"
-    ]
-  },
-  {
     "id": "stade-ahmadou-ahidjo",
     "name": "Stade Ahmadou Ahidjo",
     "city": null,
@@ -2748,7 +2712,7 @@
   {
     "id": "guiyang-olympic-sports-center",
     "name": "Guiyang Olympic Sports Center",
-    "city": "Guanshanhu District",
+    "city": "Guiyang",
     "countryCode": "CHN",
     "capacity": 52000,
     "tenantClubs": [
@@ -2766,9 +2730,19 @@
     ]
   },
   {
+    "id": "estadio-monumental-de-maturin",
+    "name": "Estadio Monumental de Maturín",
+    "city": null,
+    "countryCode": "VEN",
+    "capacity": 52000,
+    "tenantClubs": [
+      "monagas-sport-club"
+    ]
+  },
+  {
     "id": "newlands-stadium",
     "name": "Newlands Stadium",
-    "city": "Cape Town",
+    "city": "City of Cape Town",
     "countryCode": "ZAF",
     "capacity": 51900,
     "tenantClubs": [
@@ -2790,7 +2764,7 @@
   {
     "id": "secu-stadium",
     "name": "SECU Stadium",
-    "city": "University of Maryland",
+    "city": "College Park",
     "countryCode": "USA",
     "capacity": 51802,
     "tenantClubs": [
@@ -2814,6 +2788,16 @@
     ]
   },
   {
+    "id": "ibrox-stadium",
+    "name": "Ibrox Stadium",
+    "city": "Glasgow",
+    "countryCode": "GBR",
+    "capacity": 51700,
+    "tenantClubs": [
+      "rangers-f-c"
+    ]
+  },
+  {
     "id": "aviva-stadium",
     "name": "Aviva Stadium",
     "city": null,
@@ -2822,16 +2806,6 @@
     "tenantClubs": [
       "football-association-of-ireland",
       "irish-rugby-football-union"
-    ]
-  },
-  {
-    "id": "ibrox-stadium",
-    "name": "Ibrox Stadium",
-    "city": "Glasgow",
-    "countryCode": "GBR",
-    "capacity": 51700,
-    "tenantClubs": [
-      "rangers-f-c"
     ]
   },
   {
@@ -2868,21 +2842,11 @@
   {
     "id": "shizuoka-stadium",
     "name": "Shizuoka Stadium",
-    "city": "Fukuroi",
+    "city": null,
     "countryCode": "JPN",
     "capacity": 51349,
     "tenantClubs": [
       "jubilo-iwata"
-    ]
-  },
-  {
-    "id": "ghadir-stadium",
-    "name": "Ghadir Stadium",
-    "city": "Ahvaz",
-    "countryCode": "IRN",
-    "capacity": 51000,
-    "tenantClubs": [
-      "foolad-f-c"
     ]
   },
   {
@@ -2893,6 +2857,16 @@
     "capacity": 51000,
     "tenantClubs": [
       "zhejiang-professional-f-c"
+    ]
+  },
+  {
+    "id": "ghadir-stadium",
+    "name": "Ghadir Stadium",
+    "city": "Ahvaz",
+    "countryCode": "IRN",
+    "capacity": 51000,
+    "tenantClubs": [
+      "foolad-f-c"
     ]
   },
   {
@@ -3021,7 +2995,7 @@
   {
     "id": "king-baudouin-stadium",
     "name": "King Baudouin Stadium",
-    "city": "Heysel - Heizel",
+    "city": "Brussels",
     "countryCode": "BEL",
     "capacity": 50024,
     "tenantClubs": [
@@ -3029,54 +3003,30 @@
     ]
   },
   {
-    "id": "stade-olympique-de-la-pontaise",
-    "name": "Stade Olympique de la Pontaise",
-    "city": "Lausanne",
-    "countryCode": "CHE",
-    "capacity": 50000,
-    "tenantClubs": [
-      "fc-lausanne-sport"
-    ]
-  },
-  {
-    "id": "hocine-ait-ahmed-stadium",
-    "name": "Hocine-Ait Ahmed Stadium",
-    "city": "Boukhalfa",
-    "countryCode": "DZA",
-    "capacity": 50000,
-    "tenantClubs": [
-      "js-kabylie"
-    ]
-  },
-  {
-    "id": "pars-stadium",
-    "name": "Pars Stadium",
+    "id": "bill-snyder-family-football-stadium",
+    "name": "Bill Snyder Family Football Stadium",
     "city": null,
-    "countryCode": "IRN",
+    "countryCode": "USA",
     "capacity": 50000,
     "tenantClubs": [
-      "fajr-sepasi-f-c"
+      "kansas-state-wildcats-football"
     ]
   },
   {
-    "id": "max-morlock-stadion",
-    "name": "Max-Morlock-Stadion",
+    "id": "shaheed-mohtarama-benazir-bhutto-international-cricket-stadium",
+    "name": "Shaheed Mohtarama Benazir Bhutto International Cricket Stadium",
     "city": null,
-    "countryCode": "DEU",
+    "countryCode": "PAK",
     "capacity": 50000,
-    "tenantClubs": [
-      "1-fc-nurnberg"
-    ]
+    "tenantClubs": []
   },
   {
-    "id": "stade-tata-raphael",
-    "name": "Stade Tata Raphaël",
+    "id": "wadi-al-rabi-stadium",
+    "name": "Wadi Al Rabi Stadium",
     "city": null,
-    "countryCode": "COD",
+    "countryCode": "LBY",
     "capacity": 50000,
-    "tenantClubs": [
-      "daring-club-motema-pembe"
-    ]
+    "tenantClubs": []
   },
   {
     "id": "stade-du-26-mars",
@@ -3091,9 +3041,87 @@
     ]
   },
   {
+    "id": "harbin-sports-city-center-stadium",
+    "name": "Harbin Sports City Center Stadium",
+    "city": null,
+    "countryCode": "CHN",
+    "capacity": 50000,
+    "tenantClubs": [
+      "harbin-yiteng-f-c"
+    ]
+  },
+  {
+    "id": "may-19-1956-stadium",
+    "name": "May 19, 1956 Stadium",
+    "city": null,
+    "countryCode": "DZA",
+    "capacity": 50000,
+    "tenantClubs": [
+      "usm-annaba"
+    ]
+  },
+  {
+    "id": "hiroshima-big-arch",
+    "name": "Hiroshima Big Arch",
+    "city": "Hiroshima",
+    "countryCode": "JPN",
+    "capacity": 50000,
+    "tenantClubs": [
+      "sanfrecce-hiroshima"
+    ]
+  },
+  {
+    "id": "estadio-11-de-novembro",
+    "name": "Estádio 11 de Novembro",
+    "city": null,
+    "countryCode": "AGO",
+    "capacity": 50000,
+    "tenantClubs": [
+      "clube-desportivo-primeiro-de-agosto"
+    ]
+  },
+  {
+    "id": "stade-24-fevrier-1956",
+    "name": "Stade 24 Fevrier 1956",
+    "city": null,
+    "countryCode": "DZA",
+    "capacity": 50000,
+    "tenantClubs": [
+      "usm-bel-abbes"
+    ]
+  },
+  {
+    "id": "wulihe-stadium",
+    "name": "Wulihe Stadium",
+    "city": null,
+    "countryCode": "CHN",
+    "capacity": 50000,
+    "tenantClubs": []
+  },
+  {
+    "id": "jose-amalfitani-stadium",
+    "name": "José Amalfitani Stadium",
+    "city": "Buenos Aires",
+    "countryCode": "ARG",
+    "capacity": 50000,
+    "tenantClubs": [
+      "argentina-national-rugby-union-team",
+      "club-atletico-velez-sarsfield",
+      "jaguares"
+    ]
+  },
+  {
+    "id": "jiangxi-olympic-sports-center",
+    "name": "Jiangxi Olympic Sports Center",
+    "city": "Nanchang",
+    "countryCode": "CHN",
+    "capacity": 50000,
+    "tenantClubs": []
+  },
+  {
     "id": "aloha-stadium",
     "name": "Aloha Stadium",
-    "city": "Halawa",
+    "city": null,
     "countryCode": "USA",
     "capacity": 50000,
     "tenantClubs": [
@@ -3102,32 +3130,56 @@
     ]
   },
   {
-    "id": "stadium-at-olympia",
-    "name": "Stadium at Olympia",
-    "city": "Olympia",
-    "countryCode": "GRC",
+    "id": "stade-olympique-de-la-pontaise",
+    "name": "Stade Olympique de la Pontaise",
+    "city": "Lausanne",
+    "countryCode": "CHE",
     "capacity": 50000,
     "tenantClubs": [
-      "2004-summer-olympics"
+      "fc-lausanne-sport"
     ]
   },
   {
-    "id": "shaheed-mohtarama-benazir-bhutto-international-cricket-stadium",
-    "name": "Shaheed Mohtarama Benazir Bhutto International Cricket Stadium",
+    "id": "estadio-zapote",
+    "name": "Estadio Zapote",
     "city": null,
-    "countryCode": "PAK",
-    "capacity": 50000,
-    "tenantClubs": []
-  },
-  {
-    "id": "felix-houphouet-boigny-stadium",
-    "name": "Felix Houphouet Boigny Stadium",
-    "city": null,
-    "countryCode": "CIV",
+    "countryCode": "MEX",
     "capacity": 50000,
     "tenantClubs": [
-      "academie-de-sol-beni",
-      "asec-mimosas"
+      "jaiba-brava"
+    ]
+  },
+  {
+    "id": "estadio-pedro-bidegain",
+    "name": "Estadio Pedro Bidegain",
+    "city": "Buenos Aires",
+    "countryCode": "ARG",
+    "capacity": 50000,
+    "tenantClubs": [
+      "san-lorenzo-de-almagro",
+      "san-lorenzo-de-almagro-women"
+    ]
+  },
+  {
+    "id": "stade-tata-raphael",
+    "name": "Stade Tata Raphaël",
+    "city": null,
+    "countryCode": "COD",
+    "capacity": 50000,
+    "tenantClubs": [
+      "daring-club-motema-pembe"
+    ]
+  },
+  {
+    "id": "eden-park",
+    "name": "Eden Park",
+    "city": null,
+    "countryCode": "NZL",
+    "capacity": 50000,
+    "tenantClubs": [
+      "auckland-rfu",
+      "auckland-rugby-union-team",
+      "blues"
     ]
   },
   {
@@ -3139,13 +3191,13 @@
     "tenantClubs": []
   },
   {
-    "id": "thuwunna-stadium",
-    "name": "Thuwunna Stadium",
-    "city": "Thingangyun Township",
-    "countryCode": "MMR",
+    "id": "pars-stadium",
+    "name": "Pars Stadium",
+    "city": null,
+    "countryCode": "IRN",
     "capacity": 50000,
     "tenantClubs": [
-      "myanmar-men-s-national-football-team"
+      "fajr-sepasi-f-c"
     ]
   },
   {
@@ -3160,23 +3212,64 @@
     ]
   },
   {
-    "id": "harbin-sports-city-center-stadium",
-    "name": "Harbin Sports City Center Stadium",
-    "city": null,
-    "countryCode": "CHN",
+    "id": "thuwunna-stadium",
+    "name": "Thuwunna Stadium",
+    "city": "Yangon",
+    "countryCode": "MMR",
     "capacity": 50000,
     "tenantClubs": [
-      "harbin-yiteng-f-c"
+      "myanmar-men-s-national-football-team"
     ]
   },
   {
-    "id": "general-lansana-conte-stadium",
-    "name": "General Lansana Conté Stadium",
-    "city": null,
-    "countryCode": "GIN",
+    "id": "stadium-at-olympia",
+    "name": "Stadium at Olympia",
+    "city": "Olympia",
+    "countryCode": "GRC",
     "capacity": 50000,
     "tenantClubs": [
-      "guinea-men-s-national-football-team"
+      "2004-summer-olympics"
+    ]
+  },
+  {
+    "id": "max-morlock-stadion",
+    "name": "Max-Morlock-Stadion",
+    "city": null,
+    "countryCode": "DEU",
+    "capacity": 50000,
+    "tenantClubs": [
+      "1-fc-nurnberg"
+    ]
+  },
+  {
+    "id": "stadion-za-luzankami",
+    "name": "Stadion Za Lužánkami",
+    "city": "Brno",
+    "countryCode": "CZE",
+    "capacity": 50000,
+    "tenantClubs": [
+      "fc-zbrojovka-brno"
+    ]
+  },
+  {
+    "id": "felix-houphouet-boigny-stadium",
+    "name": "Felix Houphouet Boigny Stadium",
+    "city": null,
+    "countryCode": "CIV",
+    "capacity": 50000,
+    "tenantClubs": [
+      "academie-de-sol-beni",
+      "asec-mimosas"
+    ]
+  },
+  {
+    "id": "sultan-mizan-zainal-abidin-stadium",
+    "name": "Sultan Mizan Zainal Abidin Stadium",
+    "city": null,
+    "countryCode": "MYS",
+    "capacity": 50000,
+    "tenantClubs": [
+      "terengganu-f-c"
     ]
   },
   {
@@ -3190,60 +3283,10 @@
     ]
   },
   {
-    "id": "estadio-zapote",
-    "name": "Estadio Zapote",
-    "city": null,
-    "countryCode": "MEX",
-    "capacity": 50000,
-    "tenantClubs": [
-      "jaiba-brava"
-    ]
-  },
-  {
-    "id": "eden-park",
-    "name": "Eden Park",
-    "city": "Kingsland",
-    "countryCode": "NZL",
-    "capacity": 50000,
-    "tenantClubs": [
-      "auckland-rfu",
-      "auckland-rugby-union-team",
-      "blues"
-    ]
-  },
-  {
-    "id": "hiroshima-big-arch",
-    "name": "Hiroshima Big Arch",
-    "city": "Hiroshima",
-    "countryCode": "JPN",
-    "capacity": 50000,
-    "tenantClubs": [
-      "sanfrecce-hiroshima"
-    ]
-  },
-  {
     "id": "lago-di-tesero-cross-country-ski-stadium",
     "name": "Lago di Tesero Cross-Country Ski Stadium",
-    "city": "Lago",
+    "city": null,
     "countryCode": "ITA",
-    "capacity": 50000,
-    "tenantClubs": []
-  },
-  {
-    "id": "stade-24-fevrier-1956",
-    "name": "Stade 24 Fevrier 1956",
-    "city": null,
-    "countryCode": "DZA",
-    "capacity": 50000,
-    "tenantClubs": [
-      "usm-bel-abbes"
-    ]
-  },
-  {
-    "id": "wadi-al-rabi-stadium",
-    "name": "Wadi Al Rabi Stadium",
-    "city": null,
-    "countryCode": "LBY",
     "capacity": 50000,
     "tenantClubs": []
   },
@@ -3259,92 +3302,13 @@
     ]
   },
   {
-    "id": "estadio-11-de-novembro",
-    "name": "Estádio 11 de Novembro",
-    "city": "Talatona",
-    "countryCode": "AGO",
-    "capacity": 50000,
-    "tenantClubs": [
-      "clube-desportivo-primeiro-de-agosto"
-    ]
-  },
-  {
-    "id": "jiangxi-olympic-sports-center",
-    "name": "Jiangxi Olympic Sports Center",
-    "city": "Nanchang",
-    "countryCode": "CHN",
-    "capacity": 50000,
-    "tenantClubs": []
-  },
-  {
-    "id": "jose-amalfitani-stadium",
-    "name": "José Amalfitani Stadium",
-    "city": "Liniers",
-    "countryCode": "ARG",
-    "capacity": 50000,
-    "tenantClubs": [
-      "argentina-national-rugby-union-team",
-      "club-atletico-velez-sarsfield",
-      "jaguares"
-    ]
-  },
-  {
-    "id": "estadio-pedro-bidegain",
-    "name": "Estadio Pedro Bidegain",
-    "city": "Flores",
-    "countryCode": "ARG",
-    "capacity": 50000,
-    "tenantClubs": [
-      "san-lorenzo-de-almagro",
-      "san-lorenzo-de-almagro-women"
-    ]
-  },
-  {
-    "id": "wulihe-stadium",
-    "name": "Wulihe Stadium",
-    "city": null,
-    "countryCode": "CHN",
-    "capacity": 50000,
-    "tenantClubs": []
-  },
-  {
-    "id": "stadion-za-luzankami",
-    "name": "Stadion Za Lužánkami",
-    "city": "Brno",
-    "countryCode": "CZE",
-    "capacity": 50000,
-    "tenantClubs": [
-      "fc-zbrojovka-brno"
-    ]
-  },
-  {
-    "id": "bill-snyder-family-football-stadium",
-    "name": "Bill Snyder Family Football Stadium",
-    "city": null,
-    "countryCode": "USA",
-    "capacity": 50000,
-    "tenantClubs": [
-      "kansas-state-wildcats-football"
-    ]
-  },
-  {
-    "id": "sultan-mizan-zainal-abidin-stadium",
-    "name": "Sultan Mizan Zainal Abidin Stadium",
-    "city": null,
-    "countryCode": "MYS",
-    "capacity": 50000,
-    "tenantClubs": [
-      "terengganu-f-c"
-    ]
-  },
-  {
-    "id": "may-19-1956-stadium",
-    "name": "May 19, 1956 Stadium",
+    "id": "hocine-ait-ahmed-stadium",
+    "name": "Hocine-Ait Ahmed Stadium",
     "city": null,
     "countryCode": "DZA",
     "capacity": 50000,
     "tenantClubs": [
-      "usm-annaba"
+      "js-kabylie"
     ]
   },
   {
@@ -3356,6 +3320,16 @@
     "tenantClubs": [
       "east-carolina-pirates",
       "east-carolina-pirates-football"
+    ]
+  },
+  {
+    "id": "general-lansana-conte-stadium",
+    "name": "General Lansana Conté Stadium",
+    "city": null,
+    "countryCode": "GIN",
+    "capacity": 50000,
+    "tenantClubs": [
+      "guinea-men-s-national-football-team"
     ]
   },
   {
@@ -3371,7 +3345,7 @@
   {
     "id": "levy-mwanawasa-stadium",
     "name": "Levy Mwanawasa Stadium",
-    "city": "T3 road",
+    "city": null,
     "countryCode": "ZMB",
     "capacity": 49800,
     "tenantClubs": [
@@ -3437,7 +3411,7 @@
   {
     "id": "q-a-stadium-miyagi",
     "name": "Q&A Stadium Miyagi",
-    "city": "Miyagi Sports Park",
+    "city": null,
     "countryCode": "JPN",
     "capacity": 49133,
     "tenantClubs": [
@@ -3530,7 +3504,7 @@
   {
     "id": "arena-fonte-nova",
     "name": "Arena Fonte Nova",
-    "city": "Nazaré",
+    "city": "Salvador",
     "countryCode": "BRA",
     "capacity": 47915,
     "tenantClubs": [
@@ -3541,7 +3515,7 @@
   {
     "id": "yanmar-stadium-nagai",
     "name": "Yanmar Stadium Nagai",
-    "city": "Nagai Park",
+    "city": "Osaka",
     "countryCode": "JPN",
     "capacity": 47853,
     "tenantClubs": [
@@ -3601,26 +3575,6 @@
     "tenantClubs": []
   },
   {
-    "id": "amon-g-carter-stadium",
-    "name": "Amon G. Carter Stadium",
-    "city": null,
-    "countryCode": "USA",
-    "capacity": 47000,
-    "tenantClubs": [
-      "tcu-horned-frogs-football"
-    ]
-  },
-  {
-    "id": "estadio-monumental",
-    "name": "Estadio Monumental",
-    "city": "Macul",
-    "countryCode": "CHL",
-    "capacity": 47000,
-    "tenantClubs": [
-      "club-social-y-deportivo-colo-colo"
-    ]
-  },
-  {
     "id": "rice-stadium",
     "name": "Rice Stadium",
     "city": null,
@@ -3633,9 +3587,29 @@
     ]
   },
   {
+    "id": "estadio-monumental",
+    "name": "Estadio Monumental",
+    "city": null,
+    "countryCode": "CHL",
+    "capacity": 47000,
+    "tenantClubs": [
+      "club-social-y-deportivo-colo-colo"
+    ]
+  },
+  {
+    "id": "amon-g-carter-stadium",
+    "name": "Amon G. Carter Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 47000,
+    "tenantClubs": [
+      "tcu-horned-frogs-football"
+    ]
+  },
+  {
     "id": "prince-mohammed-bin-salman-stadium",
     "name": "Prince Mohammed bin Salman Stadium",
-    "city": "Qiddiya",
+    "city": null,
     "countryCode": "SAU",
     "capacity": 46979,
     "tenantClubs": [
@@ -3697,14 +3671,6 @@
     ]
   },
   {
-    "id": "qiddiya-coast-stadium",
-    "name": "Qiddiya Coast Stadium",
-    "city": null,
-    "countryCode": "SAU",
-    "capacity": 46096,
-    "tenantClubs": []
-  },
-  {
     "id": "aramco-stadium",
     "name": "Aramco Stadium",
     "city": null,
@@ -3713,17 +3679,25 @@
     "tenantClubs": []
   },
   {
-    "id": "al-murabba-stadium",
-    "name": "Al-Murabba Stadium",
-    "city": "Riyadh",
+    "id": "qiddiya-coast-stadium",
+    "name": "Qiddiya Coast Stadium",
+    "city": null,
     "countryCode": "SAU",
-    "capacity": 46010,
+    "capacity": 46096,
     "tenantClubs": []
   },
   {
     "id": "neom-stadium",
     "name": "NEOM Stadium",
     "city": null,
+    "countryCode": "SAU",
+    "capacity": 46010,
+    "tenantClubs": []
+  },
+  {
+    "id": "al-murabba-stadium",
+    "name": "Al-Murabba Stadium",
+    "city": "Riyadh",
     "countryCode": "SAU",
     "capacity": 46010,
     "tenantClubs": []
@@ -3778,7 +3752,7 @@
   {
     "id": "king-abdullah-economic-city-stadium",
     "name": "King Abdullah Economic City Stadium",
-    "city": "Rabigh governorate",
+    "city": null,
     "countryCode": "SAU",
     "capacity": 45700,
     "tenantClubs": []
@@ -3786,7 +3760,7 @@
   {
     "id": "reser-stadium",
     "name": "Reser Stadium",
-    "city": "Oregon State University",
+    "city": "Corvallis",
     "countryCode": "USA",
     "capacity": 45674,
     "tenantClubs": [
@@ -3850,7 +3824,7 @@
   {
     "id": "al-shamal-stadium",
     "name": "Al-Shamal Stadium",
-    "city": "Al Shamal",
+    "city": null,
     "countryCode": "QAT",
     "capacity": 45330,
     "tenantClubs": [
@@ -3860,7 +3834,7 @@
   {
     "id": "acrisure-bounce-house",
     "name": "Acrisure Bounce House",
-    "city": "University of Central Florida",
+    "city": "Orlando",
     "countryCode": "USA",
     "capacity": 45323,
     "tenantClubs": [
@@ -3872,7 +3846,7 @@
   {
     "id": "dy-patil-stadium",
     "name": "DY Patil Stadium",
-    "city": "Nerul",
+    "city": "Navi Mumbai",
     "countryCode": "IND",
     "capacity": 45300,
     "tenantClubs": []
@@ -3910,7 +3884,7 @@
   {
     "id": "mandela-national-stadium",
     "name": "Mandela National Stadium",
-    "city": "Bweyogerere",
+    "city": "Kira Town",
     "countryCode": "UGA",
     "capacity": 45202,
     "tenantClubs": [
@@ -3942,23 +3916,13 @@
   {
     "id": "rice-eccles-stadium",
     "name": "Rice–Eccles Stadium",
-    "city": "University of Utah",
+    "city": "Salt Lake City",
     "countryCode": "USA",
     "capacity": 45017,
     "tenantClubs": [
       "salt-lake-stallions",
       "utah-utes",
       "utah-utes-football"
-    ]
-  },
-  {
-    "id": "rostec-arena",
-    "name": "Rostec Arena",
-    "city": null,
-    "countryCode": "RUS",
-    "capacity": 45015,
-    "tenantClubs": [
-      "fc-baltika-kaliningrad"
     ]
   },
   {
@@ -3972,189 +3936,23 @@
     ]
   },
   {
+    "id": "rostec-arena",
+    "name": "Rostec Arena",
+    "city": null,
+    "countryCode": "RUS",
+    "capacity": 45015,
+    "tenantClubs": [
+      "fc-baltika-kaliningrad"
+    ]
+  },
+  {
     "id": "estadio-estadual-jornalista-edgar-augusto-proenca",
     "name": "Estádio Estadual Jornalista Edgar Augusto Proença",
-    "city": "Mangueirão",
+    "city": null,
     "countryCode": "BRA",
     "capacity": 45007,
     "tenantClubs": [
       "clube-do-remo"
-    ]
-  },
-  {
-    "id": "estadio-campeon-del-siglo",
-    "name": "Estadio Campeón del Siglo",
-    "city": null,
-    "countryCode": "URY",
-    "capacity": 45000,
-    "tenantClubs": [
-      "club-atletico-penarol"
-    ]
-  },
-  {
-    "id": "zibo-sports-center-stadium",
-    "name": "Zibo Sports Center Stadium",
-    "city": "Zibo",
-    "countryCode": "CHN",
-    "capacity": 45000,
-    "tenantClubs": [
-      "2010-afc-u-19-championship"
-    ]
-  },
-  {
-    "id": "harapan-bangsa-stadium",
-    "name": "Harapan Bangsa Stadium",
-    "city": null,
-    "countryCode": "IDN",
-    "capacity": 45000,
-    "tenantClubs": [
-      "persiraja-banda-aceh"
-    ]
-  },
-  {
-    "id": "weifang-sports-center-stadium",
-    "name": "Weifang Sports Center Stadium",
-    "city": "Weifang",
-    "countryCode": "CHN",
-    "capacity": 45000,
-    "tenantClubs": []
-  },
-  {
-    "id": "estadio-olimpico-monumental",
-    "name": "Estádio Olímpico Monumental",
-    "city": null,
-    "countryCode": "BRA",
-    "capacity": 45000,
-    "tenantClubs": [
-      "gremio-fbpa"
-    ]
-  },
-  {
-    "id": "naghsh-e-jahan-stadium",
-    "name": "Naghsh-e-Jahan Stadium",
-    "city": null,
-    "countryCode": "IRN",
-    "capacity": 45000,
-    "tenantClubs": [
-      "sepahan-f-c"
-    ]
-  },
-  {
-    "id": "mclane-stadium",
-    "name": "McLane Stadium",
-    "city": null,
-    "countryCode": "USA",
-    "capacity": 45000,
-    "tenantClubs": [
-      "baylor-bears",
-      "baylor-bears-football"
-    ]
-  },
-  {
-    "id": "fez-stadium",
-    "name": "Fez Stadium",
-    "city": null,
-    "countryCode": "MAR",
-    "capacity": 45000,
-    "tenantClubs": [
-      "maghreb-association-sportive-de-fes"
-    ]
-  },
-  {
-    "id": "estadio-da-machava",
-    "name": "Estádio da Machava",
-    "city": null,
-    "countryCode": "MOZ",
-    "capacity": 45000,
-    "tenantClubs": [
-      "clube-ferroviario-de-maputo"
-    ]
-  },
-  {
-    "id": "kobe-universiade-memorial-stadium",
-    "name": "Kobe Universiade Memorial Stadium",
-    "city": null,
-    "countryCode": "JPN",
-    "capacity": 45000,
-    "tenantClubs": [
-      "1985-summer-universiade",
-      "kobelco-kobe-steelers"
-    ]
-  },
-  {
-    "id": "stadium-974",
-    "name": "Stadium 974",
-    "city": "Doha",
-    "countryCode": "QAT",
-    "capacity": 45000,
-    "tenantClubs": []
-  },
-  {
-    "id": "stade-omar-bongo",
-    "name": "Stade Omar Bongo",
-    "city": null,
-    "countryCode": "GAB",
-    "capacity": 45000,
-    "tenantClubs": [
-      "fc-105-libreville"
-    ]
-  },
-  {
-    "id": "stade-el-menzah",
-    "name": "Stade El Menzah",
-    "city": null,
-    "countryCode": "TUN",
-    "capacity": 45000,
-    "tenantClubs": [
-      "esperance-sportive-de-tunis"
-    ]
-  },
-  {
-    "id": "mubarak-international-stadium",
-    "name": "Mubarak International Stadium",
-    "city": null,
-    "countryCode": "EGY",
-    "capacity": 45000,
-    "tenantClubs": []
-  },
-  {
-    "id": "qingdao-conson-stadium",
-    "name": "Qingdao Conson Stadium",
-    "city": "Qingdao",
-    "countryCode": "CHN",
-    "capacity": 45000,
-    "tenantClubs": [
-      "qingdao-f-c"
-    ]
-  },
-  {
-    "id": "morenao",
-    "name": "Morenão",
-    "city": null,
-    "countryCode": "BRA",
-    "capacity": 45000,
-    "tenantClubs": [
-      "esporte-clube-comercial"
-    ]
-  },
-  {
-    "id": "rostov-arena",
-    "name": "Rostov Arena",
-    "city": null,
-    "countryCode": "RUS",
-    "capacity": 45000,
-    "tenantClubs": [
-      "fc-rostov"
-    ]
-  },
-  {
-    "id": "arena-das-dunas",
-    "name": "Arena das Dunas",
-    "city": null,
-    "countryCode": "BRA",
-    "capacity": 45000,
-    "tenantClubs": [
-      "america-futebol-clube"
     ]
   },
   {
@@ -4168,6 +3966,103 @@
     ]
   },
   {
+    "id": "mubarak-international-stadium",
+    "name": "Mubarak International Stadium",
+    "city": null,
+    "countryCode": "EGY",
+    "capacity": 45000,
+    "tenantClubs": []
+  },
+  {
+    "id": "weifang-sports-center-stadium",
+    "name": "Weifang Sports Center Stadium",
+    "city": "Weifang",
+    "countryCode": "CHN",
+    "capacity": 45000,
+    "tenantClubs": []
+  },
+  {
+    "id": "mclane-stadium",
+    "name": "McLane Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 45000,
+    "tenantClubs": [
+      "baylor-bears",
+      "baylor-bears-football"
+    ]
+  },
+  {
+    "id": "qingdao-conson-stadium",
+    "name": "Qingdao Conson Stadium",
+    "city": "Qingdao",
+    "countryCode": "CHN",
+    "capacity": 45000,
+    "tenantClubs": [
+      "qingdao-f-c"
+    ]
+  },
+  {
+    "id": "estadio-kleber-andrade",
+    "name": "Estádio Kléber Andrade",
+    "city": "Cariacica",
+    "countryCode": "BRA",
+    "capacity": 45000,
+    "tenantClubs": [
+      "rio-branco-atletico-clube"
+    ]
+  },
+  {
+    "id": "estadio-olimpico-monumental",
+    "name": "Estádio Olímpico Monumental",
+    "city": null,
+    "countryCode": "BRA",
+    "capacity": 45000,
+    "tenantClubs": [
+      "gremio-fbpa"
+    ]
+  },
+  {
+    "id": "zibo-sports-center-stadium",
+    "name": "Zibo Sports Center Stadium",
+    "city": "Zibo",
+    "countryCode": "CHN",
+    "capacity": 45000,
+    "tenantClubs": [
+      "2010-afc-u-19-championship"
+    ]
+  },
+  {
+    "id": "rostov-arena",
+    "name": "Rostov Arena",
+    "city": null,
+    "countryCode": "RUS",
+    "capacity": 45000,
+    "tenantClubs": [
+      "fc-rostov"
+    ]
+  },
+  {
+    "id": "stade-el-menzah",
+    "name": "Stade El Menzah",
+    "city": null,
+    "countryCode": "TUN",
+    "capacity": 45000,
+    "tenantClubs": [
+      "esperance-sportive-de-tunis"
+    ]
+  },
+  {
+    "id": "arena-das-dunas",
+    "name": "Arena das Dunas",
+    "city": null,
+    "countryCode": "BRA",
+    "capacity": 45000,
+    "tenantClubs": [
+      "america-futebol-clube"
+    ]
+  },
+  {
     "id": "preu-enstadion",
     "name": "Preußenstadion",
     "city": null,
@@ -4175,6 +4070,45 @@
     "capacity": 45000,
     "tenantClubs": [
       "sc-preu-en-munster"
+    ]
+  },
+  {
+    "id": "fez-stadium",
+    "name": "Fez Stadium",
+    "city": null,
+    "countryCode": "MAR",
+    "capacity": 45000,
+    "tenantClubs": [
+      "maghreb-association-sportive-de-fes"
+    ]
+  },
+  {
+    "id": "harapan-bangsa-stadium",
+    "name": "Harapan Bangsa Stadium",
+    "city": null,
+    "countryCode": "IDN",
+    "capacity": 45000,
+    "tenantClubs": [
+      "persiraja-banda-aceh"
+    ]
+  },
+  {
+    "id": "latakia-sports-city-stadium",
+    "name": "Latakia Sports City Stadium",
+    "city": "Latakia",
+    "countryCode": "SYR",
+    "capacity": 45000,
+    "tenantClubs": []
+  },
+  {
+    "id": "kobe-universiade-memorial-stadium",
+    "name": "Kobe Universiade Memorial Stadium",
+    "city": null,
+    "countryCode": "JPN",
+    "capacity": 45000,
+    "tenantClubs": [
+      "1985-summer-universiade",
+      "kobelco-kobe-steelers"
     ]
   },
   {
@@ -4188,22 +4122,62 @@
     ]
   },
   {
-    "id": "latakia-sports-city-stadium",
-    "name": "Latakia Sports City Stadium",
-    "city": "Latakia",
-    "countryCode": "SYR",
+    "id": "estadio-campeon-del-siglo",
+    "name": "Estadio Campeón del Siglo",
+    "city": null,
+    "countryCode": "URY",
     "capacity": 45000,
-    "tenantClubs": []
+    "tenantClubs": [
+      "club-atletico-penarol"
+    ]
   },
   {
-    "id": "estadio-kleber-andrade",
-    "name": "Estádio Kléber Andrade",
-    "city": "Cariacica",
+    "id": "stade-omar-bongo",
+    "name": "Stade Omar Bongo",
+    "city": null,
+    "countryCode": "GAB",
+    "capacity": 45000,
+    "tenantClubs": [
+      "fc-105-libreville"
+    ]
+  },
+  {
+    "id": "morenao",
+    "name": "Morenão",
+    "city": null,
     "countryCode": "BRA",
     "capacity": 45000,
     "tenantClubs": [
-      "rio-branco-atletico-clube"
+      "esporte-clube-comercial"
     ]
+  },
+  {
+    "id": "estadio-da-machava",
+    "name": "Estádio da Machava",
+    "city": null,
+    "countryCode": "MOZ",
+    "capacity": 45000,
+    "tenantClubs": [
+      "clube-ferroviario-de-maputo"
+    ]
+  },
+  {
+    "id": "naghsh-e-jahan-stadium",
+    "name": "Naghsh-e-Jahan Stadium",
+    "city": null,
+    "countryCode": "IRN",
+    "capacity": 45000,
+    "tenantClubs": [
+      "sepahan-f-c"
+    ]
+  },
+  {
+    "id": "stadium-974",
+    "name": "Stadium 974",
+    "city": "Doha",
+    "countryCode": "QAT",
+    "capacity": 45000,
+    "tenantClubs": []
   },
   {
     "id": "samara-arena",
@@ -4239,16 +4213,6 @@
     ]
   },
   {
-    "id": "thani-bin-jassim-stadium",
-    "name": "Thani bin Jassim Stadium",
-    "city": "Al Rayyan Municipality",
-    "countryCode": "QAT",
-    "capacity": 44740,
-    "tenantClubs": [
-      "al-gharafa-sc"
-    ]
-  },
-  {
     "id": "ahmad-bin-ali-stadium",
     "name": "Ahmad bin Ali Stadium",
     "city": "Al Rayyan",
@@ -4256,6 +4220,16 @@
     "capacity": 44740,
     "tenantClubs": [
       "al-rayyan"
+    ]
+  },
+  {
+    "id": "thani-bin-jassim-stadium",
+    "name": "Thani bin Jassim Stadium",
+    "city": null,
+    "countryCode": "QAT",
+    "capacity": 44740,
+    "tenantClubs": [
+      "al-gharafa-sc"
     ]
   },
   {
@@ -4380,7 +4354,7 @@
   {
     "id": "sydney-cricket-ground",
     "name": "Sydney Cricket Ground",
-    "city": "Moore Park",
+    "city": null,
     "countryCode": "AUS",
     "capacity": 43649,
     "tenantClubs": [
@@ -4392,18 +4366,18 @@
     ]
   },
   {
-    "id": "mbombela-stadium",
-    "name": "Mbombela Stadium",
-    "city": "Mbombela",
-    "countryCode": "ZAF",
-    "capacity": 43500,
-    "tenantClubs": []
-  },
-  {
     "id": "qatar-university-stadium",
     "name": "Qatar University Stadium",
     "city": null,
     "countryCode": "QAT",
+    "capacity": 43500,
+    "tenantClubs": []
+  },
+  {
+    "id": "mbombela-stadium",
+    "name": "Mbombela Stadium",
+    "city": "Mbombela",
+    "countryCode": "ZAF",
     "capacity": 43500,
     "tenantClubs": []
   },
@@ -4441,7 +4415,7 @@
   {
     "id": "vasil-levski-national-stadium",
     "name": "Vasil Levski National Stadium",
-    "city": "Borisova Gradina",
+    "city": null,
     "countryCode": "BGR",
     "capacity": 43230,
     "tenantClubs": [
@@ -4451,7 +4425,7 @@
   {
     "id": "fitzgerald-stadium",
     "name": "Fitzgerald Stadium",
-    "city": "Killarney",
+    "city": null,
     "countryCode": "IRL",
     "capacity": 43180,
     "tenantClubs": [
@@ -4471,23 +4445,12 @@
   {
     "id": "national-stadium-of-peru",
     "name": "National Stadium of Peru",
-    "city": "Lima",
+    "city": null,
     "countryCode": "PER",
     "capacity": 43086,
     "tenantClubs": [
       "club-atletico-defensor-lima-1931",
       "peru-men-s-national-football-team"
-    ]
-  },
-  {
-    "id": "ullevi",
-    "name": "Ullevi",
-    "city": "Heden",
-    "countryCode": "SWE",
-    "capacity": 43000,
-    "tenantClubs": [
-      "1975-world-sprint-speed-skating-championships",
-      "ifk-goteborg"
     ]
   },
   {
@@ -4498,6 +4461,17 @@
     "capacity": 43000,
     "tenantClubs": [
       "emirates-men-s-national-football-team"
+    ]
+  },
+  {
+    "id": "ullevi",
+    "name": "Ullevi",
+    "city": null,
+    "countryCode": "SWE",
+    "capacity": 43000,
+    "tenantClubs": [
+      "1975-world-sprint-speed-skating-championships",
+      "ifk-goteborg"
     ]
   },
   {
@@ -4535,7 +4509,7 @@
   {
     "id": "gwangju-world-cup-stadium",
     "name": "Gwangju World Cup Stadium",
-    "city": "Seo District",
+    "city": "Gwangju",
     "countryCode": "KOR",
     "capacity": 42880,
     "tenantClubs": [
@@ -4575,7 +4549,7 @@
   {
     "id": "ramon-sanchez-pizjuan-stadium",
     "name": "Ramón Sánchez Pizjuán Stadium",
-    "city": "Nervión",
+    "city": null,
     "countryCode": "ESP",
     "capacity": 42714,
     "tenantClubs": [
@@ -4593,13 +4567,14 @@
     ]
   },
   {
-    "id": "central-stadium-yekaterinburg",
-    "name": "Central Stadium Yekaterinburg",
-    "city": null,
-    "countryCode": "RUS",
+    "id": "estadio-polideportivo-de-pueblo-nuevo",
+    "name": "Estadio Polideportivo de Pueblo Nuevo",
+    "city": "San Cristóbal",
+    "countryCode": "VEN",
     "capacity": 42500,
     "tenantClubs": [
-      "fc-ural-yekaterinburg"
+      "atletico-san-cristobal",
+      "internacional-de-bogota"
     ]
   },
   {
@@ -4613,14 +4588,13 @@
     ]
   },
   {
-    "id": "estadio-polideportivo-de-pueblo-nuevo",
-    "name": "Estadio Polideportivo de Pueblo Nuevo",
-    "city": "San Cristóbal",
-    "countryCode": "VEN",
+    "id": "central-stadium-yekaterinburg",
+    "name": "Central Stadium Yekaterinburg",
+    "city": null,
+    "countryCode": "RUS",
     "capacity": 42500,
     "tenantClubs": [
-      "atletico-san-cristobal",
-      "internacional-de-bogota"
+      "fc-ural-yekaterinburg"
     ]
   },
   {
@@ -4727,16 +4701,6 @@
     ]
   },
   {
-    "id": "estadio-olimpico-pascual-guerrero",
-    "name": "Estadio Olímpico Pascual Guerrero",
-    "city": null,
-    "countryCode": "COL",
-    "capacity": 42200,
-    "tenantClubs": [
-      "america-de-cali"
-    ]
-  },
-  {
     "id": "estadio-metropolitano-de-merida",
     "name": "Estadio Metropolitano de Mérida",
     "city": null,
@@ -4744,6 +4708,16 @@
     "capacity": 42200,
     "tenantClubs": [
       "estudiantes-de-merida"
+    ]
+  },
+  {
+    "id": "estadio-olimpico-pascual-guerrero",
+    "name": "Estadio Olímpico Pascual Guerrero",
+    "city": null,
+    "countryCode": "COL",
+    "capacity": 42200,
+    "tenantClubs": [
+      "america-de-cali"
     ]
   },
   {
@@ -4759,7 +4733,7 @@
   {
     "id": "helsinki-olympic-stadium",
     "name": "Helsinki Olympic Stadium",
-    "city": "Taka-Töölö",
+    "city": "Helsinki",
     "countryCode": "FIN",
     "capacity": 42062,
     "tenantClubs": [
@@ -4787,15 +4761,13 @@
     ]
   },
   {
-    "id": "estadio-deportivo-cali",
-    "name": "Estadio Deportivo Cali",
-    "city": "Palmira",
-    "countryCode": "COL",
+    "id": "stade-olympique-de-sousse",
+    "name": "Stade Olympique de Sousse",
+    "city": null,
+    "countryCode": "TUN",
     "capacity": 42000,
     "tenantClubs": [
-      "deportivo-cali",
-      "deportivo-cali-women-s-team",
-      "q5803206"
+      "etoile-sportive-du-sahel"
     ]
   },
   {
@@ -4809,14 +4781,62 @@
     ]
   },
   {
-    "id": "stade-olympique-de-sousse",
-    "name": "Stade Olympique de Sousse",
+    "id": "altonaer-stadion-hamburg",
+    "name": "Altonaer Stadion (Hamburg)",
+    "city": "Hamburg",
+    "countryCode": "DEU",
+    "capacity": 42000,
+    "tenantClubs": []
+  },
+  {
+    "id": "royal-bafokeng-stadium",
+    "name": "Royal Bafokeng Stadium",
     "city": null,
-    "countryCode": "TUN",
+    "countryCode": "ZAF",
     "capacity": 42000,
     "tenantClubs": [
-      "etoile-sportive-du-sahel"
+      "platinum-stars-f-c"
     ]
+  },
+  {
+    "id": "estadio-deportivo-cali",
+    "name": "Estadio Deportivo Cali",
+    "city": null,
+    "countryCode": "COL",
+    "capacity": 42000,
+    "tenantClubs": [
+      "deportivo-cali",
+      "deportivo-cali-women-s-team",
+      "q5803206"
+    ]
+  },
+  {
+    "id": "red-bull-arena",
+    "name": "Red Bull Arena",
+    "city": "Leipzig",
+    "countryCode": "DEU",
+    "capacity": 42000,
+    "tenantClubs": [
+      "rb-leipzig"
+    ]
+  },
+  {
+    "id": "estadio-do-zimpeto",
+    "name": "Estádio do Zimpeto",
+    "city": null,
+    "countryCode": "MOZ",
+    "capacity": 42000,
+    "tenantClubs": [
+      "2011-all-africa-games"
+    ]
+  },
+  {
+    "id": "estadio-de-monteria",
+    "name": "Estadio de Monteria",
+    "city": null,
+    "countryCode": "COL",
+    "capacity": 42000,
+    "tenantClubs": []
   },
   {
     "id": "malvinas-argentinas-stadium",
@@ -4831,52 +4851,6 @@
       "huracan-las-heras",
       "independiente-rivadavia",
       "san-martin-de-mendoza"
-    ]
-  },
-  {
-    "id": "red-bull-arena",
-    "name": "Red Bull Arena",
-    "city": "Leipzig",
-    "countryCode": "DEU",
-    "capacity": 42000,
-    "tenantClubs": [
-      "rb-leipzig"
-    ]
-  },
-  {
-    "id": "altonaer-stadion-hamburg",
-    "name": "Altonaer Stadion (Hamburg)",
-    "city": "Bahrenfeld",
-    "countryCode": "DEU",
-    "capacity": 42000,
-    "tenantClubs": []
-  },
-  {
-    "id": "estadio-de-monteria",
-    "name": "Estadio de Monteria",
-    "city": null,
-    "countryCode": "COL",
-    "capacity": 42000,
-    "tenantClubs": []
-  },
-  {
-    "id": "estadio-do-zimpeto",
-    "name": "Estádio do Zimpeto",
-    "city": null,
-    "countryCode": "MOZ",
-    "capacity": 42000,
-    "tenantClubs": [
-      "2011-all-africa-games"
-    ]
-  },
-  {
-    "id": "royal-bafokeng-stadium",
-    "name": "Royal Bafokeng Stadium",
-    "city": null,
-    "countryCode": "ZAF",
-    "capacity": 42000,
-    "tenantClubs": [
-      "platinum-stars-f-c"
     ]
   },
   {
@@ -4903,7 +4877,7 @@
   {
     "id": "nationals-park",
     "name": "Nationals Park",
-    "city": "Navy Yard",
+    "city": "Washington, D.C.",
     "countryCode": "USA",
     "capacity": 41888,
     "tenantClubs": [
@@ -4913,7 +4887,7 @@
   {
     "id": "stamford-bridge",
     "name": "Stamford Bridge",
-    "city": "Fulham",
+    "city": null,
     "countryCode": "GBR",
     "capacity": 41875,
     "tenantClubs": [
@@ -4992,6 +4966,17 @@
     "tenantClubs": []
   },
   {
+    "id": "shi-stadium",
+    "name": "SHI Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 41500,
+    "tenantClubs": [
+      "rutgers-scarlet-knights-football",
+      "rutgers-scarlet-knights-men-s-lacrosse"
+    ]
+  },
+  {
     "id": "papara-park",
     "name": "Papara Park",
     "city": null,
@@ -4999,17 +4984,6 @@
     "capacity": 41500,
     "tenantClubs": [
       "trabzonspor"
-    ]
-  },
-  {
-    "id": "shi-stadium",
-    "name": "SHI Stadium",
-    "city": "Piscataway",
-    "countryCode": "USA",
-    "capacity": 41500,
-    "tenantClubs": [
-      "rutgers-scarlet-knights-football",
-      "rutgers-scarlet-knights-men-s-lacrosse"
     ]
   },
   {
@@ -5122,7 +5096,7 @@
   {
     "id": "kashima-soccer-stadium",
     "name": "Kashima Soccer Stadium",
-    "city": "Kashima",
+    "city": null,
     "countryCode": "JPN",
     "capacity": 40728,
     "tenantClubs": [
@@ -5152,16 +5126,6 @@
     ]
   },
   {
-    "id": "rcde-stadium",
-    "name": "RCDE Stadium",
-    "city": null,
-    "countryCode": "ESP",
-    "capacity": 40500,
-    "tenantClubs": [
-      "rcd-espanyol-de-barcelona"
-    ]
-  },
-  {
     "id": "nagoya-dome",
     "name": "Nagoya Dome",
     "city": null,
@@ -5172,12 +5136,14 @@
     ]
   },
   {
-    "id": "q28269730",
-    "name": "Q28269730",
+    "id": "rcde-stadium",
+    "name": "RCDE Stadium",
     "city": null,
-    "countryCode": "MAR",
-    "capacity": 40410,
-    "tenantClubs": []
+    "countryCode": "ESP",
+    "capacity": 40500,
+    "tenantClubs": [
+      "rcd-espanyol-de-barcelona"
+    ]
   },
   {
     "id": "skelly-field-at-h-a-chapman-stadium",
@@ -5223,7 +5189,7 @@
   {
     "id": "my-dinh-national-stadium",
     "name": "My Dinh National Stadium",
-    "city": "Nam Từ Liêm",
+    "city": "Hanoi",
     "countryCode": "VNM",
     "capacity": 40192,
     "tenantClubs": [
@@ -5271,113 +5237,6 @@
     ]
   },
   {
-    "id": "pratt-whitney-stadium",
-    "name": "Pratt & Whitney Stadium",
-    "city": null,
-    "countryCode": "USA",
-    "capacity": 40000,
-    "tenantClubs": [
-      "uconn-huskies",
-      "uconn-huskies-football"
-    ]
-  },
-  {
-    "id": "accra-sports-stadium",
-    "name": "Accra Sports Stadium",
-    "city": "Ministries",
-    "countryCode": "GHA",
-    "capacity": 40000,
-    "tenantClubs": [
-      "2023-african-games",
-      "accra-great-olympics-f-c",
-      "accra-hearts-of-oak-sc",
-      "accra-lions-fc"
-    ]
-  },
-  {
-    "id": "baba-yara-stadium",
-    "name": "Baba Yara Stadium",
-    "city": "Kumasi",
-    "countryCode": "GHA",
-    "capacity": 40000,
-    "tenantClubs": [
-      "asante-kotoko-f-c"
-    ]
-  },
-  {
-    "id": "kunming-tuodong-sports-center",
-    "name": "Kunming Tuodong Sports Center",
-    "city": null,
-    "countryCode": "CHN",
-    "capacity": 40000,
-    "tenantClubs": [
-      "yunnan-hongta-f-c"
-    ]
-  },
-  {
-    "id": "darul-makmur-stadium",
-    "name": "Darul Makmur Stadium",
-    "city": "Kuantan",
-    "countryCode": "MYS",
-    "capacity": 40000,
-    "tenantClubs": [
-      "sri-pahang-f-c"
-    ]
-  },
-  {
-    "id": "al-janoub-stadium",
-    "name": "Al Janoub Stadium",
-    "city": "Al Wakrah",
-    "countryCode": "QAT",
-    "capacity": 40000,
-    "tenantClubs": [
-      "al-wakrah-sports-club"
-    ]
-  },
-  {
-    "id": "barbourfields-stadium",
-    "name": "Barbourfields Stadium",
-    "city": "Bulawayo",
-    "countryCode": "ZWE",
-    "capacity": 40000,
-    "tenantClubs": [
-      "highlanders-f-c"
-    ]
-  },
-  {
-    "id": "sarawak-stadium",
-    "name": "Sarawak Stadium",
-    "city": "Kuching",
-    "countryCode": "MYS",
-    "capacity": 40000,
-    "tenantClubs": [
-      "sarawak-football-association"
-    ]
-  },
-  {
-    "id": "stade-des-trois-tilleuls",
-    "name": "stade des Trois Tilleuls",
-    "city": null,
-    "countryCode": "BEL",
-    "capacity": 40000,
-    "tenantClubs": [
-      "boitsfort-rugby-club",
-      "la-maison-de-l-escrime",
-      "q104537227",
-      "royal-racing-club-de-bruxelles"
-    ]
-  },
-  {
-    "id": "jahnstadion",
-    "name": "Jahnstadion",
-    "city": null,
-    "countryCode": "DEU",
-    "capacity": 40000,
-    "tenantClubs": [
-      "q869716"
-    ]
-  },
-  {
     "id": "grugastadion",
     "name": "Grugastadion",
     "city": null,
@@ -5386,23 +5245,23 @@
     "tenantClubs": []
   },
   {
-    "id": "estadio-da-cidadela",
-    "name": "Estádio da Cidadela",
+    "id": "orlando-stadium",
+    "name": "Orlando Stadium",
     "city": null,
-    "countryCode": "AGO",
+    "countryCode": "ZAF",
     "capacity": 40000,
     "tenantClubs": [
-      "s-l-benfica"
+      "orlando-pirates-f-c"
     ]
   },
   {
-    "id": "anoeta-stadium",
-    "name": "Anoeta Stadium",
+    "id": "sultan-ibrahim-stadium",
+    "name": "Sultan Ibrahim Stadium",
     "city": null,
-    "countryCode": "ESP",
+    "countryCode": "MYS",
     "capacity": 40000,
     "tenantClubs": [
-      "real-sociedad"
+      "johor-darul-takzim-f-c"
     ]
   },
   {
@@ -5416,13 +5275,102 @@
     ]
   },
   {
-    "id": "stade-velodrome-de-rocourt",
-    "name": "Stade Vélodrome de Rocourt",
+    "id": "bogyoke-aung-san-stadium",
+    "name": "Bogyoke Aung San Stadium",
     "city": null,
-    "countryCode": "BEL",
+    "countryCode": "MMR",
     "capacity": 40000,
     "tenantClubs": [
-      "r-f-c-de-liege"
+      "yangon-united-f-c"
+    ]
+  },
+  {
+    "id": "oita-stadium",
+    "name": "Ōita Stadium",
+    "city": "Ōita-shi",
+    "countryCode": "JPN",
+    "capacity": 40000,
+    "tenantClubs": [
+      "oita-trinita"
+    ]
+  },
+  {
+    "id": "ali-la-pointe-stadium",
+    "name": "Ali La Pointe Stadium",
+    "city": null,
+    "countryCode": "DZA",
+    "capacity": 40000,
+    "tenantClubs": [
+      "mc-algiers"
+    ]
+  },
+  {
+    "id": "sree-kanteerava-stadium",
+    "name": "Sree Kanteerava Stadium",
+    "city": "Bengaluru",
+    "countryCode": "IND",
+    "capacity": 40000,
+    "tenantClubs": [
+      "bengaluru-fc"
+    ]
+  },
+  {
+    "id": "benghazi-international-stadium",
+    "name": "Benghazi International Stadium",
+    "city": null,
+    "countryCode": "LBY",
+    "capacity": 40000,
+    "tenantClubs": []
+  },
+  {
+    "id": "sarawak-stadium",
+    "name": "Sarawak Stadium",
+    "city": "Kuching",
+    "countryCode": "MYS",
+    "capacity": 40000,
+    "tenantClubs": [
+      "sarawak-football-association"
+    ]
+  },
+  {
+    "id": "al-thumama-stadium",
+    "name": "Al Thumama Stadium",
+    "city": "Doha",
+    "countryCode": "QAT",
+    "capacity": 40000,
+    "tenantClubs": []
+  },
+  {
+    "id": "estadio-monumental-jose-fierro",
+    "name": "Estadio Monumental José Fierro",
+    "city": null,
+    "countryCode": "ARG",
+    "capacity": 40000,
+    "tenantClubs": [
+      "atletico-tucuman"
+    ]
+  },
+  {
+    "id": "accra-sports-stadium",
+    "name": "Accra Sports Stadium",
+    "city": null,
+    "countryCode": "GHA",
+    "capacity": 40000,
+    "tenantClubs": [
+      "2023-african-games",
+      "accra-great-olympics-f-c",
+      "accra-hearts-of-oak-sc",
+      "accra-lions-fc"
+    ]
+  },
+  {
+    "id": "hang-jebat-stadium",
+    "name": "Hang Jebat Stadium",
+    "city": null,
+    "countryCode": "MYS",
+    "capacity": 40000,
+    "tenantClubs": [
+      "melaka-united"
     ]
   },
   {
@@ -5440,102 +5388,23 @@
     ]
   },
   {
-    "id": "ahmed-zabana-stadium",
-    "name": "Ahmed Zabana Stadium",
+    "id": "civo-stadium",
+    "name": "Civo Stadium",
     "city": null,
-    "countryCode": "DZA",
+    "countryCode": "MWI",
     "capacity": 40000,
     "tenantClubs": [
-      "mouloudia-club-of-oran"
+      "civo-united"
     ]
   },
   {
-    "id": "barombong-stadium",
-    "name": "Barombong Stadium",
+    "id": "estadio-da-cidadela",
+    "name": "Estádio da Cidadela",
     "city": null,
-    "countryCode": "IDN",
+    "countryCode": "AGO",
     "capacity": 40000,
     "tenantClubs": [
-      "psm-makassar"
-    ]
-  },
-  {
-    "id": "sree-kanteerava-stadium",
-    "name": "Sree Kanteerava Stadium",
-    "city": "Bengaluru",
-    "countryCode": "IND",
-    "capacity": 40000,
-    "tenantClubs": [
-      "bengaluru-fc"
-    ]
-  },
-  {
-    "id": "riyadh-stadium",
-    "name": "Riyadh Stadium",
-    "city": null,
-    "countryCode": "SAU",
-    "capacity": 40000,
-    "tenantClubs": []
-  },
-  {
-    "id": "estadio-monumental-jose-fierro",
-    "name": "Estadio Monumental José Fierro",
-    "city": null,
-    "countryCode": "ARG",
-    "capacity": 40000,
-    "tenantClubs": [
-      "atletico-tucuman"
-    ]
-  },
-  {
-    "id": "hong-kong-stadium",
-    "name": "Hong Kong Stadium",
-    "city": "So Kon Po",
-    "countryCode": "CHN",
-    "capacity": 40000,
-    "tenantClubs": [
-      "eastern-fc",
-      "football-association-of-hong-kong-china",
-      "hong-kong-men-s-national-football-team",
-      "hong-kong-rugby-union"
-    ]
-  },
-  {
-    "id": "g-m-c-balayogi-athletic-stadium",
-    "name": "G. M. C. Balayogi Athletic Stadium",
-    "city": "Gachibowli",
-    "countryCode": "IND",
-    "capacity": 40000,
-    "tenantClubs": [
-      "fateh-hyderabad-f-c"
-    ]
-  },
-  {
-    "id": "almeidao",
-    "name": "Almeidão",
-    "city": "João Pessoa",
-    "countryCode": "BRA",
-    "capacity": 40000,
-    "tenantClubs": [
-      "botafogo-futebol-clube"
-    ]
-  },
-  {
-    "id": "estadio-monumental-universidad-andina-de-juliaca",
-    "name": "Estadio Monumental Universidad Andina de Juliaca",
-    "city": null,
-    "countryCode": "PER",
-    "capacity": 40000,
-    "tenantClubs": []
-  },
-  {
-    "id": "castelao-bra",
-    "name": "Castelão",
-    "city": null,
-    "countryCode": "BRA",
-    "capacity": 40000,
-    "tenantClubs": [
-      "maranhao-atletico-clube"
+      "s-l-benfica"
     ]
   },
   {
@@ -5547,153 +5416,13 @@
     "tenantClubs": []
   },
   {
-    "id": "al-markhiya-stadium",
-    "name": "Al-Markhiya Stadium",
-    "city": null,
-    "countryCode": "QAT",
+    "id": "barbourfields-stadium",
+    "name": "Barbourfields Stadium",
+    "city": "Bulawayo",
+    "countryCode": "ZWE",
     "capacity": 40000,
     "tenantClubs": [
-      "al-markhiya-sports-club"
-    ]
-  },
-  {
-    "id": "independence-stadium-gmb",
-    "name": "Independence Stadium",
-    "city": "Bakau",
-    "countryCode": "GMB",
-    "capacity": 40000,
-    "tenantClubs": [
-      "the-gambia-men-s-national-football-team"
-    ]
-  },
-  {
-    "id": "bogyoke-aung-san-stadium",
-    "name": "Bogyoke Aung San Stadium",
-    "city": null,
-    "countryCode": "MMR",
-    "capacity": 40000,
-    "tenantClubs": [
-      "yangon-united-f-c"
-    ]
-  },
-  {
-    "id": "peoples-football-stadium",
-    "name": "Peoples Football Stadium",
-    "city": "Karachi",
-    "countryCode": "PAK",
-    "capacity": 40000,
-    "tenantClubs": [
-      "hbl-f-c"
-    ]
-  },
-  {
-    "id": "civo-stadium",
-    "name": "Civo Stadium",
-    "city": null,
-    "countryCode": "MWI",
-    "capacity": 40000,
-    "tenantClubs": [
-      "civo-united"
-    ]
-  },
-  {
-    "id": "sunan-stadium",
-    "name": "Sunan Stadium",
-    "city": "Pyongyang",
-    "countryCode": "PRK",
-    "capacity": 40000,
-    "tenantClubs": []
-  },
-  {
-    "id": "orlando-stadium",
-    "name": "Orlando Stadium",
-    "city": null,
-    "countryCode": "ZAF",
-    "capacity": 40000,
-    "tenantClubs": [
-      "orlando-pirates-f-c"
-    ]
-  },
-  {
-    "id": "huizhou-olympic-stadium",
-    "name": "Huizhou Olympic Stadium",
-    "city": null,
-    "countryCode": "CHN",
-    "capacity": 40000,
-    "tenantClubs": []
-  },
-  {
-    "id": "vive-claro",
-    "name": "Vive Claro",
-    "city": null,
-    "countryCode": "COL",
-    "capacity": 40000,
-    "tenantClubs": []
-  },
-  {
-    "id": "panathinaikos-f-c-new-stadium",
-    "name": "Panathinaikos F.C. New Stadium",
-    "city": "Votanikos",
-    "countryCode": "GRC",
-    "capacity": 40000,
-    "tenantClubs": []
-  },
-  {
-    "id": "al-thumama-stadium",
-    "name": "Al Thumama Stadium",
-    "city": "Doha",
-    "countryCode": "QAT",
-    "capacity": 40000,
-    "tenantClubs": []
-  },
-  {
-    "id": "hang-jebat-stadium",
-    "name": "Hang Jebat Stadium",
-    "city": "Krubong",
-    "countryCode": "MYS",
-    "capacity": 40000,
-    "tenantClubs": [
-      "melaka-united"
-    ]
-  },
-  {
-    "id": "sultan-ibrahim-stadium",
-    "name": "Sultan Ibrahim Stadium",
-    "city": null,
-    "countryCode": "MYS",
-    "capacity": 40000,
-    "tenantClubs": [
-      "johor-darul-takzim-f-c"
-    ]
-  },
-  {
-    "id": "stade-de-la-paix",
-    "name": "Stade de la Paix",
-    "city": null,
-    "countryCode": "CIV",
-    "capacity": 40000,
-    "tenantClubs": [
-      "asc-bouake"
-    ]
-  },
-  {
-    "id": "ali-la-pointe-stadium",
-    "name": "Ali La Pointe Stadium",
-    "city": "Douéra",
-    "countryCode": "DZA",
-    "capacity": 40000,
-    "tenantClubs": [
-      "mc-algiers"
-    ]
-  },
-  {
-    "id": "gelora-joko-samudro-stadium",
-    "name": "Gelora Joko Samudro Stadium",
-    "city": null,
-    "countryCode": "IDN",
-    "capacity": 40000,
-    "tenantClubs": [
-      "persegres-gresik-united"
+      "highlanders-f-c"
     ]
   },
   {
@@ -5705,14 +5434,40 @@
     "tenantClubs": []
   },
   {
-    "id": "hauptstadion",
-    "name": "Hauptstadion",
+    "id": "riyadh-stadium",
+    "name": "Riyadh Stadium",
+    "city": null,
+    "countryCode": "SAU",
+    "capacity": 40000,
+    "tenantClubs": []
+  },
+  {
+    "id": "tuanku-abdul-rahman-stadium",
+    "name": "Tuanku Abdul Rahman Stadium",
+    "city": null,
+    "countryCode": "MYS",
+    "capacity": 40000,
+    "tenantClubs": [
+      "negeri-sembilan-fa"
+    ]
+  },
+  {
+    "id": "jahnstadion",
+    "name": "Jahnstadion",
     "city": null,
     "countryCode": "DEU",
     "capacity": 40000,
     "tenantClubs": [
-      "chio-aachen"
+      "q869716"
     ]
+  },
+  {
+    "id": "vive-claro",
+    "name": "Vive Claro",
+    "city": null,
+    "countryCode": "COL",
+    "capacity": 40000,
+    "tenantClubs": []
   },
   {
     "id": "penang-state-stadium",
@@ -5725,31 +5480,24 @@
     ]
   },
   {
-    "id": "stade-d-angondje",
-    "name": "Stade d'Angondjé",
+    "id": "ahmed-zabana-stadium",
+    "name": "Ahmed Zabana Stadium",
     "city": null,
-    "countryCode": "GAB",
-    "capacity": 40000,
-    "tenantClubs": []
-  },
-  {
-    "id": "tuanku-abdul-rahman-stadium",
-    "name": "Tuanku Abdul Rahman Stadium",
-    "city": "Paroi",
-    "countryCode": "MYS",
+    "countryCode": "DZA",
     "capacity": 40000,
     "tenantClubs": [
-      "negeri-sembilan-fa"
+      "mouloudia-club-of-oran"
     ]
   },
   {
-    "id": "franso-hariri-stadium",
-    "name": "Franso Hariri Stadium",
+    "id": "pratt-whitney-stadium",
+    "name": "Pratt & Whitney Stadium",
     "city": null,
-    "countryCode": "IRQ",
+    "countryCode": "USA",
     "capacity": 40000,
     "tenantClubs": [
-      "erbil-sc"
+      "uconn-huskies",
+      "uconn-huskies-football"
     ]
   },
   {
@@ -5763,23 +5511,69 @@
     ]
   },
   {
-    "id": "hyde-road",
-    "name": "Hyde Road",
+    "id": "independence-stadium-gmb",
+    "name": "Independence Stadium",
     "city": null,
-    "countryCode": "GBR",
+    "countryCode": "GMB",
     "capacity": 40000,
     "tenantClubs": [
-      "belle-vue-aces"
+      "the-gambia-men-s-national-football-team"
     ]
   },
   {
-    "id": "oita-stadium",
-    "name": "Ōita Stadium",
-    "city": "Ōita-shi",
-    "countryCode": "JPN",
+    "id": "stade-des-trois-tilleuls",
+    "name": "stade des Trois Tilleuls",
+    "city": null,
+    "countryCode": "BEL",
     "capacity": 40000,
     "tenantClubs": [
-      "oita-trinita"
+      "boitsfort-rugby-club",
+      "la-maison-de-l-escrime",
+      "q104537227",
+      "royal-racing-club-de-bruxelles"
+    ]
+  },
+  {
+    "id": "stade-velodrome-de-rocourt",
+    "name": "Stade Vélodrome de Rocourt",
+    "city": null,
+    "countryCode": "BEL",
+    "capacity": 40000,
+    "tenantClubs": [
+      "r-f-c-de-liege"
+    ]
+  },
+  {
+    "id": "al-markhiya-stadium",
+    "name": "Al-Markhiya Stadium",
+    "city": null,
+    "countryCode": "QAT",
+    "capacity": 40000,
+    "tenantClubs": [
+      "al-markhiya-sports-club"
+    ]
+  },
+  {
+    "id": "almeidao",
+    "name": "Almeidão",
+    "city": "João Pessoa",
+    "countryCode": "BRA",
+    "capacity": 40000,
+    "tenantClubs": [
+      "botafogo-futebol-clube"
+    ]
+  },
+  {
+    "id": "hong-kong-stadium",
+    "name": "Hong Kong Stadium",
+    "city": "Hong Kong",
+    "countryCode": "CHN",
+    "capacity": 40000,
+    "tenantClubs": [
+      "eastern-fc",
+      "football-association-of-hong-kong-china",
+      "hong-kong-men-s-national-football-team",
+      "hong-kong-rugby-union"
     ]
   },
   {
@@ -5795,10 +5589,182 @@
     ]
   },
   {
-    "id": "benghazi-international-stadium",
-    "name": "Benghazi International Stadium",
+    "id": "castelao-bra",
+    "name": "Castelão",
     "city": null,
-    "countryCode": "LBY",
+    "countryCode": "BRA",
+    "capacity": 40000,
+    "tenantClubs": [
+      "maranhao-atletico-clube"
+    ]
+  },
+  {
+    "id": "anoeta-stadium",
+    "name": "Anoeta Stadium",
+    "city": null,
+    "countryCode": "ESP",
+    "capacity": 40000,
+    "tenantClubs": [
+      "real-sociedad"
+    ]
+  },
+  {
+    "id": "stade-de-la-paix",
+    "name": "Stade de la Paix",
+    "city": null,
+    "countryCode": "CIV",
+    "capacity": 40000,
+    "tenantClubs": [
+      "asc-bouake"
+    ]
+  },
+  {
+    "id": "stade-d-angondje",
+    "name": "Stade d'Angondjé",
+    "city": null,
+    "countryCode": "GAB",
+    "capacity": 40000,
+    "tenantClubs": []
+  },
+  {
+    "id": "estadio-monumental-universidad-andina-de-juliaca",
+    "name": "Estadio Monumental Universidad Andina de Juliaca",
+    "city": null,
+    "countryCode": "PER",
+    "capacity": 40000,
+    "tenantClubs": []
+  },
+  {
+    "id": "hauptstadion",
+    "name": "Hauptstadion",
+    "city": null,
+    "countryCode": "DEU",
+    "capacity": 40000,
+    "tenantClubs": [
+      "chio-aachen"
+    ]
+  },
+  {
+    "id": "baba-yara-stadium",
+    "name": "Baba Yara Stadium",
+    "city": "Kumasi",
+    "countryCode": "GHA",
+    "capacity": 40000,
+    "tenantClubs": [
+      "asante-kotoko-f-c"
+    ]
+  },
+  {
+    "id": "peoples-football-stadium",
+    "name": "Peoples Football Stadium",
+    "city": "Karachi",
+    "countryCode": "PAK",
+    "capacity": 40000,
+    "tenantClubs": [
+      "hbl-f-c"
+    ]
+  },
+  {
+    "id": "franso-hariri-stadium",
+    "name": "Franso Hariri Stadium",
+    "city": null,
+    "countryCode": "IRQ",
+    "capacity": 40000,
+    "tenantClubs": [
+      "erbil-sc"
+    ]
+  },
+  {
+    "id": "kunming-tuodong-sports-center",
+    "name": "Kunming Tuodong Sports Center",
+    "city": null,
+    "countryCode": "CHN",
+    "capacity": 40000,
+    "tenantClubs": [
+      "yunnan-hongta-f-c"
+    ]
+  },
+  {
+    "id": "al-janoub-stadium",
+    "name": "Al Janoub Stadium",
+    "city": "Al Wakrah",
+    "countryCode": "QAT",
+    "capacity": 40000,
+    "tenantClubs": [
+      "al-wakrah-sports-club"
+    ]
+  },
+  {
+    "id": "huizhou-olympic-stadium",
+    "name": "Huizhou Olympic Stadium",
+    "city": null,
+    "countryCode": "CHN",
+    "capacity": 40000,
+    "tenantClubs": []
+  },
+  {
+    "id": "darul-makmur-stadium",
+    "name": "Darul Makmur Stadium",
+    "city": "Kuantan",
+    "countryCode": "MYS",
+    "capacity": 40000,
+    "tenantClubs": [
+      "sri-pahang-f-c"
+    ]
+  },
+  {
+    "id": "panathinaikos-f-c-new-stadium",
+    "name": "Panathinaikos F.C. New Stadium",
+    "city": null,
+    "countryCode": "GRC",
+    "capacity": 40000,
+    "tenantClubs": []
+  },
+  {
+    "id": "hyde-road",
+    "name": "Hyde Road",
+    "city": null,
+    "countryCode": "GBR",
+    "capacity": 40000,
+    "tenantClubs": [
+      "belle-vue-aces"
+    ]
+  },
+  {
+    "id": "gelora-joko-samudro-stadium",
+    "name": "Gelora Joko Samudro Stadium",
+    "city": null,
+    "countryCode": "IDN",
+    "capacity": 40000,
+    "tenantClubs": [
+      "persegres-gresik-united"
+    ]
+  },
+  {
+    "id": "barombong-stadium",
+    "name": "Barombong Stadium",
+    "city": null,
+    "countryCode": "IDN",
+    "capacity": 40000,
+    "tenantClubs": [
+      "psm-makassar"
+    ]
+  },
+  {
+    "id": "g-m-c-balayogi-athletic-stadium",
+    "name": "G. M. C. Balayogi Athletic Stadium",
+    "city": null,
+    "countryCode": "IND",
+    "capacity": 40000,
+    "tenantClubs": [
+      "fateh-hyderabad-f-c"
+    ]
+  },
+  {
+    "id": "sunan-stadium",
+    "name": "Sunan Stadium",
+    "city": "Pyongyang",
+    "countryCode": "PRK",
     "capacity": 40000,
     "tenantClubs": []
   },
@@ -5842,7 +5808,7 @@
   {
     "id": "suita-stadium",
     "name": "Suita Stadium",
-    "city": "Expo '70 Commemorative Park",
+    "city": "Suita",
     "countryCode": "JPN",
     "capacity": 39694,
     "tenantClubs": [
@@ -5882,7 +5848,7 @@
   {
     "id": "rogers-centre",
     "name": "Rogers Centre",
-    "city": "Downtown Toronto",
+    "city": null,
     "countryCode": "CAN",
     "capacity": 39150,
     "tenantClubs": [
@@ -5894,7 +5860,7 @@
   {
     "id": "fukuoka-dome",
     "name": "Fukuoka Dome",
-    "city": "Hawks Town",
+    "city": "Fukuoka",
     "countryCode": "JPN",
     "capacity": 38561,
     "tenantClubs": [
@@ -5935,7 +5901,7 @@
   {
     "id": "stade-bollaert-delelis",
     "name": "Stade Bollaert-Delelis",
-    "city": "Lens",
+    "city": null,
     "countryCode": "FRA",
     "capacity": 38223,
     "tenantClubs": [
@@ -5945,7 +5911,7 @@
   {
     "id": "parken-stadium",
     "name": "Parken Stadium",
-    "city": "Østerbro",
+    "city": null,
     "countryCode": "DNK",
     "capacity": 38065,
     "tenantClubs": [
@@ -5963,28 +5929,6 @@
     ]
   },
   {
-    "id": "estadio-hernando-siles",
-    "name": "Estadio Hernando Siles",
-    "city": null,
-    "countryCode": "BOL",
-    "capacity": 38000,
-    "tenantClubs": [
-      "club-always-ready",
-      "club-bolivar",
-      "the-strongest"
-    ]
-  },
-  {
-    "id": "gelora-bandung-lautan-api-stadium",
-    "name": "Gelora Bandung Lautan Api Stadium",
-    "city": null,
-    "countryCode": "IDN",
-    "capacity": 38000,
-    "tenantClubs": [
-      "persib-bandung"
-    ]
-  },
-  {
     "id": "eduardo-gallardon-stadium",
     "name": "Eduardo Gallardón Stadium",
     "city": null,
@@ -5992,16 +5936,6 @@
     "capacity": 38000,
     "tenantClubs": [
       "club-atletico-los-andes"
-    ]
-  },
-  {
-    "id": "king-abdulaziz-sports-city",
-    "name": "King Abdulaziz Sports City",
-    "city": null,
-    "countryCode": "SAU",
-    "capacity": 38000,
-    "tenantClubs": [
-      "al-wehda-fc"
     ]
   },
   {
@@ -6015,9 +5949,41 @@
     ]
   },
   {
+    "id": "king-abdulaziz-sports-city",
+    "name": "King Abdulaziz Sports City",
+    "city": null,
+    "countryCode": "SAU",
+    "capacity": 38000,
+    "tenantClubs": [
+      "al-wehda-fc"
+    ]
+  },
+  {
+    "id": "gelora-bandung-lautan-api-stadium",
+    "name": "Gelora Bandung Lautan Api Stadium",
+    "city": null,
+    "countryCode": "IDN",
+    "capacity": 38000,
+    "tenantClubs": [
+      "persib-bandung"
+    ]
+  },
+  {
+    "id": "estadio-hernando-siles",
+    "name": "Estadio Hernando Siles",
+    "city": null,
+    "countryCode": "BOL",
+    "capacity": 38000,
+    "tenantClubs": [
+      "club-always-ready",
+      "club-bolivar",
+      "the-strongest"
+    ]
+  },
+  {
     "id": "meiji-jingu-stadium",
     "name": "Meiji Jingu Stadium",
-    "city": "Meiji Shrine Outer Garden",
+    "city": "Tokyo",
     "countryCode": "JPN",
     "capacity": 37933,
     "tenantClubs": [
@@ -6037,7 +6003,7 @@
   {
     "id": "pnc-park",
     "name": "PNC Park",
-    "city": "North Shore",
+    "city": "Pittsburgh",
     "countryCode": "USA",
     "capacity": 37898,
     "tenantClubs": [
@@ -6087,7 +6053,7 @@
   {
     "id": "estadio-nacional",
     "name": "Estádio Nacional",
-    "city": "Oeiras",
+    "city": null,
     "countryCode": "PRT",
     "capacity": 37593,
     "tenantClubs": [
@@ -6097,7 +6063,7 @@
   {
     "id": "johannesburg-stadium",
     "name": "Johannesburg Stadium",
-    "city": "Doornfontein",
+    "city": "City of Johannesburg Metropolitan Municipality",
     "countryCode": "ZAF",
     "capacity": 37500,
     "tenantClubs": [
@@ -6118,7 +6084,7 @@
   {
     "id": "estadio-jose-antonio-anzoategui",
     "name": "Estadio José Antonio Anzoátegui",
-    "city": "Q391221",
+    "city": null,
     "countryCode": "VEN",
     "capacity": 37485,
     "tenantClubs": [
@@ -6160,17 +6126,6 @@
     ]
   },
   {
-    "id": "stadion-hoheluft",
-    "name": "Stadion Hoheluft",
-    "city": "Eppendorf",
-    "countryCode": "DEU",
-    "capacity": 37000,
-    "tenantClubs": [
-      "hamburg-sea-devils",
-      "sc-victoria-hamburg"
-    ]
-  },
-  {
     "id": "stoll-field-mclean-stadium",
     "name": "Stoll Field/McLean Stadium",
     "city": null,
@@ -6178,6 +6133,17 @@
     "capacity": 37000,
     "tenantClubs": [
       "kentucky-wildcats-football"
+    ]
+  },
+  {
+    "id": "stadion-hoheluft",
+    "name": "Stadion Hoheluft",
+    "city": "Hamburg",
+    "countryCode": "DEU",
+    "capacity": 37000,
+    "tenantClubs": [
+      "hamburg-sea-devils",
+      "sc-victoria-hamburg"
     ]
   },
   {
@@ -6205,7 +6171,7 @@
   {
     "id": "sam-boyd-stadium",
     "name": "Sam Boyd Stadium",
-    "city": "Whitney",
+    "city": null,
     "countryCode": "USA",
     "capacity": 36800,
     "tenantClubs": [
@@ -6255,7 +6221,7 @@
   {
     "id": "kyocera-dome-osaka",
     "name": "Kyocera Dome Osaka",
-    "city": "Nishi-ku",
+    "city": "Osaka",
     "countryCode": "JPN",
     "capacity": 36477,
     "tenantClubs": [
@@ -6286,7 +6252,7 @@
   {
     "id": "teda-football-stadium",
     "name": "TEDA Football Stadium",
-    "city": "Tianjin Economic-Technological Development Area",
+    "city": "Tianjin",
     "countryCode": "CHN",
     "capacity": 36390,
     "tenantClubs": [
@@ -6347,16 +6313,6 @@
     ]
   },
   {
-    "id": "m-m-roberts-stadium",
-    "name": "M. M. Roberts Stadium",
-    "city": null,
-    "countryCode": "USA",
-    "capacity": 36000,
-    "tenantClubs": [
-      "southern-miss-golden-eagles"
-    ]
-  },
-  {
     "id": "estadio-do-cafe",
     "name": "Estádio do Café",
     "city": null,
@@ -6364,18 +6320,6 @@
     "capacity": 36000,
     "tenantClubs": [
       "londrina-e-c"
-    ]
-  },
-  {
-    "id": "national-stadium-dhaka",
-    "name": "National Stadium, Dhaka",
-    "city": "Dhaka",
-    "countryCode": "BGD",
-    "capacity": 36000,
-    "tenantClubs": [
-      "bangladesh-men-s-national-football-team",
-      "bangladesh-women-s-national-football-team",
-      "bangladesh-women-s-national-under-20-football-team"
     ]
   },
   {
@@ -6397,6 +6341,18 @@
     "tenantClubs": []
   },
   {
+    "id": "national-stadium-dhaka",
+    "name": "National Stadium, Dhaka",
+    "city": "Dhaka",
+    "countryCode": "BGD",
+    "capacity": 36000,
+    "tenantClubs": [
+      "bangladesh-men-s-national-football-team",
+      "bangladesh-women-s-national-football-team",
+      "bangladesh-women-s-national-under-20-football-team"
+    ]
+  },
+  {
     "id": "green-island-stadium",
     "name": "Green Island Stadium",
     "city": null,
@@ -6405,9 +6361,19 @@
     "tenantClubs": []
   },
   {
+    "id": "m-m-roberts-stadium",
+    "name": "M. M. Roberts Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 36000,
+    "tenantClubs": [
+      "southern-miss-golden-eagles"
+    ]
+  },
+  {
     "id": "morelos-stadium",
     "name": "Morelos Stadium",
-    "city": "Morelia",
+    "city": null,
     "countryCode": "MEX",
     "capacity": 35869,
     "tenantClubs": [
@@ -6417,7 +6383,7 @@
   {
     "id": "estadio-metropolitano-de-madrid",
     "name": "Estadio Metropolitano de Madrid",
-    "city": "University City of Madrid",
+    "city": "Madrid",
     "countryCode": "ESP",
     "capacity": 35800,
     "tenantClubs": [
@@ -6451,7 +6417,7 @@
   {
     "id": "barradao",
     "name": "Barradão",
-    "city": "Q20053126",
+    "city": "Salvador",
     "countryCode": "BRA",
     "capacity": 35632,
     "tenantClubs": [
@@ -6510,7 +6476,7 @@
   {
     "id": "stadion-am-gesundbrunnen",
     "name": "Stadion am Gesundbrunnen",
-    "city": "Gesundbrunnen",
+    "city": "Berlin",
     "countryCode": "DEU",
     "capacity": 35239,
     "tenantClubs": [
@@ -6576,145 +6542,23 @@
     ]
   },
   {
-    "id": "vysocina-arena",
-    "name": "Vysočina Arena",
-    "city": "Nové Město na Moravě",
-    "countryCode": "CZE",
+    "id": "nuevo-francisco-urbano-stadium",
+    "name": "Nuevo Francisco Urbano Stadium",
+    "city": "Morón",
+    "countryCode": "ARG",
     "capacity": 35000,
-    "tenantClubs": []
+    "tenantClubs": [
+      "club-deportivo-moron",
+      "deportivo-moron-women"
+    ]
   },
   {
-    "id": "manahan-stadium",
-    "name": "Manahan Stadium",
+    "id": "gelora-delta-stadium",
+    "name": "Gelora Delta Stadium",
     "city": null,
     "countryCode": "IDN",
     "capacity": 35000,
-    "tenantClubs": [
-      "persis-solo"
-    ]
-  },
-  {
-    "id": "birsa-munda-athletics-stadium",
-    "name": "Birsa Munda Athletics Stadium",
-    "city": "Ranchi",
-    "countryCode": "IND",
-    "capacity": 35000,
-    "tenantClubs": [
-      "2011-national-games-of-india"
-    ]
-  },
-  {
-    "id": "pinheirao",
-    "name": "Pinheirão",
-    "city": null,
-    "countryCode": "BRA",
-    "capacity": 35000,
     "tenantClubs": []
-  },
-  {
-    "id": "osman-ahmed-osman-stadium",
-    "name": "Osman Ahmed Osman Stadium",
-    "city": null,
-    "countryCode": "EGY",
-    "capacity": 35000,
-    "tenantClubs": [
-      "al-mokawloon-al-arab-sc"
-    ]
-  },
-  {
-    "id": "estadio-george-capwell",
-    "name": "Estadio George Capwell",
-    "city": null,
-    "countryCode": "ECU",
-    "capacity": 35000,
-    "tenantClubs": [
-      "club-sport-emelec"
-    ]
-  },
-  {
-    "id": "prince-mohamed-bin-fahd-stadium",
-    "name": "Prince Mohamed bin Fahd Stadium",
-    "city": null,
-    "countryCode": "SAU",
-    "capacity": 35000,
-    "tenantClubs": [
-      "al-qadsiah-fc"
-    ]
-  },
-  {
-    "id": "ccm-kirumba-stadium",
-    "name": "CCM Kirumba Stadium",
-    "city": null,
-    "countryCode": "TZA",
-    "capacity": 35000,
-    "tenantClubs": []
-  },
-  {
-    "id": "stade-frederic-kibassa-maliba",
-    "name": "Stade Frederic Kibassa Maliba",
-    "city": null,
-    "countryCode": "COD",
-    "capacity": 35000,
-    "tenantClubs": [
-      "tp-mazembe"
-    ]
-  },
-  {
-    "id": "ryan-field",
-    "name": "Ryan Field",
-    "city": null,
-    "countryCode": "USA",
-    "capacity": 35000,
-    "tenantClubs": [
-      "northwestern-wildcats-football"
-    ]
-  },
-  {
-    "id": "amigao",
-    "name": "Amigão",
-    "city": "Campina Grande",
-    "countryCode": "BRA",
-    "capacity": 35000,
-    "tenantClubs": [
-      "campinense-clube"
-    ]
-  },
-  {
-    "id": "ombaka-national-stadium",
-    "name": "Ombaka National Stadium",
-    "city": null,
-    "countryCode": "AGO",
-    "capacity": 35000,
-    "tenantClubs": []
-  },
-  {
-    "id": "kobe-sports-park-baseball-stadium",
-    "name": "Kobe Sports Park Baseball Stadium",
-    "city": null,
-    "countryCode": "JPN",
-    "capacity": 35000,
-    "tenantClubs": [
-      "orix-buffaloes"
-    ]
-  },
-  {
-    "id": "sariwon-youth-stadium",
-    "name": "Sariwon Youth Stadium",
-    "city": "Sariwon",
-    "countryCode": "PRK",
-    "capacity": 35000,
-    "tenantClubs": []
-  },
-  {
-    "id": "estadio-felix-capriles",
-    "name": "Estadio Félix Capriles",
-    "city": "Q42797420",
-    "countryCode": "BOL",
-    "capacity": 35000,
-    "tenantClubs": [
-      "c-d-jorge-wilstermann",
-      "club-aurora"
-    ]
   },
   {
     "id": "larbi-zaouli-stadium",
@@ -6727,137 +6571,66 @@
     ]
   },
   {
-    "id": "victoria-stadium",
-    "name": "Victoria Stadium",
-    "city": null,
-    "countryCode": "MEX",
-    "capacity": 35000,
-    "tenantClubs": [
-      "club-necaxa"
-    ]
-  },
-  {
-    "id": "nuevo-francisco-urbano-stadium",
-    "name": "Nuevo Francisco Urbano Stadium",
-    "city": "Morón",
-    "countryCode": "ARG",
-    "capacity": 35000,
-    "tenantClubs": [
-      "club-deportivo-moron",
-      "deportivo-moron-women"
-    ]
-  },
-  {
-    "id": "honor-stadium",
-    "name": "Honor Stadium",
-    "city": "Oujda",
-    "countryCode": "MAR",
-    "capacity": 35000,
-    "tenantClubs": [
-      "mc-oujda"
-    ]
-  },
-  {
-    "id": "independence-park",
-    "name": "Independence Park",
-    "city": null,
-    "countryCode": "JAM",
-    "capacity": 35000,
-    "tenantClubs": [
-      "jamaica-men-s-national-association-football-team"
-    ]
-  },
-  {
-    "id": "barthelemy-boganda-stadium",
-    "name": "Barthélemy Boganda Stadium",
-    "city": null,
-    "countryCode": "CAF",
-    "capacity": 35000,
-    "tenantClubs": [
-      "central-african-republic-men-s-national-football-team"
-    ]
-  },
-  {
-    "id": "muhammadu-dikko-stadium",
-    "name": "Muhammadu Dikko Stadium",
-    "city": "Katsina",
-    "countryCode": "NGA",
-    "capacity": 35000,
-    "tenantClubs": []
-  },
-  {
-    "id": "gelora-delta-stadium",
-    "name": "Gelora Delta Stadium",
+    "id": "maguwoharjo-stadium",
+    "name": "Maguwoharjo Stadium",
     "city": null,
     "countryCode": "IDN",
     "capacity": 35000,
-    "tenantClubs": []
-  },
-  {
-    "id": "estadio-jesus-bermudez",
-    "name": "Estadio Jesús Bermúdez",
-    "city": null,
-    "countryCode": "BOL",
-    "capacity": 35000,
     "tenantClubs": [
-      "cd-san-jose"
+      "pss-sleman"
     ]
   },
   {
-    "id": "thrissur-municipal-corporation-stadium",
-    "name": "Thrissur Municipal Corporation Stadium",
-    "city": "Thrissur",
-    "countryCode": "IND",
+    "id": "hamhung-stadium",
+    "name": "Hamhung Stadium",
+    "city": null,
+    "countryCode": "PRK",
     "capacity": 35000,
     "tenantClubs": []
   },
   {
-    "id": "addis-ababa-stadium",
-    "name": "Addis Ababa Stadium",
+    "id": "serejao",
+    "name": "Serejão",
     "city": null,
-    "countryCode": "ETH",
+    "countryCode": "BRA",
     "capacity": 35000,
     "tenantClubs": [
-      "ethiopia-men-s-national-football-team"
+      "taguatinga-esporte-clube"
     ]
   },
   {
-    "id": "jahnstadion-deu",
-    "name": "Jahnstadion",
+    "id": "kaesong-youth-stadium",
+    "name": "Kaesong Youth Stadium",
     "city": null,
-    "countryCode": "DEU",
+    "countryCode": "PRK",
     "capacity": 35000,
     "tenantClubs": []
   },
   {
-    "id": "stade-de-l-amitie",
-    "name": "Stade de l'Amitié",
-    "city": null,
-    "countryCode": "BEN",
+    "id": "pakhtakor-markaziy-stadium",
+    "name": "Pakhtakor Markaziy Stadium",
+    "city": "Tashkent",
+    "countryCode": "UZB",
     "capacity": 35000,
     "tenantClubs": [
-      "benin-men-s-national-football-team"
+      "pakhtakor-tashkent-fk"
     ]
   },
   {
-    "id": "stadion-poljud",
-    "name": "Stadion Poljud",
-    "city": "Spinut",
-    "countryCode": "HRV",
+    "id": "sariwon-youth-stadium",
+    "name": "Sariwon Youth Stadium",
+    "city": "Sariwon",
+    "countryCode": "PRK",
     "capacity": 35000,
-    "tenantClubs": [
-      "hnk-hajduk-split"
-    ]
+    "tenantClubs": []
   },
   {
-    "id": "emam-reeza-stadium",
-    "name": "emam reeza  Stadium",
+    "id": "yingkou-olympic-sports-centre-stadium",
+    "name": "Yingkou Olympic Sports Centre Stadium",
     "city": null,
-    "countryCode": "IRN",
+    "countryCode": "CHN",
     "capacity": 35000,
-    "tenantClubs": [
-      "aboomoslem-f-c"
-    ]
+    "tenantClubs": []
   },
   {
     "id": "estadio-manuel-rivera-sanchez",
@@ -6871,28 +6644,137 @@
     ]
   },
   {
-    "id": "kaesong-youth-stadium",
-    "name": "Kaesong Youth Stadium",
+    "id": "likas-stadium",
+    "name": "Likas Stadium",
     "city": null,
-    "countryCode": "PRK",
+    "countryCode": "MYS",
+    "capacity": 35000,
+    "tenantClubs": [
+      "sabah-f-c"
+    ]
+  },
+  {
+    "id": "thrissur-municipal-corporation-stadium",
+    "name": "Thrissur Municipal Corporation Stadium",
+    "city": "Thrissur",
+    "countryCode": "IND",
     "capacity": 35000,
     "tenantClubs": []
   },
   {
-    "id": "gajayana-stadium",
-    "name": "Gajayana Stadium",
+    "id": "ryan-field",
+    "name": "Ryan Field",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 35000,
+    "tenantClubs": [
+      "northwestern-wildcats-football"
+    ]
+  },
+  {
+    "id": "addis-ababa-stadium",
+    "name": "Addis Ababa Stadium",
+    "city": null,
+    "countryCode": "ETH",
+    "capacity": 35000,
+    "tenantClubs": [
+      "ethiopia-men-s-national-football-team"
+    ]
+  },
+  {
+    "id": "stade-frederic-kibassa-maliba",
+    "name": "Stade Frederic Kibassa Maliba",
+    "city": null,
+    "countryCode": "COD",
+    "capacity": 35000,
+    "tenantClubs": [
+      "tp-mazembe"
+    ]
+  },
+  {
+    "id": "yunak-stadium",
+    "name": "Yunak Stadium",
+    "city": "Sofia",
+    "countryCode": "BGR",
+    "capacity": 35000,
+    "tenantClubs": [
+      "bulgaria-men-s-national-football-team"
+    ]
+  },
+  {
+    "id": "emam-reeza-stadium",
+    "name": "emam reeza  Stadium",
+    "city": null,
+    "countryCode": "IRN",
+    "capacity": 35000,
+    "tenantClubs": [
+      "aboomoslem-f-c"
+    ]
+  },
+  {
+    "id": "birsa-munda-athletics-stadium",
+    "name": "Birsa Munda Athletics Stadium",
+    "city": "Ranchi",
+    "countryCode": "IND",
+    "capacity": 35000,
+    "tenantClubs": [
+      "2011-national-games-of-india"
+    ]
+  },
+  {
+    "id": "amakhosi-stadium",
+    "name": "Amakhosi Stadium",
+    "city": null,
+    "countryCode": "ZAF",
+    "capacity": 35000,
+    "tenantClubs": []
+  },
+  {
+    "id": "honor-stadium",
+    "name": "Honor Stadium",
+    "city": "Oujda",
+    "countryCode": "MAR",
+    "capacity": 35000,
+    "tenantClubs": [
+      "mc-oujda"
+    ]
+  },
+  {
+    "id": "stade-general-seyni-kountche",
+    "name": "Stade Général Seyni Kountché",
+    "city": null,
+    "countryCode": "NER",
+    "capacity": 35000,
+    "tenantClubs": [
+      "niger-men-s-national-football-team",
+      "us-gn"
+    ]
+  },
+  {
+    "id": "mko-abiola-stadium",
+    "name": "MKO Abiola Stadium",
+    "city": "Abeokuta",
+    "countryCode": "NGA",
+    "capacity": 35000,
+    "tenantClubs": [
+      "gateway-united-f-c"
+    ]
+  },
+  {
+    "id": "sultan-agung-stadium",
+    "name": "Sultan Agung Stadium",
     "city": null,
     "countryCode": "IDN",
     "capacity": 35000,
     "tenantClubs": [
-      "persema-malang"
+      "persiba-bantul"
     ]
   },
   {
-    "id": "estadio-nido-del-colibri",
-    "name": "Estadio Nido del Colibri",
+    "id": "r-premadasa-stadium",
+    "name": "R. Premadasa Stadium",
     "city": null,
-    "countryCode": "MEX",
+    "countryCode": "LKA",
     "capacity": 35000,
     "tenantClubs": []
   },
@@ -6907,23 +6789,71 @@
     ]
   },
   {
-    "id": "arena-barueri",
-    "name": "Arena Barueri",
-    "city": "Barueri",
-    "countryCode": "BRA",
+    "id": "stade-de-l-amitie",
+    "name": "Stade de l'Amitié",
+    "city": null,
+    "countryCode": "BEN",
     "capacity": 35000,
     "tenantClubs": [
-      "gremio-barueri-futebol"
+      "benin-men-s-national-football-team"
     ]
   },
   {
-    "id": "maguwoharjo-stadium",
-    "name": "Maguwoharjo Stadium",
-    "city": "Sleman",
-    "countryCode": "IDN",
+    "id": "barthelemy-boganda-stadium",
+    "name": "Barthélemy Boganda Stadium",
+    "city": null,
+    "countryCode": "CAF",
     "capacity": 35000,
     "tenantClubs": [
-      "pss-sleman"
+      "central-african-republic-men-s-national-football-team"
+    ]
+  },
+  {
+    "id": "suzhou-sports-center",
+    "name": "Suzhou Sports Center",
+    "city": null,
+    "countryCode": "CHN",
+    "capacity": 35000,
+    "tenantClubs": []
+  },
+  {
+    "id": "stadion-poljud",
+    "name": "Stadion Poljud",
+    "city": "Split",
+    "countryCode": "HRV",
+    "capacity": 35000,
+    "tenantClubs": [
+      "hnk-hajduk-split"
+    ]
+  },
+  {
+    "id": "tinsulanonda-stadium",
+    "name": "Tinsulanonda Stadium",
+    "city": null,
+    "countryCode": "THA",
+    "capacity": 35000,
+    "tenantClubs": [
+      "football-at-the-1998-asian-games"
+    ]
+  },
+  {
+    "id": "zhuhai-sports-center",
+    "name": "Zhuhai Sports Center",
+    "city": null,
+    "countryCode": "CHN",
+    "capacity": 35000,
+    "tenantClubs": [
+      "zhuhai-qin-ao-f-c"
+    ]
+  },
+  {
+    "id": "prince-mohamed-bin-fahd-stadium",
+    "name": "Prince Mohamed bin Fahd Stadium",
+    "city": null,
+    "countryCode": "SAU",
+    "capacity": 35000,
+    "tenantClubs": [
+      "al-qadsiah-fc"
     ]
   },
   {
@@ -6937,79 +6867,73 @@
     ]
   },
   {
-    "id": "al-shaab-stadium",
-    "name": "Al-Shaab Stadium",
-    "city": "Baghdad",
-    "countryCode": "IRQ",
+    "id": "vysocina-arena",
+    "name": "Vysočina Arena",
+    "city": "Nové Město na Moravě",
+    "countryCode": "CZE",
     "capacity": 35000,
-    "tenantClubs": [
-      "iraq-men-s-national-football-team"
-    ]
+    "tenantClubs": []
   },
   {
-    "id": "yingkou-olympic-sports-centre-stadium",
-    "name": "Yingkou Olympic Sports Centre Stadium",
+    "id": "pinheirao",
+    "name": "Pinheirão",
+    "city": null,
+    "countryCode": "BRA",
+    "capacity": 35000,
+    "tenantClubs": []
+  },
+  {
+    "id": "ccm-kirumba-stadium",
+    "name": "CCM Kirumba Stadium",
+    "city": null,
+    "countryCode": "TZA",
+    "capacity": 35000,
+    "tenantClubs": []
+  },
+  {
+    "id": "muhammadu-dikko-stadium",
+    "name": "Muhammadu Dikko Stadium",
+    "city": "Katsina",
+    "countryCode": "NGA",
+    "capacity": 35000,
+    "tenantClubs": []
+  },
+  {
+    "id": "jiaxing-stadium",
+    "name": "Jiaxing Stadium",
     "city": null,
     "countryCode": "CHN",
     "capacity": 35000,
     "tenantClubs": []
   },
   {
-    "id": "zhuhai-sports-center",
-    "name": "Zhuhai Sports Center",
-    "city": null,
-    "countryCode": "CHN",
+    "id": "amigao",
+    "name": "Amigão",
+    "city": "Campina Grande",
+    "countryCode": "BRA",
     "capacity": 35000,
     "tenantClubs": [
-      "zhuhai-qin-ao-f-c"
+      "campinense-clube"
     ]
   },
   {
-    "id": "hamhung-stadium",
-    "name": "Hamhung Stadium",
+    "id": "gajayana-stadium",
+    "name": "Gajayana Stadium",
     "city": null,
-    "countryCode": "PRK",
-    "capacity": 35000,
-    "tenantClubs": []
-  },
-  {
-    "id": "pakhtakor-markaziy-stadium",
-    "name": "Pakhtakor Markaziy Stadium",
-    "city": "Shaykhontohur",
-    "countryCode": "UZB",
-    "capacity": 35000,
-    "tenantClubs": [
-      "pakhtakor-tashkent-fk"
-    ]
-  },
-  {
-    "id": "sultan-agung-stadium",
-    "name": "Sultan Agung Stadium",
-    "city": "Bantul",
     "countryCode": "IDN",
     "capacity": 35000,
     "tenantClubs": [
-      "persiba-bantul"
+      "persema-malang"
     ]
   },
   {
-    "id": "rks-skra-stadium",
-    "name": "RKS Skra Stadium",
-    "city": "Warsaw",
-    "countryCode": "POL",
+    "id": "kobe-sports-park-baseball-stadium",
+    "name": "Kobe Sports Park Baseball Stadium",
+    "city": null,
+    "countryCode": "JPN",
     "capacity": 35000,
     "tenantClubs": [
-      "skra-warszawa"
-    ]
-  },
-  {
-    "id": "samuel-kanyon-doe-sports-complex",
-    "name": "Samuel Kanyon Doe Sports Complex",
-    "city": "Paynesville",
-    "countryCode": "LBR",
-    "capacity": 35000,
-    "tenantClubs": [
-      "liberia-men-s-national-football-team"
+      "orix-buffaloes"
     ]
   },
   {
@@ -7026,67 +6950,98 @@
     ]
   },
   {
-    "id": "yunak-stadium",
-    "name": "Yunak Stadium",
-    "city": "Sofia",
-    "countryCode": "BGR",
-    "capacity": 35000,
-    "tenantClubs": [
-      "bulgaria-men-s-national-football-team"
-    ]
-  },
-  {
-    "id": "stade-general-seyni-kountche",
-    "name": "Stade Général Seyni Kountché",
+    "id": "estadio-jesus-bermudez",
+    "name": "Estadio Jesús Bermúdez",
     "city": null,
-    "countryCode": "NER",
+    "countryCode": "BOL",
     "capacity": 35000,
     "tenantClubs": [
-      "niger-men-s-national-football-team",
-      "us-gn"
+      "cd-san-jose"
     ]
   },
   {
-    "id": "chandrasekharan-nair-stadium",
-    "name": "Chandrasekharan Nair Stadium",
-    "city": "Thiruvananthapuram",
-    "countryCode": "IND",
+    "id": "manahan-stadium",
+    "name": "Manahan Stadium",
+    "city": null,
+    "countryCode": "IDN",
+    "capacity": 35000,
+    "tenantClubs": [
+      "persis-solo"
+    ]
+  },
+  {
+    "id": "rks-skra-stadium",
+    "name": "RKS Skra Stadium",
+    "city": "Warsaw",
+    "countryCode": "POL",
+    "capacity": 35000,
+    "tenantClubs": [
+      "skra-warszawa"
+    ]
+  },
+  {
+    "id": "estadio-nido-del-colibri",
+    "name": "Estadio Nido del Colibri",
+    "city": null,
+    "countryCode": "MEX",
     "capacity": 35000,
     "tenantClubs": []
   },
   {
-    "id": "jiaxing-stadium",
-    "name": "Jiaxing Stadium",
-    "city": null,
-    "countryCode": "CHN",
-    "capacity": 35000,
-    "tenantClubs": []
-  },
-  {
-    "id": "serejao",
-    "name": "Serejão",
-    "city": null,
+    "id": "arena-barueri",
+    "name": "Arena Barueri",
+    "city": "Barueri",
     "countryCode": "BRA",
     "capacity": 35000,
     "tenantClubs": [
-      "taguatinga-esporte-clube"
+      "gremio-barueri-futebol"
     ]
   },
   {
-    "id": "suzhou-sports-center",
-    "name": "Suzhou Sports Center",
+    "id": "estadio-george-capwell",
+    "name": "Estadio George Capwell",
     "city": null,
-    "countryCode": "CHN",
+    "countryCode": "ECU",
+    "capacity": 35000,
+    "tenantClubs": [
+      "club-sport-emelec"
+    ]
+  },
+  {
+    "id": "ombaka-national-stadium",
+    "name": "Ombaka National Stadium",
+    "city": null,
+    "countryCode": "AGO",
     "capacity": 35000,
     "tenantClubs": []
   },
   {
-    "id": "amakhosi-stadium",
-    "name": "Amakhosi Stadium",
-    "city": "Krugersdorp",
-    "countryCode": "ZAF",
+    "id": "jahnstadion-deu",
+    "name": "Jahnstadion",
+    "city": null,
+    "countryCode": "DEU",
     "capacity": 35000,
     "tenantClubs": []
+  },
+  {
+    "id": "al-shaab-stadium",
+    "name": "Al-Shaab Stadium",
+    "city": "Baghdad",
+    "countryCode": "IRQ",
+    "capacity": 35000,
+    "tenantClubs": [
+      "iraq-men-s-national-football-team"
+    ]
+  },
+  {
+    "id": "samuel-kanyon-doe-sports-complex",
+    "name": "Samuel Kanyon Doe Sports Complex",
+    "city": null,
+    "countryCode": "LBR",
+    "capacity": 35000,
+    "tenantClubs": [
+      "liberia-men-s-national-football-team"
+    ]
   },
   {
     "id": "charles-mopeli-stadium",
@@ -7099,40 +7054,51 @@
     ]
   },
   {
-    "id": "likas-stadium",
-    "name": "Likas Stadium",
+    "id": "independence-park",
+    "name": "Independence Park",
     "city": null,
-    "countryCode": "MYS",
+    "countryCode": "JAM",
     "capacity": 35000,
     "tenantClubs": [
-      "sabah-f-c"
+      "jamaica-men-s-national-association-football-team"
     ]
   },
   {
-    "id": "tinsulanonda-stadium",
-    "name": "Tinsulanonda Stadium",
-    "city": "Mueang Songkhla",
-    "countryCode": "THA",
+    "id": "estadio-felix-capriles",
+    "name": "Estadio Félix Capriles",
+    "city": "Cochabamba",
+    "countryCode": "BOL",
     "capacity": 35000,
     "tenantClubs": [
-      "football-at-the-1998-asian-games"
+      "c-d-jorge-wilstermann",
+      "club-aurora"
     ]
   },
   {
-    "id": "mko-abiola-stadium",
-    "name": "MKO Abiola Stadium",
-    "city": "Abeokuta",
-    "countryCode": "NGA",
+    "id": "osman-ahmed-osman-stadium",
+    "name": "Osman Ahmed Osman Stadium",
+    "city": null,
+    "countryCode": "EGY",
     "capacity": 35000,
     "tenantClubs": [
-      "gateway-united-f-c"
+      "al-mokawloon-al-arab-sc"
     ]
   },
   {
-    "id": "r-premadasa-stadium",
-    "name": "R. Premadasa Stadium",
-    "city": "Maligawatta",
-    "countryCode": "LKA",
+    "id": "victoria-stadium",
+    "name": "Victoria Stadium",
+    "city": null,
+    "countryCode": "MEX",
+    "capacity": 35000,
+    "tenantClubs": [
+      "club-necaxa"
+    ]
+  },
+  {
+    "id": "chandrasekharan-nair-stadium",
+    "name": "Chandrasekharan Nair Stadium",
+    "city": "Thiruvananthapuram",
+    "countryCode": "IND",
     "capacity": 35000,
     "tenantClubs": []
   },
@@ -7169,7 +7135,7 @@
   {
     "id": "julio-cesar-villagra-stadium",
     "name": "Julio Cesar Villagra Stadium",
-    "city": "Barrio Alberdi Córdoba",
+    "city": "Córdoba",
     "countryCode": "ARG",
     "capacity": 34830,
     "tenantClubs": [
@@ -7198,6 +7164,16 @@
     ]
   },
   {
+    "id": "grotenburg-stadion",
+    "name": "Grotenburg-Stadion",
+    "city": null,
+    "countryCode": "DEU",
+    "capacity": 34500,
+    "tenantClubs": [
+      "kfc-uerdingen-05"
+    ]
+  },
+  {
     "id": "estadio-garcilaso",
     "name": "Estadio Garcilaso",
     "city": "Cusco",
@@ -7206,16 +7182,6 @@
     "tenantClubs": [
       "cienciano",
       "club-deportivo-garcilaso"
-    ]
-  },
-  {
-    "id": "grotenburg-stadion",
-    "name": "Grotenburg-Stadion",
-    "city": null,
-    "countryCode": "DEU",
-    "capacity": 34500,
-    "tenantClubs": [
-      "kfc-uerdingen-05"
     ]
   },
   {
@@ -7229,7 +7195,7 @@
   {
     "id": "chornomorets-stadium",
     "name": "Chornomorets Stadium",
-    "city": "Shevchenko Park",
+    "city": "Odesa",
     "countryCode": "UKR",
     "capacity": 34164,
     "tenantClubs": [
@@ -7239,7 +7205,7 @@
   {
     "id": "yokohama-stadium",
     "name": "Yokohama Stadium",
-    "city": "Yokohama Park",
+    "city": "Yokohama",
     "countryCode": "JPN",
     "capacity": 34046,
     "tenantClubs": [
@@ -7257,23 +7223,13 @@
     ]
   },
   {
-    "id": "stadion-rujevica",
-    "name": "Stadion Rujevica",
-    "city": "Rijeka",
-    "countryCode": "HRV",
+    "id": "athlone-stadium",
+    "name": "Athlone Stadium",
+    "city": null,
+    "countryCode": "ZAF",
     "capacity": 34000,
     "tenantClubs": [
-      "hnk-rijeka"
-    ]
-  },
-  {
-    "id": "bunyodkor-stadium",
-    "name": "Bunyodkor Stadium",
-    "city": "Chilanzar",
-    "countryCode": "UZB",
-    "capacity": 34000,
-    "tenantClubs": [
-      "f-c-bunyodkor"
+      "santos-f-c"
     ]
   },
   {
@@ -7308,33 +7264,23 @@
     ]
   },
   {
+    "id": "stadion-rujevica",
+    "name": "Stadion Rujevica",
+    "city": "Rijeka",
+    "countryCode": "HRV",
+    "capacity": 34000,
+    "tenantClubs": [
+      "hnk-rijeka"
+    ]
+  },
+  {
     "id": "sultan-qaboos-sports-complex",
     "name": "Sultan Qaboos Sports Complex",
-    "city": "Bawshar",
+    "city": null,
     "countryCode": "OMN",
     "capacity": 34000,
     "tenantClubs": [
       "oman-men-s-national-football-team"
-    ]
-  },
-  {
-    "id": "athlone-stadium",
-    "name": "Athlone Stadium",
-    "city": null,
-    "countryCode": "ZAF",
-    "capacity": 34000,
-    "tenantClubs": [
-      "santos-f-c"
-    ]
-  },
-  {
-    "id": "oakland-ballpark",
-    "name": "Oakland Ballpark",
-    "city": null,
-    "countryCode": "USA",
-    "capacity": 34000,
-    "tenantClubs": [
-      "athletics"
     ]
   },
   {
@@ -7348,6 +7294,16 @@
     ]
   },
   {
+    "id": "oakland-ballpark",
+    "name": "Oakland Ballpark",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 34000,
+    "tenantClubs": [
+      "athletics"
+    ]
+  },
+  {
     "id": "agia-sophia-stadium",
     "name": "Agia Sophia Stadium",
     "city": "Nea Filadelfeia",
@@ -7355,6 +7311,16 @@
     "capacity": 34000,
     "tenantClubs": [
       "olympiacos-f-c"
+    ]
+  },
+  {
+    "id": "bunyodkor-stadium",
+    "name": "Bunyodkor Stadium",
+    "city": "Tashkent",
+    "countryCode": "UZB",
+    "capacity": 34000,
+    "tenantClubs": [
+      "f-c-bunyodkor"
     ]
   },
   {
@@ -7380,7 +7346,7 @@
   {
     "id": "samsun-19-may-s-stadium",
     "name": "Samsun 19 Mayıs Stadium",
-    "city": "Tekkeköy district",
+    "city": "Samsun",
     "countryCode": "TUR",
     "capacity": 33919,
     "tenantClubs": [
@@ -7390,7 +7356,7 @@
   {
     "id": "pride-park-stadium",
     "name": "Pride Park Stadium",
-    "city": "Pride Park",
+    "city": null,
     "countryCode": "GBR",
     "capacity": 33597,
     "tenantClubs": [
@@ -7408,7 +7374,7 @@
   {
     "id": "gaziantep-stadium",
     "name": "Gaziantep Stadium",
-    "city": "Göktürk",
+    "city": null,
     "countryCode": "TUR",
     "capacity": 33502,
     "tenantClubs": [
@@ -7418,7 +7384,7 @@
   {
     "id": "kardinia-park",
     "name": "Kardinia Park",
-    "city": "South Geelong",
+    "city": null,
     "countryCode": "AUS",
     "capacity": 33500,
     "tenantClubs": [
@@ -7450,7 +7416,7 @@
   {
     "id": "princess-auto-stadium",
     "name": "Princess Auto Stadium",
-    "city": "University of Manitoba",
+    "city": "Winnipeg",
     "countryCode": "CAN",
     "capacity": 33422,
     "tenantClubs": [
@@ -7548,6 +7514,16 @@
     ]
   },
   {
+    "id": "estadio-jk",
+    "name": "Estádio JK",
+    "city": null,
+    "countryCode": "BRA",
+    "capacity": 33000,
+    "tenantClubs": [
+      "itumbiara-esporte-clube"
+    ]
+  },
+  {
     "id": "estadio-anisio-haddad",
     "name": "Estádio Anísio Haddad",
     "city": null,
@@ -7558,13 +7534,23 @@
     ]
   },
   {
-    "id": "yale-field",
-    "name": "Yale Field",
+    "id": "colt-stadium",
+    "name": "Colt Stadium",
     "city": null,
     "countryCode": "USA",
     "capacity": 33000,
     "tenantClubs": [
-      "yale-bulldogs-football"
+      "houston-astros"
+    ]
+  },
+  {
+    "id": "deutsches-stadion",
+    "name": "Deutsches Stadion",
+    "city": null,
+    "countryCode": "DEU",
+    "capacity": 33000,
+    "tenantClubs": [
+      "list-of-german-football-champions"
     ]
   },
   {
@@ -7578,31 +7564,13 @@
     ]
   },
   {
-    "id": "national-football-stadium",
-    "name": "National Football Stadium",
-    "city": "Minsk",
-    "countryCode": "BLR",
-    "capacity": 33000,
-    "tenantClubs": []
-  },
-  {
-    "id": "estadio-jk",
-    "name": "Estádio JK",
+    "id": "markaziy-stadium",
+    "name": "Markaziy Stadium",
     "city": null,
-    "countryCode": "BRA",
+    "countryCode": "UZB",
     "capacity": 33000,
     "tenantClubs": [
-      "itumbiara-esporte-clube"
-    ]
-  },
-  {
-    "id": "deutsches-stadion-deu",
-    "name": "Deutsches Stadion",
-    "city": null,
-    "countryCode": "DEU",
-    "capacity": 33000,
-    "tenantClubs": [
-      "list-of-german-football-champions"
+      "navbahor-namangan"
     ]
   },
   {
@@ -7616,24 +7584,22 @@
     ]
   },
   {
-    "id": "markaziy-stadium",
-    "name": "Markaziy Stadium",
-    "city": null,
-    "countryCode": "UZB",
-    "capacity": 33000,
-    "tenantClubs": [
-      "navbahor-namangan"
-    ]
-  },
-  {
-    "id": "colt-stadium",
-    "name": "Colt Stadium",
+    "id": "yale-field",
+    "name": "Yale Field",
     "city": null,
     "countryCode": "USA",
     "capacity": 33000,
     "tenantClubs": [
-      "houston-astros"
+      "yale-bulldogs-football"
     ]
+  },
+  {
+    "id": "national-football-stadium",
+    "name": "National Football Stadium",
+    "city": "Minsk",
+    "countryCode": "BLR",
+    "capacity": 33000,
+    "tenantClubs": []
   },
   {
     "id": "stadionul-dan-paltinisanu",
@@ -7650,7 +7616,7 @@
   {
     "id": "new-tivoli",
     "name": "New Tivoli",
-    "city": "Soers",
+    "city": "Aachen",
     "countryCode": "DEU",
     "capacity": 32960,
     "tenantClubs": [
@@ -7691,7 +7657,7 @@
   {
     "id": "estadio-municipal-de-aveiro-mario-duarte",
     "name": "Estádio Municipal de Aveiro – Mário Duarte",
-    "city": "Aveiro",
+    "city": null,
     "countryCode": "PRT",
     "capacity": 32830,
     "tenantClubs": [
@@ -7721,7 +7687,7 @@
   {
     "id": "martin-stadium",
     "name": "Martin Stadium",
-    "city": "Washington State University",
+    "city": "Pullman",
     "countryCode": "USA",
     "capacity": 32740,
     "tenantClubs": [
@@ -7732,7 +7698,7 @@
   {
     "id": "partizan-stadium",
     "name": "Partizan Stadium",
-    "city": "Autokomanda",
+    "city": "City of Belgrade",
     "countryCode": "SRB",
     "capacity": 32710,
     "tenantClubs": [
@@ -7815,16 +7781,6 @@
     ]
   },
   {
-    "id": "nueva-espana-stadium",
-    "name": "Nueva España Stadium",
-    "city": "Parque Avellaneda",
-    "countryCode": "ARG",
-    "capacity": 32500,
-    "tenantClubs": [
-      "deportivo-espanol"
-    ]
-  },
-  {
     "id": "robert-rice-stadium",
     "name": "Robert Rice Stadium",
     "city": null,
@@ -7837,11 +7793,21 @@
   {
     "id": "shenzhen-stadium",
     "name": "Shenzhen Stadium",
-    "city": "Futian District",
+    "city": "Shenzhen",
     "countryCode": "CHN",
     "capacity": 32500,
     "tenantClubs": [
       "shenzhen-f-c"
+    ]
+  },
+  {
+    "id": "nueva-espana-stadium",
+    "name": "Nueva España Stadium",
+    "city": "Buenos Aires",
+    "countryCode": "ARG",
+    "capacity": 32500,
+    "tenantClubs": [
+      "deportivo-espanol"
     ]
   },
   {
@@ -7887,7 +7853,7 @@
   {
     "id": "gran-canaria-stadium",
     "name": "Gran Canaria Stadium",
-    "city": "Las Palmas de Gran Canaria",
+    "city": null,
     "countryCode": "ESP",
     "capacity": 32392,
     "tenantClubs": [
@@ -7907,7 +7873,7 @@
   {
     "id": "monumental-stadium-football-miguel-aleman-valdes",
     "name": "Monumental Stadium football Miguel Aleman Valdes",
-    "city": "Celaya",
+    "city": null,
     "countryCode": "MEX",
     "capacity": 32300,
     "tenantClubs": [
@@ -7937,7 +7903,7 @@
   {
     "id": "estadio-de-pituacu",
     "name": "Estádio de Pituaçu",
-    "city": "Pituaçu",
+    "city": "Salvador",
     "countryCode": "BRA",
     "capacity": 32157,
     "tenantClubs": [
@@ -7965,6 +7931,46 @@
     ]
   },
   {
+    "id": "stadion-am-schloss-strunkede",
+    "name": "Stadion am Schloss Strünkede",
+    "city": null,
+    "countryCode": "DEU",
+    "capacity": 32000,
+    "tenantClubs": [
+      "sc-westfalia-herne"
+    ]
+  },
+  {
+    "id": "stadion-wankdorf",
+    "name": "Stadion Wankdorf",
+    "city": "Bern",
+    "countryCode": "CHE",
+    "capacity": 32000,
+    "tenantClubs": [
+      "bsc-young-boys"
+    ]
+  },
+  {
+    "id": "ischelandstadion",
+    "name": "Ischelandstadion",
+    "city": null,
+    "countryCode": "DEU",
+    "capacity": 32000,
+    "tenantClubs": [
+      "bbv-hagen"
+    ]
+  },
+  {
+    "id": "estadio-rommel-fernandez",
+    "name": "Estadio Rommel Fernández",
+    "city": null,
+    "countryCode": "PAN",
+    "capacity": 32000,
+    "tenantClubs": [
+      "panama-men-s-national-football-team"
+    ]
+  },
+  {
     "id": "weinan-sports-center-stadium",
     "name": "Weinan Sports Center Stadium",
     "city": null,
@@ -7975,31 +7981,21 @@
     ]
   },
   {
-    "id": "gerald-j-ford-stadium",
-    "name": "Gerald J. Ford Stadium",
+    "id": "datianwan-stadium",
+    "name": "Datianwan Stadium",
     "city": null,
-    "countryCode": "USA",
-    "capacity": 32000,
-    "tenantClubs": [
-      "smu-mustangs"
-    ]
-  },
-  {
-    "id": "zabuthiri-stadium",
-    "name": "Zabuthiri Stadium",
-    "city": null,
-    "countryCode": "MMR",
+    "countryCode": "CHN",
     "capacity": 32000,
     "tenantClubs": []
   },
   {
-    "id": "homs-municipal-stadium",
-    "name": "Homs Municipal Stadium",
+    "id": "estadio-jorge-el-magico-gonzalez",
+    "name": "Estadio Jorge \"El Mágico\" González",
     "city": null,
-    "countryCode": "SYR",
+    "countryCode": "SLV",
     "capacity": 32000,
     "tenantClubs": [
-      "al-karamah-sc"
+      "alianza-futbol-cub"
     ]
   },
   {
@@ -8013,90 +8009,6 @@
     ]
   },
   {
-    "id": "datianwan-stadium",
-    "name": "Datianwan Stadium",
-    "city": null,
-    "countryCode": "CHN",
-    "capacity": 32000,
-    "tenantClubs": []
-  },
-  {
-    "id": "stadion-wankdorf",
-    "name": "Stadion Wankdorf",
-    "city": "Breitfeld",
-    "countryCode": "CHE",
-    "capacity": 32000,
-    "tenantClubs": [
-      "bsc-young-boys"
-    ]
-  },
-  {
-    "id": "stadion-am-schloss-strunkede",
-    "name": "Stadion am Schloss Strünkede",
-    "city": null,
-    "countryCode": "DEU",
-    "capacity": 32000,
-    "tenantClubs": [
-      "sc-westfalia-herne"
-    ]
-  },
-  {
-    "id": "shanxi-provincial-stadium",
-    "name": "Shanxi Provincial Stadium",
-    "city": null,
-    "countryCode": "CHN",
-    "capacity": 32000,
-    "tenantClubs": []
-  },
-  {
-    "id": "hailanjiang-stadium",
-    "name": "Hailanjiang Stadium",
-    "city": null,
-    "countryCode": "CHN",
-    "capacity": 32000,
-    "tenantClubs": []
-  },
-  {
-    "id": "estadio-rommel-fernandez",
-    "name": "Estadio Rommel Fernández",
-    "city": null,
-    "countryCode": "PAN",
-    "capacity": 32000,
-    "tenantClubs": [
-      "panama-men-s-national-football-team"
-    ]
-  },
-  {
-    "id": "estadio-jorge-el-magico-gonzalez",
-    "name": "Estadio Jorge \"El Mágico\" González",
-    "city": null,
-    "countryCode": "SLV",
-    "capacity": 32000,
-    "tenantClubs": [
-      "alianza-futbol-cub"
-    ]
-  },
-  {
-    "id": "estadio-nilmo-edwards",
-    "name": "Estadio Nilmo Edwards",
-    "city": null,
-    "countryCode": "HND",
-    "capacity": 32000,
-    "tenantClubs": [
-      "club-deportivo-victoria"
-    ]
-  },
-  {
-    "id": "worthersee-stadion",
-    "name": "Wörthersee Stadion",
-    "city": "Klagenfurt am Wörthersee",
-    "countryCode": "AUT",
-    "capacity": 32000,
-    "tenantClubs": [
-      "sk-austria-karnten"
-    ]
-  },
-  {
     "id": "paris-la-defense-arena",
     "name": "Paris La Défense Arena",
     "city": "La Défense",
@@ -8105,32 +8017,6 @@
     "tenantClubs": [
       "racing-92"
     ]
-  },
-  {
-    "id": "tai-an-sports-center-stadium",
-    "name": "Tai'an Sports Center Stadium",
-    "city": null,
-    "countryCode": "CHN",
-    "capacity": 32000,
-    "tenantClubs": []
-  },
-  {
-    "id": "estadio-victor-agustin-ugarte",
-    "name": "Estadio Víctor Agustín Ugarte",
-    "city": null,
-    "countryCode": "BOL",
-    "capacity": 32000,
-    "tenantClubs": [
-      "club-real-potosi"
-    ]
-  },
-  {
-    "id": "al-madina-stadium",
-    "name": "Al-Madina Stadium",
-    "city": null,
-    "countryCode": "IRQ",
-    "capacity": 32000,
-    "tenantClubs": []
   },
   {
     "id": "kamuzu-stadium",
@@ -8145,14 +8031,94 @@
     ]
   },
   {
-    "id": "ischelandstadion",
-    "name": "Ischelandstadion",
-    "city": null,
-    "countryCode": "DEU",
+    "id": "worthersee-stadion",
+    "name": "Wörthersee Stadion",
+    "city": "Klagenfurt am Wörthersee",
+    "countryCode": "AUT",
     "capacity": 32000,
     "tenantClubs": [
-      "bbv-hagen"
+      "sk-austria-karnten"
     ]
+  },
+  {
+    "id": "shanxi-provincial-stadium",
+    "name": "Shanxi Provincial Stadium",
+    "city": null,
+    "countryCode": "CHN",
+    "capacity": 32000,
+    "tenantClubs": []
+  },
+  {
+    "id": "al-madina-stadium",
+    "name": "Al-Madina Stadium",
+    "city": null,
+    "countryCode": "IRQ",
+    "capacity": 32000,
+    "tenantClubs": []
+  },
+  {
+    "id": "estadio-nilmo-edwards",
+    "name": "Estadio Nilmo Edwards",
+    "city": null,
+    "countryCode": "HND",
+    "capacity": 32000,
+    "tenantClubs": [
+      "club-deportivo-victoria"
+    ]
+  },
+  {
+    "id": "gerald-j-ford-stadium",
+    "name": "Gerald J. Ford Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 32000,
+    "tenantClubs": [
+      "smu-mustangs"
+    ]
+  },
+  {
+    "id": "estadio-victor-agustin-ugarte",
+    "name": "Estadio Víctor Agustín Ugarte",
+    "city": null,
+    "countryCode": "BOL",
+    "capacity": 32000,
+    "tenantClubs": [
+      "club-real-potosi"
+    ]
+  },
+  {
+    "id": "tai-an-sports-center-stadium",
+    "name": "Tai'an Sports Center Stadium",
+    "city": null,
+    "countryCode": "CHN",
+    "capacity": 32000,
+    "tenantClubs": []
+  },
+  {
+    "id": "hailanjiang-stadium",
+    "name": "Hailanjiang Stadium",
+    "city": null,
+    "countryCode": "CHN",
+    "capacity": 32000,
+    "tenantClubs": []
+  },
+  {
+    "id": "homs-municipal-stadium",
+    "name": "Homs Municipal Stadium",
+    "city": null,
+    "countryCode": "SYR",
+    "capacity": 32000,
+    "tenantClubs": [
+      "al-karamah-sc"
+    ]
+  },
+  {
+    "id": "zabuthiri-stadium",
+    "name": "Zabuthiri Stadium",
+    "city": null,
+    "countryCode": "MMR",
+    "capacity": 32000,
+    "tenantClubs": []
   },
   {
     "id": "hiroshima-municipal-stadium",
@@ -8187,7 +8153,7 @@
   {
     "id": "brighton-community-stadium",
     "name": "Brighton Community Stadium",
-    "city": "Falmer",
+    "city": null,
     "countryCode": "GBR",
     "capacity": 31800,
     "tenantClubs": [
@@ -8251,14 +8217,12 @@
     ]
   },
   {
-    "id": "cessna-stadium",
-    "name": "Cessna Stadium",
-    "city": null,
-    "countryCode": "USA",
+    "id": "jose-hernandez-amphitheatre",
+    "name": "José Hernández Amphitheatre",
+    "city": "Jesús María",
+    "countryCode": "ARG",
     "capacity": 31500,
-    "tenantClubs": [
-      "wichita-state-shockers-football"
-    ]
+    "tenantClubs": []
   },
   {
     "id": "allegacy-federal-credit-union-stadium",
@@ -8271,6 +8235,16 @@
     ]
   },
   {
+    "id": "cessna-stadium",
+    "name": "Cessna Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 31500,
+    "tenantClubs": [
+      "wichita-state-shockers-football"
+    ]
+  },
+  {
     "id": "schauinsland-reisen-arena",
     "name": "Schauinsland-Reisen-Arena",
     "city": null,
@@ -8279,14 +8253,6 @@
     "tenantClubs": [
       "msv-duisburg"
     ]
-  },
-  {
-    "id": "jose-hernandez-amphitheatre",
-    "name": "José Hernández Amphitheatre",
-    "city": "Jesús María",
-    "countryCode": "ARG",
-    "capacity": 31500,
-    "tenantClubs": []
   },
   {
     "id": "stadio-via-del-mare",
@@ -8301,7 +8267,7 @@
   {
     "id": "estadio-manuel-martinez-valero",
     "name": "Estadio Manuel Martínez Valero",
-    "city": "Elche",
+    "city": null,
     "countryCode": "ESP",
     "capacity": 31388,
     "tenantClubs": [
@@ -8311,7 +8277,7 @@
   {
     "id": "ewood-park",
     "name": "Ewood Park",
-    "city": "Blackburn",
+    "city": null,
     "countryCode": "GBR",
     "capacity": 31367,
     "tenantClubs": [
@@ -8360,7 +8326,7 @@
   {
     "id": "estadio-nueva-condomina",
     "name": "Estadio Nueva Condomina",
-    "city": "Murcia",
+    "city": null,
     "countryCode": "ESP",
     "capacity": 31179,
     "tenantClubs": [
@@ -8409,16 +8375,6 @@
     ]
   },
   {
-    "id": "birkebeineren-ski-stadium",
-    "name": "Birkebeineren Ski Stadium",
-    "city": null,
-    "countryCode": "NOR",
-    "capacity": 31000,
-    "tenantClubs": [
-      "1994-winter-olympics"
-    ]
-  },
-  {
     "id": "dalian-jinzhou-stadium",
     "name": "Dalian Jinzhou Stadium",
     "city": null,
@@ -8429,6 +8385,27 @@
     ]
   },
   {
+    "id": "university-at-buffalo-stadium",
+    "name": "University at Buffalo Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 31000,
+    "tenantClubs": [
+      "buffalo-bulls-football",
+      "buffalo-bulls-men-s-soccer"
+    ]
+  },
+  {
+    "id": "birkebeineren-ski-stadium",
+    "name": "Birkebeineren Ski Stadium",
+    "city": null,
+    "countryCode": "NOR",
+    "capacity": 31000,
+    "tenantClubs": [
+      "1994-winter-olympics"
+    ]
+  },
+  {
     "id": "gifu-nagaragawa-stadium",
     "name": "Gifu Nagaragawa Stadium",
     "city": null,
@@ -8436,17 +8413,6 @@
     "capacity": 31000,
     "tenantClubs": [
       "fc-gifu"
-    ]
-  },
-  {
-    "id": "university-at-buffalo-stadium",
-    "name": "University at Buffalo Stadium",
-    "city": "Amherst",
-    "countryCode": "USA",
-    "capacity": 31000,
-    "tenantClubs": [
-      "buffalo-bulls-football",
-      "buffalo-bulls-men-s-soccer"
     ]
   },
   {
@@ -8535,7 +8501,7 @@
   {
     "id": "forsyth-barr-stadium",
     "name": "Forsyth Barr Stadium",
-    "city": "Central Dunedin",
+    "city": null,
     "countryCode": "NZL",
     "capacity": 30748,
     "tenantClubs": [
@@ -8641,7 +8607,7 @@
   {
     "id": "muscat-stadium",
     "name": "Muscat Stadium",
-    "city": "Nakashō",
+    "city": "Kurashiki",
     "countryCode": "JPN",
     "capacity": 30494,
     "tenantClubs": []
@@ -8743,7 +8709,7 @@
   {
     "id": "portman-road",
     "name": "Portman Road",
-    "city": "Ipswich",
+    "city": null,
     "countryCode": "GBR",
     "capacity": 30311,
     "tenantClubs": [
@@ -8753,7 +8719,7 @@
   {
     "id": "estadio-algarve",
     "name": "Estádio Algarve",
-    "city": "Loulé",
+    "city": null,
     "countryCode": "PRT",
     "capacity": 30305,
     "tenantClubs": [
@@ -8766,7 +8732,7 @@
   {
     "id": "municipal-stadium-sidi-bennour",
     "name": "Municipal Stadium (Sidi Bennour)",
-    "city": "Sidi Bennour Province",
+    "city": null,
     "countryCode": "MAR",
     "capacity": 30286,
     "tenantClubs": [
@@ -8777,7 +8743,7 @@
   {
     "id": "estadio-municipal-de-braga",
     "name": "Estádio Municipal de Braga",
-    "city": "Braga",
+    "city": null,
     "countryCode": "PRT",
     "capacity": 30286,
     "tenantClubs": [
@@ -8798,7 +8764,7 @@
   {
     "id": "jamsil-baseball-stadium",
     "name": "Jamsil Baseball Stadium",
-    "city": "Jamsil-dong",
+    "city": "Seoul",
     "countryCode": "KOR",
     "capacity": 30265,
     "tenantClubs": [
@@ -8825,14 +8791,13 @@
     ]
   },
   {
-    "id": "waldo-stadium",
-    "name": "Waldo Stadium",
-    "city": null,
-    "countryCode": "USA",
+    "id": "estadio-centenario-ciudad-de-quilmes",
+    "name": "Estadio Centenario Ciudad de Quilmes",
+    "city": "Quilmes",
+    "countryCode": "ARG",
     "capacity": 30200,
     "tenantClubs": [
-      "western-michigan-broncos",
-      "western-michigan-broncos-football"
+      "quilmes-atletico-club"
     ]
   },
   {
@@ -8846,16 +8811,6 @@
     ]
   },
   {
-    "id": "estadio-centenario-ciudad-de-quilmes",
-    "name": "Estadio Centenario Ciudad de Quilmes",
-    "city": "Quilmes",
-    "countryCode": "ARG",
-    "capacity": 30200,
-    "tenantClubs": [
-      "quilmes-atletico-club"
-    ]
-  },
-  {
     "id": "rynearson-stadium",
     "name": "Rynearson Stadium",
     "city": null,
@@ -8866,9 +8821,20 @@
     ]
   },
   {
+    "id": "waldo-stadium",
+    "name": "Waldo Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 30200,
+    "tenantClubs": [
+      "western-michigan-broncos",
+      "western-michigan-broncos-football"
+    ]
+  },
+  {
     "id": "jiangyin-sports-centre",
     "name": "Jiangyin Sports Centre",
-    "city": "Jiangyin",
+    "city": "Wuxi",
     "countryCode": "CHN",
     "capacity": 30161,
     "tenantClubs": []
@@ -8936,7 +8902,7 @@
   {
     "id": "melbourne-rectangular-stadium",
     "name": "Melbourne Rectangular Stadium",
-    "city": "Olympic Park",
+    "city": null,
     "countryCode": "AUS",
     "capacity": 30050,
     "tenantClubs": [
@@ -8950,7 +8916,7 @@
   {
     "id": "la-rosaleda-stadium",
     "name": "La Rosaleda Stadium",
-    "city": "Málaga",
+    "city": null,
     "countryCode": "ESP",
     "capacity": 30044,
     "tenantClubs": [
@@ -8961,7 +8927,7 @@
   {
     "id": "estadio-d-afonso-henriques",
     "name": "Estádio D. Afonso Henriques",
-    "city": "Guimarães",
+    "city": null,
     "countryCode": "PRT",
     "capacity": 30029,
     "tenantClubs": [
@@ -8993,7 +8959,7 @@
   {
     "id": "st-andrew-s",
     "name": "St Andrew's",
-    "city": "Bordesley",
+    "city": null,
     "countryCode": "GBR",
     "capacity": 30016,
     "tenantClubs": [
@@ -9014,255 +8980,13 @@
   {
     "id": "3arena",
     "name": "3Arena",
-    "city": "Johanneshov",
+    "city": null,
     "countryCode": "SWE",
     "capacity": 30001,
     "tenantClubs": [
       "djurgardens-if-fotboll",
       "hammarby-fotboll"
     ]
-  },
-  {
-    "id": "q2326073",
-    "name": "Q2326073",
-    "city": null,
-    "countryCode": "DEU",
-    "capacity": 30000,
-    "tenantClubs": [
-      "1-fc-recklinghausen",
-      "1-ffc-recklinghausen"
-    ]
-  },
-  {
-    "id": "honsellstra-e-stadium",
-    "name": "Honsellstraße stadium",
-    "city": null,
-    "countryCode": "DEU",
-    "capacity": 30000,
-    "tenantClubs": [
-      "karlsruher-sc"
-    ]
-  },
-  {
-    "id": "lal-bahadur-shastri-stadium",
-    "name": "Lal Bahadur Shastri Stadium",
-    "city": "Hyderabad",
-    "countryCode": "IND",
-    "capacity": 30000,
-    "tenantClubs": []
-  },
-  {
-    "id": "indomilk-arena",
-    "name": "Indomilk Arena",
-    "city": null,
-    "countryCode": "IDN",
-    "capacity": 30000,
-    "tenantClubs": []
-  },
-  {
-    "id": "billtalstadion",
-    "name": "Billtalstadion",
-    "city": "Bergedorf",
-    "countryCode": "DEU",
-    "capacity": 30000,
-    "tenantClubs": []
-  },
-  {
-    "id": "althawra-sports-city-stadium",
-    "name": "Althawra Sports City Stadium",
-    "city": null,
-    "countryCode": "YEM",
-    "capacity": 30000,
-    "tenantClubs": [
-      "al-ahli-club-sana-a",
-      "yemen-men-s-national-football-team"
-    ]
-  },
-  {
-    "id": "hanazono-rugby-stadium",
-    "name": "Hanazono Rugby Stadium",
-    "city": "Higashiōsaka-shi",
-    "countryCode": "JPN",
-    "capacity": 30000,
-    "tenantClubs": [
-      "fc-osaka",
-      "hanazono-kintetsu-liners"
-    ]
-  },
-  {
-    "id": "nyayo-national-stadium",
-    "name": "Nyayo National Stadium",
-    "city": null,
-    "countryCode": "KEN",
-    "capacity": 30000,
-    "tenantClubs": [
-      "a-f-c-leopards"
-    ]
-  },
-  {
-    "id": "yanggakdo-stadium",
-    "name": "Yanggakdo Stadium",
-    "city": "Pyongyang",
-    "countryCode": "PRK",
-    "capacity": 30000,
-    "tenantClubs": [
-      "north-korea-men-s-national-football-team"
-    ]
-  },
-  {
-    "id": "paljor-stadium",
-    "name": "Paljor Stadium",
-    "city": "Gangtok",
-    "countryCode": "IND",
-    "capacity": 30000,
-    "tenantClubs": [
-      "united-sikkim-f-c"
-    ]
-  },
-  {
-    "id": "stade-de-la-reunification",
-    "name": "Stade de la Réunification",
-    "city": null,
-    "countryCode": "CMR",
-    "capacity": 30000,
-    "tenantClubs": [
-      "union-douala"
-    ]
-  },
-  {
-    "id": "yulman-stadium",
-    "name": "Yulman Stadium",
-    "city": null,
-    "countryCode": "USA",
-    "capacity": 30000,
-    "tenantClubs": [
-      "tulane-green-wave",
-      "tulane-green-wave-football"
-    ]
-  },
-  {
-    "id": "tottori-athletics-stadium",
-    "name": "Tottori Athletics Stadium",
-    "city": "Tottori",
-    "countryCode": "JPN",
-    "capacity": 30000,
-    "tenantClubs": []
-  },
-  {
-    "id": "volkswagen-arena",
-    "name": "Volkswagen Arena",
-    "city": null,
-    "countryCode": "DEU",
-    "capacity": 30000,
-    "tenantClubs": [
-      "vfl-wolfsburg"
-    ]
-  },
-  {
-    "id": "gifu-prefectural-baseball-stadium",
-    "name": "Gifu Prefectural Baseball Stadium",
-    "city": null,
-    "countryCode": "JPN",
-    "capacity": 30000,
-    "tenantClubs": []
-  },
-  {
-    "id": "kidd-brewer-stadium",
-    "name": "Kidd Brewer Stadium",
-    "city": null,
-    "countryCode": "USA",
-    "capacity": 30000,
-    "tenantClubs": [
-      "appalachian-state-mountaineers",
-      "appalachian-state-mountaineers-football"
-    ]
-  },
-  {
-    "id": "colonel-lotfi-stadium",
-    "name": "Colonel Lotfi Stadium",
-    "city": null,
-    "countryCode": "DZA",
-    "capacity": 30000,
-    "tenantClubs": [
-      "wa-tlemcen"
-    ]
-  },
-  {
-    "id": "30-june-stadium",
-    "name": "30 June Stadium",
-    "city": "Cairo",
-    "countryCode": "EGY",
-    "capacity": 30000,
-    "tenantClubs": []
-  },
-  {
-    "id": "al-salam-stadium",
-    "name": "Al Salam Stadium",
-    "city": null,
-    "countryCode": "EGY",
-    "capacity": 30000,
-    "tenantClubs": [
-      "al-ahly-sc",
-      "el-entag-el-harby"
-    ]
-  },
-  {
-    "id": "western-sydney-stadium",
-    "name": "Western Sydney Stadium",
-    "city": "Parramatta",
-    "countryCode": "AUS",
-    "capacity": 30000,
-    "tenantClubs": [
-      "parramatta-eels",
-      "parramatta-eels-women-s-rugby-league",
-      "western-sydney-wanderers-fc"
-    ]
-  },
-  {
-    "id": "konoike-athletic-stadium",
-    "name": "Kōnoike Athletic Stadium",
-    "city": null,
-    "countryCode": "JPN",
-    "capacity": 30000,
-    "tenantClubs": [
-      "nara-club"
-    ]
-  },
-  {
-    "id": "bakhshi-stadium",
-    "name": "Bakhshi Stadium",
-    "city": "Srinagar",
-    "countryCode": "IND",
-    "capacity": 30000,
-    "tenantClubs": []
-  },
-  {
-    "id": "niigata-prefectural-baseball-stadium",
-    "name": "Niigata Prefectural Baseball Stadium",
-    "city": "Niigata",
-    "countryCode": "JPN",
-    "capacity": 30000,
-    "tenantClubs": [
-      "oisix-niigata-albirex-baseball-club"
-    ]
-  },
-  {
-    "id": "sheikh-mohamed-laghdaf-stadium",
-    "name": "Sheikh Mohamed Laghdaf Stadium",
-    "city": null,
-    "countryCode": "MAR",
-    "capacity": 30000,
-    "tenantClubs": [
-      "js-massira"
-    ]
-  },
-  {
-    "id": "malappuram-district-sports-complex-stadium",
-    "name": "Malappuram District Sports Complex Stadium",
-    "city": "Payyanad",
-    "countryCode": "IND",
-    "capacity": 30000,
-    "tenantClubs": []
   },
   {
     "id": "haihe-educational-football-stadium",
@@ -9273,149 +8997,10 @@
     "tenantClubs": []
   },
   {
-    "id": "liaocheng-sports-park-stadium",
-    "name": "Liaocheng Sports Park Stadium",
-    "city": null,
-    "countryCode": "CHN",
-    "capacity": 30000,
-    "tenantClubs": []
-  },
-  {
-    "id": "tan-sri-dato-haji-hassan-yunos-stadium",
-    "name": "Tan Sri Dato Haji Hassan Yunos Stadium",
-    "city": null,
-    "countryCode": "MYS",
-    "capacity": 30000,
-    "tenantClubs": [
-      "johor-darul-takzim-f-c"
-    ]
-  },
-  {
-    "id": "estadio-nacional-mexico",
-    "name": "Estadio Nacional (Mexico)",
-    "city": "Colonia Roma",
-    "countryCode": "MEX",
-    "capacity": 30000,
-    "tenantClubs": [
-      "1926-central-american-and-caribbean-games"
-    ]
-  },
-  {
-    "id": "estadio-agustin-tovar",
-    "name": "Estadio Agustín Tovar",
-    "city": "Barinas",
-    "countryCode": "VEN",
-    "capacity": 30000,
-    "tenantClubs": [
-      "internacional-de-barinas-fc",
-      "zamora-f-c"
-    ]
-  },
-  {
-    "id": "abebe-bikila-stadium",
-    "name": "Abebe Bikila Stadium",
-    "city": null,
-    "countryCode": "ETH",
-    "capacity": 30000,
-    "tenantClubs": [
-      "dedebit"
-    ]
-  },
-  {
-    "id": "lal-bahadur-shastri-stadium-kollam",
-    "name": "Lal Bahadur Shastri Stadium (Kollam)",
-    "city": "Kollam Cantonment",
-    "countryCode": "IND",
-    "capacity": 30000,
-    "tenantClubs": []
-  },
-  {
-    "id": "sailen-manna-stadium",
-    "name": "Sailen Manna Stadium",
-    "city": "Howrah",
-    "countryCode": "IND",
-    "capacity": 30000,
-    "tenantClubs": []
-  },
-  {
-    "id": "kiyohara-baseball-stadium",
-    "name": "Kiyohara Baseball Stadium",
-    "city": null,
-    "countryCode": "JPN",
-    "capacity": 30000,
-    "tenantClubs": []
-  },
-  {
-    "id": "chaohu-stadium",
-    "name": "Chaohu Stadium",
-    "city": "Chaohu",
-    "countryCode": "CHN",
-    "capacity": 30000,
-    "tenantClubs": []
-  },
-  {
-    "id": "q16605719",
-    "name": "Q16605719",
-    "city": null,
-    "countryCode": "POL",
-    "capacity": 30000,
-    "tenantClubs": []
-  },
-  {
-    "id": "q86666021",
-    "name": "Q86666021",
-    "city": null,
-    "countryCode": "YUG",
-    "capacity": 30000,
-    "tenantClubs": []
-  },
-  {
-    "id": "changzhi-stadium",
-    "name": "Changzhi Stadium",
-    "city": null,
-    "countryCode": "CHN",
-    "capacity": 30000,
-    "tenantClubs": []
-  },
-  {
-    "id": "changshu-stadium",
-    "name": "Changshu Stadium",
-    "city": null,
-    "countryCode": "CHN",
-    "capacity": 30000,
-    "tenantClubs": []
-  },
-  {
-    "id": "cangzhou-stadium",
-    "name": "Cangzhou Stadium",
-    "city": null,
-    "countryCode": "CHN",
-    "capacity": 30000,
-    "tenantClubs": []
-  },
-  {
-    "id": "yashwant-stadium",
-    "name": "Yashwant Stadium",
-    "city": null,
-    "countryCode": "IND",
-    "capacity": 30000,
-    "tenantClubs": []
-  },
-  {
-    "id": "estadio-daniel-villa-zapata",
-    "name": "Estadio Daniel Villa Zapata",
-    "city": "Barrancabermeja",
-    "countryCode": "COL",
-    "capacity": 30000,
-    "tenantClubs": [
-      "alianza-petrolera-f-c"
-    ]
-  },
-  {
-    "id": "wunna-theikdi-stadium",
-    "name": "Wunna Theikdi Stadium",
-    "city": null,
-    "countryCode": "MMR",
+    "id": "billtalstadion",
+    "name": "Billtalstadion",
+    "city": "Hamburg",
+    "countryCode": "DEU",
     "capacity": 30000,
     "tenantClubs": []
   },
@@ -9430,6 +9015,92 @@
     ]
   },
   {
+    "id": "estadio-unico-madre-de-ciudades",
+    "name": "Estadio Único Madre de Ciudades",
+    "city": "Santiago del Estero",
+    "countryCode": "ARG",
+    "capacity": 30000,
+    "tenantClubs": [
+      "central-cordoba-de-santiago-del-estero",
+      "club-atletico-guemes",
+      "club-atletico-mitre"
+    ]
+  },
+  {
+    "id": "wunna-theikdi-stadium",
+    "name": "Wunna Theikdi Stadium",
+    "city": null,
+    "countryCode": "MMR",
+    "capacity": 30000,
+    "tenantClubs": []
+  },
+  {
+    "id": "kunshan-stadium",
+    "name": "Kunshan Stadium",
+    "city": null,
+    "countryCode": "CHN",
+    "capacity": 30000,
+    "tenantClubs": []
+  },
+  {
+    "id": "estadio-luis-pirata-fuente",
+    "name": "Estadio Luis \"Pirata\" Fuente",
+    "city": null,
+    "countryCode": "MEX",
+    "capacity": 30000,
+    "tenantClubs": [
+      "tiburones-rojos-de-veracruz"
+    ]
+  },
+  {
+    "id": "rand-stadium",
+    "name": "Rand Stadium",
+    "city": "City of Johannesburg Metropolitan Municipality",
+    "countryCode": "ZAF",
+    "capacity": 30000,
+    "tenantClubs": [
+      "kaizer-chiefs-f-c"
+    ]
+  },
+  {
+    "id": "stade-balibie",
+    "name": "Stade Balibiè",
+    "city": null,
+    "countryCode": "BFA",
+    "capacity": 30000,
+    "tenantClubs": [
+      "asec-koudougou"
+    ]
+  },
+  {
+    "id": "1-november-1954-stadium",
+    "name": "1 November 1954 Stadium",
+    "city": null,
+    "countryCode": "DZA",
+    "capacity": 30000,
+    "tenantClubs": [
+      "js-kabylie"
+    ]
+  },
+  {
+    "id": "tottori-athletics-stadium",
+    "name": "Tottori Athletics Stadium",
+    "city": "Tottori",
+    "countryCode": "JPN",
+    "capacity": 30000,
+    "tenantClubs": []
+  },
+  {
+    "id": "zhengzhou-hanghai-stadium",
+    "name": "Zhengzhou Hanghai Stadium",
+    "city": null,
+    "countryCode": "CHN",
+    "capacity": 30000,
+    "tenantClubs": [
+      "henan-f-c"
+    ]
+  },
+  {
     "id": "rajarshi-shahu-stadium",
     "name": "Rajarshi Shahu Stadium",
     "city": null,
@@ -9440,54 +9111,67 @@
     ]
   },
   {
-    "id": "jawaharlal-nehru-stadium-shillong",
-    "name": "Jawaharlal Nehru Stadium, Shillong",
-    "city": "Shillong",
-    "countryCode": "IND",
+    "id": "friedrich-ludwig-jahn-stadium-herford",
+    "name": "Friedrich-Ludwig-Jahn-Stadium (Herford)",
+    "city": null,
+    "countryCode": "DEU",
     "capacity": 30000,
     "tenantClubs": [
-      "shillong-lajong-f-c"
+      "herforder-sv-borussia-friedenstal"
     ]
   },
   {
-    "id": "mandala-stadium",
-    "name": "Mandala Stadium",
+    "id": "taoyuan-city-stadium",
+    "name": "Taoyuan City Stadium",
+    "city": null,
+    "countryCode": "TWN",
+    "capacity": 30000,
+    "tenantClubs": []
+  },
+  {
+    "id": "new-beaver-field",
+    "name": "New Beaver Field",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 30000,
+    "tenantClubs": [
+      "penn-state-nittany-lions-baseball",
+      "penn-state-nittany-lions-football",
+      "penn-state-nittany-lions-men-s-lacrosse",
+      "penn-state-nittany-lions-men-s-soccer"
+    ]
+  },
+  {
+    "id": "faridpur-stadium",
+    "name": "Faridpur Stadium",
+    "city": null,
+    "countryCode": "BGD",
+    "capacity": 30000,
+    "tenantClubs": []
+  },
+  {
+    "id": "yangsan-stadium",
+    "name": "Yangsan Stadium",
+    "city": null,
+    "countryCode": "KOR",
+    "capacity": 30000,
+    "tenantClubs": []
+  },
+  {
+    "id": "pakansari-stadium",
+    "name": "Pakansari Stadium",
     "city": null,
     "countryCode": "IDN",
     "capacity": 30000,
-    "tenantClubs": [
-      "persipura-jayapura"
-    ]
+    "tenantClubs": []
   },
   {
-    "id": "rand-stadium",
-    "name": "Rand Stadium",
-    "city": "Rosettenville",
-    "countryCode": "ZAF",
-    "capacity": 30000,
-    "tenantClubs": [
-      "kaizer-chiefs-f-c"
-    ]
-  },
-  {
-    "id": "hakatanomori-athletic-stadium",
-    "name": "Hakatanomori Athletic Stadium",
+    "id": "guangxi-zhuang-autonomous-region-stadium",
+    "name": "Guangxi Zhuang Autonomous Region Stadium",
     "city": null,
-    "countryCode": "JPN",
+    "countryCode": "CHN",
     "capacity": 30000,
-    "tenantClubs": [
-      "1995-summer-universiade"
-    ]
-  },
-  {
-    "id": "estadio-15-de-abril",
-    "name": "Estadio 15 de Abril",
-    "city": null,
-    "countryCode": "ARG",
-    "capacity": 30000,
-    "tenantClubs": [
-      "union-de-santa-fe"
-    ]
+    "tenantClubs": []
   },
   {
     "id": "botchan-stadium",
@@ -9498,6 +9182,346 @@
     "tenantClubs": [
       "japanese-high-school-baseball-championship"
     ]
+  },
+  {
+    "id": "kusanagi-stadium",
+    "name": "Kusanagi Stadium",
+    "city": null,
+    "countryCode": "JPN",
+    "capacity": 30000,
+    "tenantClubs": []
+  },
+  {
+    "id": "gifu-prefectural-baseball-stadium",
+    "name": "Gifu Prefectural Baseball Stadium",
+    "city": null,
+    "countryCode": "JPN",
+    "capacity": 30000,
+    "tenantClubs": []
+  },
+  {
+    "id": "ghazi-stadium",
+    "name": "Ghazi Stadium",
+    "city": null,
+    "countryCode": "AFG",
+    "capacity": 30000,
+    "tenantClubs": [
+      "afghanistan-men-s-national-football-team"
+    ]
+  },
+  {
+    "id": "estadio-agustin-tovar",
+    "name": "Estadio Agustín Tovar",
+    "city": "Barinas",
+    "countryCode": "VEN",
+    "capacity": 30000,
+    "tenantClubs": [
+      "internacional-de-barinas-fc",
+      "zamora-f-c"
+    ]
+  },
+  {
+    "id": "yiyang-stadium",
+    "name": "Yiyang Stadium",
+    "city": "Yiyang",
+    "countryCode": "CHN",
+    "capacity": 30000,
+    "tenantClubs": []
+  },
+  {
+    "id": "stade-ahmed-kaid",
+    "name": "Stade Ahmed Kaïd",
+    "city": null,
+    "countryCode": "DZA",
+    "capacity": 30000,
+    "tenantClubs": [
+      "jsm-tiaret"
+    ]
+  },
+  {
+    "id": "fukushima-azuma-baseball-stadium",
+    "name": "Fukushima Azuma Baseball Stadium",
+    "city": "Fukushima",
+    "countryCode": "JPN",
+    "capacity": 30000,
+    "tenantClubs": [
+      "2020-summer-olympics"
+    ]
+  },
+  {
+    "id": "guru-nanak-stadium",
+    "name": "Guru Nanak Stadium",
+    "city": "Ludhiana",
+    "countryCode": "IND",
+    "capacity": 30000,
+    "tenantClubs": [
+      "national-games-of-india",
+      "punjab-fc"
+    ]
+  },
+  {
+    "id": "khuman-lampak-main-stadium",
+    "name": "Khuman Lampak Main Stadium",
+    "city": "Imphal",
+    "countryCode": "IND",
+    "capacity": 30000,
+    "tenantClubs": [
+      "shillong-lajong-f-c"
+    ]
+  },
+  {
+    "id": "fujian-provincial-sports-centre-stadium",
+    "name": "Fujian Provincial Sports Centre Stadium",
+    "city": null,
+    "countryCode": "CHN",
+    "capacity": 30000,
+    "tenantClubs": []
+  },
+  {
+    "id": "malappuram-district-sports-complex-stadium",
+    "name": "Malappuram District Sports Complex Stadium",
+    "city": null,
+    "countryCode": "IND",
+    "capacity": 30000,
+    "tenantClubs": []
+  },
+  {
+    "id": "incheon-asiad-main-stadium",
+    "name": "Incheon Asiad Main Stadium",
+    "city": null,
+    "countryCode": "KOR",
+    "capacity": 30000,
+    "tenantClubs": [
+      "2014-asian-games"
+    ]
+  },
+  {
+    "id": "lake-placid-equestrian-stadium",
+    "name": "Lake Placid Equestrian Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 30000,
+    "tenantClubs": []
+  },
+  {
+    "id": "ahmadu-bello-stadium",
+    "name": "Ahmadu Bello Stadium",
+    "city": null,
+    "countryCode": "NGA",
+    "capacity": 30000,
+    "tenantClubs": []
+  },
+  {
+    "id": "yuvileiny-stadium",
+    "name": "Yuvileiny Stadium",
+    "city": null,
+    "countryCode": "UKR",
+    "capacity": 30000,
+    "tenantClubs": [
+      "fc-spartak-sumy"
+    ]
+  },
+  {
+    "id": "anji-arena",
+    "name": "Anji Arena",
+    "city": "Kaspiysk",
+    "countryCode": "RUS",
+    "capacity": 30000,
+    "tenantClubs": [
+      "fc-anzhi-makhachkala",
+      "fc-dynamo-makhachkala",
+      "fc-makhachkala"
+    ]
+  },
+  {
+    "id": "stade-lumumba",
+    "name": "Stade Lumumba",
+    "city": null,
+    "countryCode": "COD",
+    "capacity": 30000,
+    "tenantClubs": [
+      "as-nika"
+    ]
+  },
+  {
+    "id": "rongcheng-stadium",
+    "name": "Rongcheng Stadium",
+    "city": null,
+    "countryCode": "CHN",
+    "capacity": 30000,
+    "tenantClubs": []
+  },
+  {
+    "id": "saga-sunrise-park-athletic-stadium",
+    "name": "SAGA Sunrise Park Athletic Stadium",
+    "city": null,
+    "countryCode": "JPN",
+    "capacity": 30000,
+    "tenantClubs": []
+  },
+  {
+    "id": "western-sydney-stadium",
+    "name": "Western Sydney Stadium",
+    "city": null,
+    "countryCode": "AUS",
+    "capacity": 30000,
+    "tenantClubs": [
+      "parramatta-eels",
+      "parramatta-eels-women-s-rugby-league",
+      "western-sydney-wanderers-fc"
+    ]
+  },
+  {
+    "id": "lal-bahadur-shastri-stadium",
+    "name": "Lal Bahadur Shastri Stadium",
+    "city": "Hyderabad",
+    "countryCode": "IND",
+    "capacity": 30000,
+    "tenantClubs": []
+  },
+  {
+    "id": "stadio-filadelfia",
+    "name": "Stadio Filadelfia",
+    "city": null,
+    "countryCode": "ITA",
+    "capacity": 30000,
+    "tenantClubs": [
+      "torino-fc"
+    ]
+  },
+  {
+    "id": "stade-de-kegue",
+    "name": "Stade de Kégué",
+    "city": "Lomé",
+    "countryCode": "TGO",
+    "capacity": 30000,
+    "tenantClubs": [
+      "togo-men-s-national-football-team"
+    ]
+  },
+  {
+    "id": "rizal-memorial-stadium",
+    "name": "Rizal Memorial Stadium",
+    "city": null,
+    "countryCode": "PHL",
+    "capacity": 30000,
+    "tenantClubs": [
+      "philippines-men-s-national-association-football-team"
+    ]
+  },
+  {
+    "id": "shahid-shiroudi-stadium",
+    "name": "Shahid Shiroudi Stadium",
+    "city": null,
+    "countryCode": "IRN",
+    "capacity": 30000,
+    "tenantClubs": [
+      "iran-men-s-national-football-team"
+    ]
+  },
+  {
+    "id": "takhti-stadium",
+    "name": "Takhti Stadium",
+    "city": null,
+    "countryCode": "IRN",
+    "capacity": 30000,
+    "tenantClubs": [
+      "foolad-f-c"
+    ]
+  },
+  {
+    "id": "sultan-mohammad-iv-stadium",
+    "name": "Sultan Mohammad IV Stadium",
+    "city": null,
+    "countryCode": "MYS",
+    "capacity": 30000,
+    "tenantClubs": [
+      "kelantan-f-c"
+    ]
+  },
+  {
+    "id": "al-mina-a-stadium",
+    "name": "Al Mina'a Stadium",
+    "city": null,
+    "countryCode": "IRQ",
+    "capacity": 30000,
+    "tenantClubs": [
+      "al-mina-a-sc"
+    ]
+  },
+  {
+    "id": "tengzhou-olympic-center-stadium",
+    "name": "Tengzhou Olympic Center Stadium",
+    "city": null,
+    "countryCode": "CHN",
+    "capacity": 30000,
+    "tenantClubs": []
+  },
+  {
+    "id": "olympic-stadium-tkm",
+    "name": "Olympic Stadium",
+    "city": null,
+    "countryCode": "TKM",
+    "capacity": 30000,
+    "tenantClubs": [
+      "turkmenistan-men-s-national-football-team"
+    ]
+  },
+  {
+    "id": "may-22-stadium",
+    "name": "May 22 Stadium",
+    "city": null,
+    "countryCode": "YEM",
+    "capacity": 30000,
+    "tenantClubs": []
+  },
+  {
+    "id": "sheikh-mohamed-laghdaf-stadium",
+    "name": "Sheikh Mohamed Laghdaf Stadium",
+    "city": null,
+    "countryCode": "MAR",
+    "capacity": 30000,
+    "tenantClubs": [
+      "js-massira"
+    ]
+  },
+  {
+    "id": "de-grolsch-veste",
+    "name": "De Grolsch Veste",
+    "city": null,
+    "countryCode": null,
+    "capacity": 30000,
+    "tenantClubs": [
+      "fc-twente"
+    ]
+  },
+  {
+    "id": "colonel-lotfi-stadium",
+    "name": "Colonel Lotfi Stadium",
+    "city": null,
+    "countryCode": "DZA",
+    "capacity": 30000,
+    "tenantClubs": [
+      "wa-tlemcen"
+    ]
+  },
+  {
+    "id": "lacerdao",
+    "name": "Lacerdão",
+    "city": null,
+    "countryCode": "BRA",
+    "capacity": 30000,
+    "tenantClubs": [
+      "central-sport-club"
+    ]
+  },
+  {
+    "id": "jeonju-sports-complex",
+    "name": "Jeonju Sports Complex",
+    "city": null,
+    "countryCode": "KOR",
+    "capacity": 30000,
+    "tenantClubs": []
   },
   {
     "id": "abbasiyyin-stadium",
@@ -9514,259 +9538,50 @@
     ]
   },
   {
-    "id": "mount-smart-stadium",
-    "name": "Mount Smart Stadium",
+    "id": "stade-of-1st-november-1954",
+    "name": "Stade of 1st November 1954",
     "city": null,
-    "countryCode": "NZL",
+    "countryCode": "DZA",
     "capacity": 30000,
     "tenantClubs": [
-      "moana-pasifika",
-      "new-zealand-warriors"
+      "ca-batna"
     ]
   },
   {
-    "id": "zozo-marine-stadium",
-    "name": "ZOZO Marine Stadium",
-    "city": "Makuhari Seaside Park",
-    "countryCode": "JPN",
-    "capacity": 30000,
-    "tenantClubs": [
-      "chiba-lotte-marines",
-      "pacific-league"
-    ]
-  },
-  {
-    "id": "saga-sunrise-park-athletic-stadium",
-    "name": "SAGA Sunrise Park Athletic Stadium",
-    "city": null,
-    "countryCode": "JPN",
-    "capacity": 30000,
-    "tenantClubs": []
-  },
-  {
-    "id": "rongcheng-stadium",
-    "name": "Rongcheng Stadium",
+    "id": "liaocheng-sports-park-stadium",
+    "name": "Liaocheng Sports Park Stadium",
     "city": null,
     "countryCode": "CHN",
     "capacity": 30000,
     "tenantClubs": []
   },
   {
-    "id": "stadio-filadelfia",
-    "name": "Stadio Filadelfia",
+    "id": "punjab-stadium",
+    "name": "Punjab Stadium",
     "city": null,
-    "countryCode": "ITA",
+    "countryCode": "PAK",
     "capacity": 30000,
     "tenantClubs": [
-      "torino-fc"
+      "wapda-f-c"
     ]
   },
   {
-    "id": "guru-nanak-stadium",
-    "name": "Guru Nanak Stadium",
-    "city": "Ludhiana",
-    "countryCode": "IND",
-    "capacity": 30000,
-    "tenantClubs": [
-      "national-games-of-india",
-      "punjab-fc"
-    ]
-  },
-  {
-    "id": "guangxi-zhuang-autonomous-region-stadium",
-    "name": "Guangxi Zhuang Autonomous Region Stadium",
+    "id": "tainan-county-stadium",
+    "name": "Tainan County Stadium",
     "city": null,
-    "countryCode": "CHN",
+    "countryCode": "TWN",
     "capacity": 30000,
     "tenantClubs": []
   },
   {
-    "id": "stade-de-kegue",
-    "name": "Stade de Kégué",
-    "city": "Lomé",
-    "countryCode": "TGO",
-    "capacity": 30000,
-    "tenantClubs": [
-      "togo-men-s-national-football-team"
-    ]
-  },
-  {
-    "id": "estadio-pedro-marrero",
-    "name": "Estadio Pedro Marrero",
+    "id": "hassanal-bolkiah-national-stadium",
+    "name": "Hassanal Bolkiah National Stadium",
     "city": null,
-    "countryCode": "CUB",
+    "countryCode": "BRN",
     "capacity": 30000,
     "tenantClubs": [
-      "ciudad-de-la-habana"
+      "brunei-men-s-national-football-team"
     ]
-  },
-  {
-    "id": "estadio-luis-pirata-fuente",
-    "name": "Estadio Luis \"Pirata\" Fuente",
-    "city": "Boca del Río",
-    "countryCode": "MEX",
-    "capacity": 30000,
-    "tenantClubs": [
-      "tiburones-rojos-de-veracruz"
-    ]
-  },
-  {
-    "id": "estadio-olimpico-colosso-da-lagoa",
-    "name": "Estádio Olímpico Colosso da Lagoa",
-    "city": null,
-    "countryCode": "BRA",
-    "capacity": 30000,
-    "tenantClubs": [
-      "ypiranga-futebol-clube"
-    ]
-  },
-  {
-    "id": "incheon-asiad-main-stadium",
-    "name": "Incheon Asiad Main Stadium",
-    "city": null,
-    "countryCode": "KOR",
-    "capacity": 30000,
-    "tenantClubs": [
-      "2014-asian-games"
-    ]
-  },
-  {
-    "id": "bobcat-stadium",
-    "name": "Bobcat Stadium",
-    "city": null,
-    "countryCode": "USA",
-    "capacity": 30000,
-    "tenantClubs": [
-      "texas-state-bobcats",
-      "texas-state-bobcats-football"
-    ]
-  },
-  {
-    "id": "lacerdao",
-    "name": "Lacerdão",
-    "city": null,
-    "countryCode": "BRA",
-    "capacity": 30000,
-    "tenantClubs": [
-      "central-sport-club"
-    ]
-  },
-  {
-    "id": "estadio-doroteo-guamuch-flores",
-    "name": "Estadio Doroteo Guamuch Flores",
-    "city": null,
-    "countryCode": "GTM",
-    "capacity": 30000,
-    "tenantClubs": [
-      "guatemala-men-s-national-football-team"
-    ]
-  },
-  {
-    "id": "new-beaver-field",
-    "name": "New Beaver Field",
-    "city": "Penn State University Park",
-    "countryCode": "USA",
-    "capacity": 30000,
-    "tenantClubs": [
-      "penn-state-nittany-lions-baseball",
-      "penn-state-nittany-lions-football",
-      "penn-state-nittany-lions-men-s-lacrosse",
-      "penn-state-nittany-lions-men-s-soccer"
-    ]
-  },
-  {
-    "id": "kawasaki-stadium",
-    "name": "Kawasaki Stadium",
-    "city": "Kawasaki",
-    "countryCode": "JPN",
-    "capacity": 30000,
-    "tenantClubs": [
-      "chiba-lotte-marines",
-      "takahashi-unions",
-      "yokohama-dena-baystars"
-    ]
-  },
-  {
-    "id": "kunshan-stadium",
-    "name": "Kunshan Stadium",
-    "city": null,
-    "countryCode": "CHN",
-    "capacity": 30000,
-    "tenantClubs": []
-  },
-  {
-    "id": "khuman-lampak-main-stadium",
-    "name": "Khuman Lampak Main Stadium",
-    "city": "Imphal",
-    "countryCode": "IND",
-    "capacity": 30000,
-    "tenantClubs": [
-      "shillong-lajong-f-c"
-    ]
-  },
-  {
-    "id": "fukushima-azuma-baseball-stadium",
-    "name": "Fukushima Azuma Baseball Stadium",
-    "city": "Fukushima Prefectural Azuma Sports Park",
-    "countryCode": "JPN",
-    "capacity": 30000,
-    "tenantClubs": [
-      "2020-summer-olympics"
-    ]
-  },
-  {
-    "id": "faridpur-stadium",
-    "name": "Faridpur Stadium",
-    "city": "Faridpur Sadar Upazila",
-    "countryCode": "BGD",
-    "capacity": 30000,
-    "tenantClubs": []
-  },
-  {
-    "id": "empire-stadium-gzira",
-    "name": "Empire Stadium, Gżira",
-    "city": "Gżira",
-    "countryCode": "MLT",
-    "capacity": 30000,
-    "tenantClubs": [
-      "hibernians-f-c"
-    ]
-  },
-  {
-    "id": "hengyang-stadium",
-    "name": "Hengyang Stadium",
-    "city": null,
-    "countryCode": "CHN",
-    "capacity": 30000,
-    "tenantClubs": []
-  },
-  {
-    "id": "ghazi-stadium",
-    "name": "Ghazi Stadium",
-    "city": null,
-    "countryCode": "AFG",
-    "capacity": 30000,
-    "tenantClubs": [
-      "afghanistan-men-s-national-football-team"
-    ]
-  },
-  {
-    "id": "william-dick-price-stadium",
-    "name": "William \"Dick\" Price Stadium",
-    "city": null,
-    "countryCode": "USA",
-    "capacity": 30000,
-    "tenantClubs": [
-      "norfolk-state-spartans-football"
-    ]
-  },
-  {
-    "id": "kamoike-ballpark",
-    "name": "Kamoike Ballpark",
-    "city": "Kagoshima",
-    "countryCode": "JPN",
-    "capacity": 30000,
-    "tenantClubs": []
   },
   {
     "id": "estadio-heroe-de-nacozari",
@@ -9776,6 +9591,16 @@
     "capacity": 30000,
     "tenantClubs": [
       "cimarrones-de-sonora-fc"
+    ]
+  },
+  {
+    "id": "empire-stadium-gzira",
+    "name": "Empire Stadium, Gżira",
+    "city": null,
+    "countryCode": "MLT",
+    "capacity": 30000,
+    "tenantClubs": [
+      "hibernians-f-c"
     ]
   },
   {
@@ -9791,6 +9616,16 @@
     ]
   },
   {
+    "id": "stade-de-l-unite-africaine",
+    "name": "Stade de l'Unité Africaine",
+    "city": null,
+    "countryCode": "DZA",
+    "capacity": 30000,
+    "tenantClubs": [
+      "ghali-chabab-mascara"
+    ]
+  },
+  {
     "id": "sector-42-stadium",
     "name": "Sector 42 Stadium",
     "city": "Chandigarh",
@@ -9801,31 +9636,99 @@
     ]
   },
   {
-    "id": "gelora-10-november-stadium",
-    "name": "Gelora 10 November Stadium",
-    "city": "Tambaksari",
+    "id": "mandala-stadium",
+    "name": "Mandala Stadium",
+    "city": null,
     "countryCode": "IDN",
     "capacity": 30000,
     "tenantClubs": [
-      "persebaya-surabaya"
+      "persipura-jayapura"
     ]
   },
   {
-    "id": "salah-al-din-stadium",
-    "name": "Salah Al Din Stadium",
+    "id": "changshu-stadium",
+    "name": "Changshu Stadium",
     "city": null,
-    "countryCode": "IRQ",
+    "countryCode": "CHN",
     "capacity": 30000,
     "tenantClubs": []
   },
   {
-    "id": "de-grolsch-veste",
-    "name": "De Grolsch Veste",
+    "id": "bobcat-stadium",
+    "name": "Bobcat Stadium",
     "city": null,
-    "countryCode": null,
+    "countryCode": "USA",
     "capacity": 30000,
     "tenantClubs": [
-      "fc-twente"
+      "texas-state-bobcats",
+      "texas-state-bobcats-football"
+    ]
+  },
+  {
+    "id": "chaohu-stadium",
+    "name": "Chaohu Stadium",
+    "city": "Hefei",
+    "countryCode": "CHN",
+    "capacity": 30000,
+    "tenantClubs": []
+  },
+  {
+    "id": "nehru-stadium-coimbatore",
+    "name": "Nehru Stadium, Coimbatore",
+    "city": "Coimbatore",
+    "countryCode": "IND",
+    "capacity": 30000,
+    "tenantClubs": []
+  },
+  {
+    "id": "yanggakdo-stadium",
+    "name": "Yanggakdo Stadium",
+    "city": "Pyongyang",
+    "countryCode": "PRK",
+    "capacity": 30000,
+    "tenantClubs": [
+      "north-korea-men-s-national-football-team"
+    ]
+  },
+  {
+    "id": "yulman-stadium",
+    "name": "Yulman Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 30000,
+    "tenantClubs": [
+      "tulane-green-wave",
+      "tulane-green-wave-football"
+    ]
+  },
+  {
+    "id": "honsellstra-e-stadium",
+    "name": "Honsellstraße stadium",
+    "city": null,
+    "countryCode": "DEU",
+    "capacity": 30000,
+    "tenantClubs": [
+      "karlsruher-sc"
+    ]
+  },
+  {
+    "id": "hakatanomori-athletic-stadium",
+    "name": "Hakatanomori Athletic Stadium",
+    "city": null,
+    "countryCode": "JPN",
+    "capacity": 30000,
+    "tenantClubs": [
+      "1995-summer-universiade"
+    ]
+  },
+  {
+    "id": "estadio-pedro-marrero",
+    "name": "Estadio Pedro Marrero",
+    "city": null,
+    "countryCode": "CUB",
+    "capacity": 30000,
+    "tenantClubs": [
+      "ciudad-de-la-habana"
     ]
   },
   {
@@ -9839,126 +9742,14 @@
     ]
   },
   {
-    "id": "friedrich-ludwig-jahn-stadium-herford",
-    "name": "Friedrich-Ludwig-Jahn-Stadium (Herford)",
+    "id": "gorda-hilda",
+    "name": "Gorda hilda",
     "city": null,
-    "countryCode": "DEU",
+    "countryCode": "MEX",
     "capacity": 30000,
     "tenantClubs": [
-      "herforder-sv-borussia-friedenstal"
+      "cf-pachuca"
     ]
-  },
-  {
-    "id": "punjab-stadium",
-    "name": "Punjab Stadium",
-    "city": null,
-    "countryCode": "PAK",
-    "capacity": 30000,
-    "tenantClubs": [
-      "wapda-f-c"
-    ]
-  },
-  {
-    "id": "jawahar-municipal-stadium",
-    "name": "Jawahar Municipal Stadium",
-    "city": "Kannur",
-    "countryCode": "IND",
-    "capacity": 30000,
-    "tenantClubs": []
-  },
-  {
-    "id": "stade-ahmed-kaid",
-    "name": "Stade Ahmed Kaïd",
-    "city": null,
-    "countryCode": "DZA",
-    "capacity": 30000,
-    "tenantClubs": [
-      "jsm-tiaret"
-    ]
-  },
-  {
-    "id": "jeonju-sports-complex",
-    "name": "Jeonju Sports Complex",
-    "city": null,
-    "countryCode": "KOR",
-    "capacity": 30000,
-    "tenantClubs": []
-  },
-  {
-    "id": "1-november-1954-stadium",
-    "name": "1 November 1954 Stadium",
-    "city": null,
-    "countryCode": "DZA",
-    "capacity": 30000,
-    "tenantClubs": [
-      "js-kabylie"
-    ]
-  },
-  {
-    "id": "mianyang-stadium",
-    "name": "Mianyang Stadium",
-    "city": null,
-    "countryCode": "CHN",
-    "capacity": 30000,
-    "tenantClubs": []
-  },
-  {
-    "id": "yuvileiny-stadium",
-    "name": "Yuvileiny Stadium",
-    "city": null,
-    "countryCode": "UKR",
-    "capacity": 30000,
-    "tenantClubs": [
-      "fc-spartak-sumy"
-    ]
-  },
-  {
-    "id": "stade-de-l-unite-africaine",
-    "name": "Stade de l'Unité Africaine",
-    "city": null,
-    "countryCode": "DZA",
-    "capacity": 30000,
-    "tenantClubs": [
-      "ghali-chabab-mascara"
-    ]
-  },
-  {
-    "id": "fujian-provincial-sports-centre-stadium",
-    "name": "Fujian Provincial Sports Centre Stadium",
-    "city": null,
-    "countryCode": "CHN",
-    "capacity": 30000,
-    "tenantClubs": []
-  },
-  {
-    "id": "independence-stadium-zmb",
-    "name": "Independence Stadium",
-    "city": null,
-    "countryCode": "ZMB",
-    "capacity": 30000,
-    "tenantClubs": [
-      "zambia-men-s-national-football-team"
-    ]
-  },
-  {
-    "id": "estadio-unico-madre-de-ciudades",
-    "name": "Estadio Único Madre de Ciudades",
-    "city": "Santiago del Estero",
-    "countryCode": "ARG",
-    "capacity": 30000,
-    "tenantClubs": [
-      "central-cordoba-de-santiago-del-estero",
-      "club-atletico-guemes",
-      "club-atletico-mitre"
-    ]
-  },
-  {
-    "id": "yiyang-stadium",
-    "name": "Yiyang Stadium",
-    "city": "Yiyang",
-    "countryCode": "CHN",
-    "capacity": 30000,
-    "tenantClubs": []
   },
   {
     "id": "corona-stadium",
@@ -9971,13 +9762,24 @@
     ]
   },
   {
-    "id": "shahid-shiroudi-stadium",
-    "name": "Shahid Shiroudi Stadium",
+    "id": "independence-stadium-zmb",
+    "name": "Independence Stadium",
     "city": null,
-    "countryCode": "IRN",
+    "countryCode": "ZMB",
     "capacity": 30000,
     "tenantClubs": [
-      "iran-men-s-national-football-team"
+      "zambia-men-s-national-football-team"
+    ]
+  },
+  {
+    "id": "althawra-sports-city-stadium",
+    "name": "Althawra Sports City Stadium",
+    "city": null,
+    "countryCode": "YEM",
+    "capacity": 30000,
+    "tenantClubs": [
+      "al-ahli-club-sana-a",
+      "yemen-men-s-national-football-team"
     ]
   },
   {
@@ -9987,16 +9789,6 @@
     "countryCode": "CHN",
     "capacity": 30000,
     "tenantClubs": []
-  },
-  {
-    "id": "sarusajai-stadium-guwahati",
-    "name": "Sarusajai Stadium (Guwahati)",
-    "city": null,
-    "countryCode": "IND",
-    "capacity": 30000,
-    "tenantClubs": [
-      "guwahati-town-club"
-    ]
   },
   {
     "id": "brookland-stadium",
@@ -10010,229 +9802,6 @@
     ]
   },
   {
-    "id": "jinshan-sports-centre",
-    "name": "Jinshan Sports Centre",
-    "city": null,
-    "countryCode": "CHN",
-    "capacity": 30000,
-    "tenantClubs": [
-      "shanghai-shenxin-f-c"
-    ]
-  },
-  {
-    "id": "zhengzhou-hanghai-stadium",
-    "name": "Zhengzhou Hanghai Stadium",
-    "city": null,
-    "countryCode": "CHN",
-    "capacity": 30000,
-    "tenantClubs": [
-      "henan-f-c"
-    ]
-  },
-  {
-    "id": "ahmadu-bello-stadium",
-    "name": "Ahmadu Bello Stadium",
-    "city": null,
-    "countryCode": "NGA",
-    "capacity": 30000,
-    "tenantClubs": []
-  },
-  {
-    "id": "anji-arena",
-    "name": "Anji Arena",
-    "city": "Kaspiysk",
-    "countryCode": "RUS",
-    "capacity": 30000,
-    "tenantClubs": [
-      "fc-anzhi-makhachkala",
-      "fc-dynamo-makhachkala",
-      "fc-makhachkala"
-    ]
-  },
-  {
-    "id": "rizal-memorial-stadium",
-    "name": "Rizal Memorial Stadium",
-    "city": null,
-    "countryCode": "PHL",
-    "capacity": 30000,
-    "tenantClubs": [
-      "philippines-men-s-national-association-football-team"
-    ]
-  },
-  {
-    "id": "yangsan-stadium",
-    "name": "Yangsan Stadium",
-    "city": null,
-    "countryCode": "KOR",
-    "capacity": 30000,
-    "tenantClubs": []
-  },
-  {
-    "id": "taoyuan-city-stadium",
-    "name": "Taoyuan City Stadium",
-    "city": null,
-    "countryCode": "TWN",
-    "capacity": 30000,
-    "tenantClubs": []
-  },
-  {
-    "id": "takhti-stadium",
-    "name": "Takhti Stadium",
-    "city": null,
-    "countryCode": "IRN",
-    "capacity": 30000,
-    "tenantClubs": [
-      "foolad-f-c"
-    ]
-  },
-  {
-    "id": "mackay-stadium",
-    "name": "Mackay Stadium",
-    "city": "Reno",
-    "countryCode": "USA",
-    "capacity": 30000,
-    "tenantClubs": [
-      "nevada-wolf-pack",
-      "nevada-wolf-pack-football"
-    ]
-  },
-  {
-    "id": "olympic-stadium-tkm",
-    "name": "Olympic Stadium",
-    "city": null,
-    "countryCode": "TKM",
-    "capacity": 30000,
-    "tenantClubs": [
-      "turkmenistan-men-s-national-football-team"
-    ]
-  },
-  {
-    "id": "tainan-county-stadium",
-    "name": "Tainan County Stadium",
-    "city": null,
-    "countryCode": "TWN",
-    "capacity": 30000,
-    "tenantClubs": []
-  },
-  {
-    "id": "dazhou-xiwai-stadium",
-    "name": "Dazhou Xiwai Stadium",
-    "city": null,
-    "countryCode": "CHN",
-    "capacity": 30000,
-    "tenantClubs": []
-  },
-  {
-    "id": "estadio-fredis-saldivar",
-    "name": "Estádio Fredis Saldívar",
-    "city": "Dourados",
-    "countryCode": "BRA",
-    "capacity": 30000,
-    "tenantClubs": [
-      "clube-desportivo-sete-de-setembro"
-    ]
-  },
-  {
-    "id": "iowa-field",
-    "name": "Iowa Field",
-    "city": null,
-    "countryCode": "USA",
-    "capacity": 30000,
-    "tenantClubs": [
-      "iowa-hawkeyes-football"
-    ]
-  },
-  {
-    "id": "hassanal-bolkiah-national-stadium",
-    "name": "Hassanal Bolkiah National Stadium",
-    "city": null,
-    "countryCode": "BRN",
-    "capacity": 30000,
-    "tenantClubs": [
-      "brunei-men-s-national-football-team"
-    ]
-  },
-  {
-    "id": "al-mina-a-stadium",
-    "name": "Al Mina'a Stadium",
-    "city": null,
-    "countryCode": "IRQ",
-    "capacity": 30000,
-    "tenantClubs": [
-      "al-mina-a-sc"
-    ]
-  },
-  {
-    "id": "iwate-athletic-stadium",
-    "name": "Iwate Athletic Stadium",
-    "city": "Morioka",
-    "countryCode": "JPN",
-    "capacity": 30000,
-    "tenantClubs": []
-  },
-  {
-    "id": "tengzhou-olympic-center-stadium",
-    "name": "Tengzhou Olympic Center Stadium",
-    "city": null,
-    "countryCode": "CHN",
-    "capacity": 30000,
-    "tenantClubs": []
-  },
-  {
-    "id": "may-22-stadium",
-    "name": "May 22 Stadium",
-    "city": null,
-    "countryCode": "YEM",
-    "capacity": 30000,
-    "tenantClubs": []
-  },
-  {
-    "id": "stade-of-1st-november-1954",
-    "name": "Stade of 1st November 1954",
-    "city": null,
-    "countryCode": "DZA",
-    "capacity": 30000,
-    "tenantClubs": [
-      "ca-batna"
-    ]
-  },
-  {
-    "id": "maharaja-college-stadium",
-    "name": "Maharaja College Stadium",
-    "city": "Kochi",
-    "countryCode": "IND",
-    "capacity": 30000,
-    "tenantClubs": [
-      "maharaja-s-college"
-    ]
-  },
-  {
-    "id": "du-stadium",
-    "name": "DU Stadium",
-    "city": "University of Denver",
-    "countryCode": "USA",
-    "capacity": 30000,
-    "tenantClubs": [
-      "denver-pioneers"
-    ]
-  },
-  {
-    "id": "mgr-race-course-stadium",
-    "name": "MGR Race Course Stadium",
-    "city": null,
-    "countryCode": "IND",
-    "capacity": 30000,
-    "tenantClubs": []
-  },
-  {
-    "id": "east-pyongyang-stadium",
-    "name": "East Pyongyang Stadium",
-    "city": null,
-    "countryCode": "PRK",
-    "capacity": 30000,
-    "tenantClubs": []
-  },
-  {
     "id": "infocision-stadium-summa-field",
     "name": "InfoCision Stadium – Summa Field",
     "city": "Akron",
@@ -10244,103 +9813,65 @@
     ]
   },
   {
-    "id": "zayyarthiri-stadium",
-    "name": "Zayyarthiri Stadium",
-    "city": "Naypyidaw",
-    "countryCode": "MMR",
+    "id": "iwate-athletic-stadium",
+    "name": "Iwate Athletic Stadium",
+    "city": "Morioka",
+    "countryCode": "JPN",
+    "capacity": 30000,
+    "tenantClubs": []
+  },
+  {
+    "id": "30-june-stadium",
+    "name": "30 June Stadium",
+    "city": "Cairo",
+    "countryCode": "EGY",
+    "capacity": 30000,
+    "tenantClubs": []
+  },
+  {
+    "id": "changzhi-stadium",
+    "name": "Changzhi Stadium",
+    "city": null,
+    "countryCode": "CHN",
+    "capacity": 30000,
+    "tenantClubs": []
+  },
+  {
+    "id": "hengyang-stadium",
+    "name": "Hengyang Stadium",
+    "city": null,
+    "countryCode": "CHN",
+    "capacity": 30000,
+    "tenantClubs": []
+  },
+  {
+    "id": "gelora-10-november-stadium",
+    "name": "Gelora 10 November Stadium",
+    "city": "Surabaya",
+    "countryCode": "IDN",
     "capacity": 30000,
     "tenantClubs": [
-      "2013-southeast-asian-games"
+      "persebaya-surabaya"
     ]
   },
   {
-    "id": "najaf-stadium",
-    "name": "Najaf Stadium",
-    "city": "Najaf",
-    "countryCode": "IRQ",
-    "capacity": 30000,
-    "tenantClubs": [
-      "najaf-fc"
-    ]
-  },
-  {
-    "id": "pakansari-stadium",
-    "name": "Pakansari Stadium",
+    "id": "indomilk-arena",
+    "name": "Indomilk Arena",
     "city": null,
     "countryCode": "IDN",
     "capacity": 30000,
     "tenantClubs": []
   },
   {
-    "id": "stade-balibie",
-    "name": "Stade Balibiè",
-    "city": null,
-    "countryCode": "BFA",
-    "capacity": 30000,
-    "tenantClubs": [
-      "asec-koudougou"
-    ]
-  },
-  {
-    "id": "new-minaa-stadium",
-    "name": "New Minaa Stadium",
-    "city": "Basra",
-    "countryCode": "IRQ",
-    "capacity": 30000,
-    "tenantClubs": []
-  },
-  {
-    "id": "chiba-sports-center-stadium",
-    "name": "Chiba Sports Center Stadium",
-    "city": "Chiba",
+    "id": "kawasaki-stadium",
+    "name": "Kawasaki Stadium",
+    "city": "Kawasaki",
     "countryCode": "JPN",
     "capacity": 30000,
-    "tenantClubs": []
-  },
-  {
-    "id": "stade-lumumba",
-    "name": "Stade Lumumba",
-    "city": null,
-    "countryCode": "COD",
-    "capacity": 30000,
     "tenantClubs": [
-      "as-nika"
-    ]
-  },
-  {
-    "id": "sultan-mohammad-iv-stadium",
-    "name": "Sultan Mohammad IV Stadium",
-    "city": null,
-    "countryCode": "MYS",
-    "capacity": 30000,
-    "tenantClubs": [
-      "kelantan-f-c"
-    ]
-  },
-  {
-    "id": "war-heroes-stadium",
-    "name": "War Heroes Stadium",
-    "city": null,
-    "countryCode": "IND",
-    "capacity": 30000,
-    "tenantClubs": []
-  },
-  {
-    "id": "lake-placid-equestrian-stadium",
-    "name": "Lake Placid Equestrian Stadium",
-    "city": "Lake Placid",
-    "countryCode": "USA",
-    "capacity": 30000,
-    "tenantClubs": []
-  },
-  {
-    "id": "dasarath-rangasala-stadium",
-    "name": "Dasarath Rangasala Stadium",
-    "city": null,
-    "countryCode": "NPL",
-    "capacity": 30000,
-    "tenantClubs": [
-      "nepal-men-s-national-football-team"
+      "chiba-lotte-marines",
+      "takahashi-unions",
+      "yokohama-dena-baystars"
     ]
   },
   {
@@ -10348,40 +9879,6 @@
     "name": "Olympia Park",
     "city": null,
     "countryCode": "ZAF",
-    "capacity": 30000,
-    "tenantClubs": []
-  },
-  {
-    "id": "nehru-stadium-coimbatore",
-    "name": "Nehru Stadium, Coimbatore",
-    "city": "Coimbatore",
-    "countryCode": "IND",
-    "capacity": 30000,
-    "tenantClubs": []
-  },
-  {
-    "id": "kusanagi-stadium",
-    "name": "Kusanagi Stadium",
-    "city": null,
-    "countryCode": "JPN",
-    "capacity": 30000,
-    "tenantClubs": []
-  },
-  {
-    "id": "gorda-hilda",
-    "name": "Gorda hilda",
-    "city": "Pachuca",
-    "countryCode": "MEX",
-    "capacity": 30000,
-    "tenantClubs": [
-      "cf-pachuca"
-    ]
-  },
-  {
-    "id": "gwangmyeong-velodrome",
-    "name": "Gwangmyeong Velodrome",
-    "city": "Gwangmyeong",
-    "countryCode": "KOR",
     "capacity": 30000,
     "tenantClubs": []
   },
@@ -10396,6 +9893,448 @@
     ]
   },
   {
+    "id": "niigata-prefectural-baseball-stadium",
+    "name": "Niigata Prefectural Baseball Stadium",
+    "city": "Niigata",
+    "countryCode": "JPN",
+    "capacity": 30000,
+    "tenantClubs": [
+      "oisix-niigata-albirex-baseball-club"
+    ]
+  },
+  {
+    "id": "kidd-brewer-stadium",
+    "name": "Kidd Brewer Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 30000,
+    "tenantClubs": [
+      "appalachian-state-mountaineers",
+      "appalachian-state-mountaineers-football"
+    ]
+  },
+  {
+    "id": "war-heroes-stadium",
+    "name": "War Heroes Stadium",
+    "city": null,
+    "countryCode": "IND",
+    "capacity": 30000,
+    "tenantClubs": []
+  },
+  {
+    "id": "dasarath-rangasala-stadium",
+    "name": "Dasarath Rangasala Stadium",
+    "city": null,
+    "countryCode": "NPL",
+    "capacity": 30000,
+    "tenantClubs": [
+      "nepal-men-s-national-football-team"
+    ]
+  },
+  {
+    "id": "estadio-15-de-abril",
+    "name": "Estadio 15 de Abril",
+    "city": null,
+    "countryCode": "ARG",
+    "capacity": 30000,
+    "tenantClubs": [
+      "union-de-santa-fe"
+    ]
+  },
+  {
+    "id": "najaf-stadium",
+    "name": "Najaf Stadium",
+    "city": "Najaf",
+    "countryCode": "IRQ",
+    "capacity": 30000,
+    "tenantClubs": [
+      "najaf-fc"
+    ]
+  },
+  {
+    "id": "new-minaa-stadium",
+    "name": "New Minaa Stadium",
+    "city": "Basra",
+    "countryCode": "IRQ",
+    "capacity": 30000,
+    "tenantClubs": []
+  },
+  {
+    "id": "zozo-marine-stadium",
+    "name": "ZOZO Marine Stadium",
+    "city": "Chiba",
+    "countryCode": "JPN",
+    "capacity": 30000,
+    "tenantClubs": [
+      "chiba-lotte-marines",
+      "pacific-league"
+    ]
+  },
+  {
+    "id": "estadio-doroteo-guamuch-flores",
+    "name": "Estadio Doroteo Guamuch Flores",
+    "city": null,
+    "countryCode": "GTM",
+    "capacity": 30000,
+    "tenantClubs": [
+      "guatemala-men-s-national-football-team"
+    ]
+  },
+  {
+    "id": "estadio-daniel-villa-zapata",
+    "name": "Estadio Daniel Villa Zapata",
+    "city": null,
+    "countryCode": "COL",
+    "capacity": 30000,
+    "tenantClubs": [
+      "alianza-petrolera-f-c"
+    ]
+  },
+  {
+    "id": "abebe-bikila-stadium",
+    "name": "Abebe Bikila Stadium",
+    "city": null,
+    "countryCode": "ETH",
+    "capacity": 30000,
+    "tenantClubs": [
+      "dedebit"
+    ]
+  },
+  {
+    "id": "iowa-field",
+    "name": "Iowa Field",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 30000,
+    "tenantClubs": [
+      "iowa-hawkeyes-football"
+    ]
+  },
+  {
+    "id": "jawaharlal-nehru-stadium-shillong",
+    "name": "Jawaharlal Nehru Stadium, Shillong",
+    "city": "Shillong",
+    "countryCode": "IND",
+    "capacity": 30000,
+    "tenantClubs": [
+      "shillong-lajong-f-c"
+    ]
+  },
+  {
+    "id": "mgr-race-course-stadium",
+    "name": "MGR Race Course Stadium",
+    "city": null,
+    "countryCode": "IND",
+    "capacity": 30000,
+    "tenantClubs": []
+  },
+  {
+    "id": "lal-bahadur-shastri-stadium-kollam",
+    "name": "Lal Bahadur Shastri Stadium (Kollam)",
+    "city": "Kollam",
+    "countryCode": "IND",
+    "capacity": 30000,
+    "tenantClubs": []
+  },
+  {
+    "id": "stade-de-la-reunification",
+    "name": "Stade de la Réunification",
+    "city": null,
+    "countryCode": "CMR",
+    "capacity": 30000,
+    "tenantClubs": [
+      "union-douala"
+    ]
+  },
+  {
+    "id": "maharaja-college-stadium",
+    "name": "Maharaja College Stadium",
+    "city": "Kochi",
+    "countryCode": "IND",
+    "capacity": 30000,
+    "tenantClubs": [
+      "maharaja-s-college"
+    ]
+  },
+  {
+    "id": "sarusajai-stadium-guwahati",
+    "name": "Sarusajai Stadium (Guwahati)",
+    "city": null,
+    "countryCode": "IND",
+    "capacity": 30000,
+    "tenantClubs": [
+      "guwahati-town-club"
+    ]
+  },
+  {
+    "id": "yashwant-stadium",
+    "name": "Yashwant Stadium",
+    "city": null,
+    "countryCode": "IND",
+    "capacity": 30000,
+    "tenantClubs": []
+  },
+  {
+    "id": "jawahar-municipal-stadium",
+    "name": "Jawahar Municipal Stadium",
+    "city": "Kannur",
+    "countryCode": "IND",
+    "capacity": 30000,
+    "tenantClubs": []
+  },
+  {
+    "id": "mianyang-stadium",
+    "name": "Mianyang Stadium",
+    "city": null,
+    "countryCode": "CHN",
+    "capacity": 30000,
+    "tenantClubs": []
+  },
+  {
+    "id": "jinshan-sports-centre",
+    "name": "Jinshan Sports Centre",
+    "city": null,
+    "countryCode": "CHN",
+    "capacity": 30000,
+    "tenantClubs": [
+      "shanghai-shenxin-f-c"
+    ]
+  },
+  {
+    "id": "du-stadium",
+    "name": "DU Stadium",
+    "city": "Denver",
+    "countryCode": "USA",
+    "capacity": 30000,
+    "tenantClubs": [
+      "denver-pioneers"
+    ]
+  },
+  {
+    "id": "east-pyongyang-stadium",
+    "name": "East Pyongyang Stadium",
+    "city": null,
+    "countryCode": "PRK",
+    "capacity": 30000,
+    "tenantClubs": []
+  },
+  {
+    "id": "cangzhou-stadium",
+    "name": "Cangzhou Stadium",
+    "city": null,
+    "countryCode": "CHN",
+    "capacity": 30000,
+    "tenantClubs": []
+  },
+  {
+    "id": "dazhou-xiwai-stadium",
+    "name": "Dazhou Xiwai Stadium",
+    "city": null,
+    "countryCode": "CHN",
+    "capacity": 30000,
+    "tenantClubs": []
+  },
+  {
+    "id": "bakhshi-stadium",
+    "name": "Bakhshi Stadium",
+    "city": "Srinagar",
+    "countryCode": "IND",
+    "capacity": 30000,
+    "tenantClubs": []
+  },
+  {
+    "id": "nyayo-national-stadium",
+    "name": "Nyayo National Stadium",
+    "city": null,
+    "countryCode": "KEN",
+    "capacity": 30000,
+    "tenantClubs": [
+      "a-f-c-leopards"
+    ]
+  },
+  {
+    "id": "chiba-sports-center-stadium",
+    "name": "Chiba Sports Center Stadium",
+    "city": "Chiba",
+    "countryCode": "JPN",
+    "capacity": 30000,
+    "tenantClubs": []
+  },
+  {
+    "id": "kiyohara-baseball-stadium",
+    "name": "Kiyohara Baseball Stadium",
+    "city": null,
+    "countryCode": "JPN",
+    "capacity": 30000,
+    "tenantClubs": []
+  },
+  {
+    "id": "volkswagen-arena",
+    "name": "Volkswagen Arena",
+    "city": null,
+    "countryCode": "DEU",
+    "capacity": 30000,
+    "tenantClubs": [
+      "vfl-wolfsburg"
+    ]
+  },
+  {
+    "id": "hanazono-rugby-stadium",
+    "name": "Hanazono Rugby Stadium",
+    "city": "Higashiōsaka-shi",
+    "countryCode": "JPN",
+    "capacity": 30000,
+    "tenantClubs": [
+      "fc-osaka",
+      "hanazono-kintetsu-liners"
+    ]
+  },
+  {
+    "id": "zayyarthiri-stadium",
+    "name": "Zayyarthiri Stadium",
+    "city": "Naypyidaw",
+    "countryCode": "MMR",
+    "capacity": 30000,
+    "tenantClubs": [
+      "2013-southeast-asian-games"
+    ]
+  },
+  {
+    "id": "tan-sri-dato-haji-hassan-yunos-stadium",
+    "name": "Tan Sri Dato Haji Hassan Yunos Stadium",
+    "city": null,
+    "countryCode": "MYS",
+    "capacity": 30000,
+    "tenantClubs": [
+      "johor-darul-takzim-f-c"
+    ]
+  },
+  {
+    "id": "mount-smart-stadium",
+    "name": "Mount Smart Stadium",
+    "city": null,
+    "countryCode": "NZL",
+    "capacity": 30000,
+    "tenantClubs": [
+      "moana-pasifika",
+      "new-zealand-warriors"
+    ]
+  },
+  {
+    "id": "paljor-stadium",
+    "name": "Paljor Stadium",
+    "city": "Gangtok",
+    "countryCode": "IND",
+    "capacity": 30000,
+    "tenantClubs": [
+      "united-sikkim-f-c"
+    ]
+  },
+  {
+    "id": "sailen-manna-stadium",
+    "name": "Sailen Manna Stadium",
+    "city": null,
+    "countryCode": "IND",
+    "capacity": 30000,
+    "tenantClubs": []
+  },
+  {
+    "id": "salah-al-din-stadium",
+    "name": "Salah Al Din Stadium",
+    "city": null,
+    "countryCode": "IRQ",
+    "capacity": 30000,
+    "tenantClubs": []
+  },
+  {
+    "id": "william-dick-price-stadium",
+    "name": "William \"Dick\" Price Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 30000,
+    "tenantClubs": [
+      "norfolk-state-spartans-football"
+    ]
+  },
+  {
+    "id": "al-salam-stadium",
+    "name": "Al Salam Stadium",
+    "city": null,
+    "countryCode": "EGY",
+    "capacity": 30000,
+    "tenantClubs": [
+      "al-ahly-sc",
+      "el-entag-el-harby"
+    ]
+  },
+  {
+    "id": "konoike-athletic-stadium",
+    "name": "Kōnoike Athletic Stadium",
+    "city": null,
+    "countryCode": "JPN",
+    "capacity": 30000,
+    "tenantClubs": [
+      "nara-club"
+    ]
+  },
+  {
+    "id": "gwangmyeong-velodrome",
+    "name": "Gwangmyeong Velodrome",
+    "city": "Gwangmyeong",
+    "countryCode": "KOR",
+    "capacity": 30000,
+    "tenantClubs": []
+  },
+  {
+    "id": "estadio-fredis-saldivar",
+    "name": "Estádio Fredis Saldívar",
+    "city": "Dourados",
+    "countryCode": "BRA",
+    "capacity": 30000,
+    "tenantClubs": [
+      "clube-desportivo-sete-de-setembro"
+    ]
+  },
+  {
+    "id": "estadio-olimpico-colosso-da-lagoa",
+    "name": "Estádio Olímpico Colosso da Lagoa",
+    "city": null,
+    "countryCode": "BRA",
+    "capacity": 30000,
+    "tenantClubs": [
+      "ypiranga-futebol-clube"
+    ]
+  },
+  {
+    "id": "estadio-nacional-mexico",
+    "name": "Estadio Nacional (Mexico)",
+    "city": "Mexico City",
+    "countryCode": "MEX",
+    "capacity": 30000,
+    "tenantClubs": [
+      "1926-central-american-and-caribbean-games"
+    ]
+  },
+  {
+    "id": "mackay-stadium",
+    "name": "Mackay Stadium",
+    "city": "Reno",
+    "countryCode": "USA",
+    "capacity": 30000,
+    "tenantClubs": [
+      "nevada-wolf-pack",
+      "nevada-wolf-pack-football"
+    ]
+  },
+  {
+    "id": "kamoike-ballpark",
+    "name": "Kamoike Ballpark",
+    "city": "Kagoshima",
+    "countryCode": "JPN",
+    "capacity": 30000,
+    "tenantClubs": []
+  },
+  {
     "id": "metalurh-stadium",
     "name": "Metalurh Stadium",
     "city": "Kryvyi Rih",
@@ -10408,7 +10347,7 @@
   {
     "id": "estadio-cidade-de-coimbra",
     "name": "Estádio Cidade de Coimbra",
-    "city": "Coimbra",
+    "city": null,
     "countryCode": "PRT",
     "capacity": 29622,
     "tenantClubs": [
@@ -10418,7 +10357,7 @@
   {
     "id": "millerntor-stadion",
     "name": "Millerntor-Stadion",
-    "city": "St. Pauli",
+    "city": "Hamburg",
     "countryCode": "DEU",
     "capacity": 29546,
     "tenantClubs": [
@@ -10451,7 +10390,7 @@
   {
     "id": "el-molinon-enrique-castro-quini",
     "name": "El Molinón-Enrique Castro Quini",
-    "city": "Gijón",
+    "city": null,
     "countryCode": "ESP",
     "capacity": 29371,
     "tenantClubs": [
@@ -10502,7 +10441,7 @@
   {
     "id": "veb-arena",
     "name": "VEB Arena",
-    "city": "Khodynka Field",
+    "city": "Moscow",
     "countryCode": "RUS",
     "capacity": 29071,
     "tenantClubs": [
@@ -10512,7 +10451,7 @@
   {
     "id": "jan-breydel-stadium",
     "name": "Jan Breydel Stadium",
-    "city": "Sint-Andries",
+    "city": "Bruges",
     "countryCode": "BEL",
     "capacity": 29062,
     "tenantClubs": [
@@ -10529,6 +10468,16 @@
     "capacity": 29001,
     "tenantClubs": [
       "chiapas-f-c"
+    ]
+  },
+  {
+    "id": "br-ndby-stadium",
+    "name": "Brøndby Stadium",
+    "city": null,
+    "countryCode": "DNK",
+    "capacity": 29000,
+    "tenantClubs": [
+      "br-ndby-if"
     ]
   },
   {
@@ -10549,16 +10498,6 @@
     "capacity": 29000,
     "tenantClubs": [
       "deportes-quindio"
-    ]
-  },
-  {
-    "id": "br-ndby-stadium",
-    "name": "Brøndby Stadium",
-    "city": "Brøndbyvester",
-    "countryCode": "DNK",
-    "capacity": 29000,
-    "tenantClubs": [
-      "br-ndby-if"
     ]
   },
   {
@@ -10626,7 +10565,7 @@
   {
     "id": "city-of-vicente-lopez-stadium",
     "name": "City of Vicente López Stadium",
-    "city": "Florida",
+    "city": null,
     "countryCode": "ARG",
     "capacity": 28530,
     "tenantClubs": [
@@ -10707,13 +10646,33 @@
     ]
   },
   {
-    "id": "chi-lang-stadium",
-    "name": "Chi Lang Stadium",
-    "city": null,
-    "countryCode": "VNM",
+    "id": "stadion-eto",
+    "name": "Stadion ETO",
+    "city": "Győr",
+    "countryCode": "HUN",
     "capacity": 28000,
     "tenantClubs": [
-      "shb-da-nang-f-c"
+      "gyori-eto-fc"
+    ]
+  },
+  {
+    "id": "gopalganj-international-cricket-stadium",
+    "name": "Gopalganj International Cricket Stadium",
+    "city": null,
+    "countryCode": "BGD",
+    "capacity": 28000,
+    "tenantClubs": [
+      "bangladesh-national-cricket-team"
+    ]
+  },
+  {
+    "id": "schwelgernstadion",
+    "name": "Schwelgernstadion",
+    "city": null,
+    "countryCode": "DEU",
+    "capacity": 28000,
+    "tenantClubs": [
+      "q1264251"
     ]
   },
   {
@@ -10727,6 +10686,16 @@
     ]
   },
   {
+    "id": "chi-lang-stadium",
+    "name": "Chi Lang Stadium",
+    "city": null,
+    "countryCode": "VNM",
+    "capacity": 28000,
+    "tenantClubs": [
+      "shb-da-nang-f-c"
+    ]
+  },
+  {
     "id": "kensington-oval",
     "name": "Kensington Oval",
     "city": null,
@@ -10737,42 +10706,12 @@
     ]
   },
   {
-    "id": "nicosia-ataturk-stadium",
-    "name": "Nicosia Atatürk Stadium",
+    "id": "kusanagi-athletic-stadium",
+    "name": "Kusanagi Athletic Stadium",
     "city": null,
-    "countryCode": "CYP",
-    "capacity": 28000,
-    "tenantClubs": [
-      "cetinkaya-turk-s-k"
-    ]
-  },
-  {
-    "id": "estadio-unico-de-villa-mercedes",
-    "name": "Estadio Único de Villa Mercedes",
-    "city": null,
-    "countryCode": "ARG",
+    "countryCode": "JPN",
     "capacity": 28000,
     "tenantClubs": []
-  },
-  {
-    "id": "schwelgernstadion",
-    "name": "Schwelgernstadion",
-    "city": null,
-    "countryCode": "DEU",
-    "capacity": 28000,
-    "tenantClubs": [
-      "q1264251"
-    ]
-  },
-  {
-    "id": "gopalganj-international-cricket-stadium",
-    "name": "Gopalganj International Cricket Stadium",
-    "city": "Gopalganj District",
-    "countryCode": "BGD",
-    "capacity": 28000,
-    "tenantClubs": [
-      "bangladesh-national-cricket-team"
-    ]
   },
   {
     "id": "rosenaustadion",
@@ -10782,6 +10721,16 @@
     "capacity": 28000,
     "tenantClubs": [
       "fc-augsburg"
+    ]
+  },
+  {
+    "id": "lach-tray-stadium",
+    "name": "Lạch Tray Stadium",
+    "city": null,
+    "countryCode": "VNM",
+    "capacity": 28000,
+    "tenantClubs": [
+      "haiphong-football-club"
     ]
   },
   {
@@ -10795,48 +10744,10 @@
     ]
   },
   {
-    "id": "estadio-1-de-maio",
-    "name": "Estádio 1º de Maio",
-    "city": "São José de São Lázaro",
-    "countryCode": "PRT",
-    "capacity": 28000,
-    "tenantClubs": []
-  },
-  {
-    "id": "lach-tray-stadium",
-    "name": "Lạch Tray Stadium",
+    "id": "estadio-unico-de-villa-mercedes",
+    "name": "Estadio Único de Villa Mercedes",
     "city": null,
-    "countryCode": "VNM",
-    "capacity": 28000,
-    "tenantClubs": [
-      "haiphong-football-club"
-    ]
-  },
-  {
-    "id": "stadion-eto",
-    "name": "Stadion ETO",
-    "city": "Győr",
-    "countryCode": "HUN",
-    "capacity": 28000,
-    "tenantClubs": [
-      "gyori-eto-fc"
-    ]
-  },
-  {
-    "id": "stadionul-republicii",
-    "name": "Stadionul Republicii",
-    "city": null,
-    "countryCode": "ROU",
-    "capacity": 28000,
-    "tenantClubs": [
-      "romania-men-s-national-association-football-team"
-    ]
-  },
-  {
-    "id": "kusanagi-athletic-stadium",
-    "name": "Kusanagi Athletic Stadium",
-    "city": null,
-    "countryCode": "JPN",
+    "countryCode": "ARG",
     "capacity": 28000,
     "tenantClubs": []
   },
@@ -10853,6 +10764,34 @@
     ]
   },
   {
+    "id": "estadio-1-de-maio",
+    "name": "Estádio 1º de Maio",
+    "city": null,
+    "countryCode": "PRT",
+    "capacity": 28000,
+    "tenantClubs": []
+  },
+  {
+    "id": "stadionul-republicii",
+    "name": "Stadionul Republicii",
+    "city": null,
+    "countryCode": "ROU",
+    "capacity": 28000,
+    "tenantClubs": [
+      "romania-men-s-national-association-football-team"
+    ]
+  },
+  {
+    "id": "nicosia-ataturk-stadium",
+    "name": "Nicosia Atatürk Stadium",
+    "city": null,
+    "countryCode": "CYP",
+    "capacity": 28000,
+    "tenantClubs": [
+      "cetinkaya-turk-s-k"
+    ]
+  },
+  {
     "id": "princeton-university-stadium",
     "name": "Princeton University Stadium",
     "city": null,
@@ -10861,6 +10800,16 @@
     "tenantClubs": [
       "princeton-tigers",
       "princeton-tigers-football"
+    ]
+  },
+  {
+    "id": "central-stadium-rus-2",
+    "name": "Central Stadium",
+    "city": null,
+    "countryCode": "RUS",
+    "capacity": 27756,
+    "tenantClubs": [
+      "rubin-kazan"
     ]
   },
   {
@@ -10938,7 +10887,7 @@
   {
     "id": "robina-stadium",
     "name": "Robina Stadium",
-    "city": "Robina",
+    "city": null,
     "countryCode": "AUS",
     "capacity": 27400,
     "tenantClubs": [
@@ -11010,7 +10959,7 @@
   {
     "id": "the-valley",
     "name": "The Valley",
-    "city": "Charlton",
+    "city": null,
     "countryCode": "GBR",
     "capacity": 27111,
     "tenantClubs": [
@@ -11028,42 +10977,12 @@
     "tenantClubs": []
   },
   {
-    "id": "hasely-crawford-stadium",
-    "name": "Hasely Crawford Stadium",
-    "city": "Port of Spain",
-    "countryCode": "TTO",
-    "capacity": 27000,
-    "tenantClubs": [
-      "defence-force-f-c"
-    ]
-  },
-  {
     "id": "sportplatz-at-rothenbaum",
     "name": "Sportplatz at Rothenbaum",
-    "city": "Harvestehude",
+    "city": "Hamburg",
     "countryCode": "DEU",
     "capacity": 27000,
     "tenantClubs": []
-  },
-  {
-    "id": "si-jalak-harupat-stadium",
-    "name": "Si Jalak Harupat Stadium",
-    "city": null,
-    "countryCode": "IDN",
-    "capacity": 27000,
-    "tenantClubs": [
-      "persikab-bandung"
-    ]
-  },
-  {
-    "id": "estadio-de-beisbol-monterrey",
-    "name": "Estadio de Béisbol Monterrey",
-    "city": null,
-    "countryCode": "MEX",
-    "capacity": 27000,
-    "tenantClubs": [
-      "sultanes-de-monterrey"
-    ]
   },
   {
     "id": "mizuho-athletic-stadium",
@@ -11073,27 +10992,6 @@
     "capacity": 27000,
     "tenantClubs": [
       "nagoya-grampus"
-    ]
-  },
-  {
-    "id": "prince-abdullah-al-faisal-sports-city",
-    "name": "Prince Abdullah Al Faisal Sports City",
-    "city": "Jeddah",
-    "countryCode": "SAU",
-    "capacity": 27000,
-    "tenantClubs": [
-      "al-ahli-fc",
-      "al-ittihad-fc"
-    ]
-  },
-  {
-    "id": "estadio-nacional-de-panama",
-    "name": "Estadio Nacional de Panamá",
-    "city": null,
-    "countryCode": "PAN",
-    "capacity": 27000,
-    "tenantClubs": [
-      "q2931080"
     ]
   },
   {
@@ -11108,13 +11006,31 @@
     ]
   },
   {
-    "id": "carl-benz-stadion",
-    "name": "Carl-Benz-Stadion",
+    "id": "baoji-city-stadium",
+    "name": "Baoji City Stadium",
     "city": null,
-    "countryCode": "DEU",
+    "countryCode": "CHN",
+    "capacity": 27000,
+    "tenantClubs": []
+  },
+  {
+    "id": "si-jalak-harupat-stadium",
+    "name": "Si Jalak Harupat Stadium",
+    "city": null,
+    "countryCode": "IDN",
     "capacity": 27000,
     "tenantClubs": [
-      "sv-waldhof-mannheim"
+      "persikab-bandung"
+    ]
+  },
+  {
+    "id": "estadio-nacional-de-panama",
+    "name": "Estadio Nacional de Panamá",
+    "city": null,
+    "countryCode": "PAN",
+    "capacity": 27000,
+    "tenantClubs": [
+      "q2931080"
     ]
   },
   {
@@ -11128,12 +11044,45 @@
     ]
   },
   {
-    "id": "baoji-city-stadium",
-    "name": "Baoji City Stadium",
-    "city": null,
-    "countryCode": "CHN",
+    "id": "hasely-crawford-stadium",
+    "name": "Hasely Crawford Stadium",
+    "city": "Port of Spain",
+    "countryCode": "TTO",
     "capacity": 27000,
-    "tenantClubs": []
+    "tenantClubs": [
+      "defence-force-f-c"
+    ]
+  },
+  {
+    "id": "carl-benz-stadion",
+    "name": "Carl-Benz-Stadion",
+    "city": null,
+    "countryCode": "DEU",
+    "capacity": 27000,
+    "tenantClubs": [
+      "sv-waldhof-mannheim"
+    ]
+  },
+  {
+    "id": "prince-abdullah-al-faisal-sports-city",
+    "name": "Prince Abdullah Al Faisal Sports City",
+    "city": "Jeddah",
+    "countryCode": "SAU",
+    "capacity": 27000,
+    "tenantClubs": [
+      "al-ahli-fc",
+      "al-ittihad-fc"
+    ]
+  },
+  {
+    "id": "estadio-de-beisbol-monterrey",
+    "name": "Estadio de Béisbol Monterrey",
+    "city": null,
+    "countryCode": "MEX",
+    "capacity": 27000,
+    "tenantClubs": [
+      "sultanes-de-monterrey"
+    ]
   },
   {
     "id": "estadio-general-francisco-morazan",
@@ -11143,6 +11092,16 @@
     "capacity": 26781,
     "tenantClubs": [
       "real-c-d-espana"
+    ]
+  },
+  {
+    "id": "fargodome",
+    "name": "Fargodome",
+    "city": "Fargo",
+    "countryCode": "USA",
+    "capacity": 26700,
+    "tenantClubs": [
+      "north-dakota-state-bison-football"
     ]
   },
   {
@@ -11156,19 +11115,9 @@
     ]
   },
   {
-    "id": "fargodome",
-    "name": "Fargodome",
-    "city": "North Dakota State University",
-    "countryCode": "USA",
-    "capacity": 26700,
-    "tenantClubs": [
-      "north-dakota-state-bison-football"
-    ]
-  },
-  {
     "id": "nu-stadium",
     "name": "Nu Stadium",
-    "city": "Miami Freedom Park",
+    "city": "Miami",
     "countryCode": "USA",
     "capacity": 26700,
     "tenantClubs": [
@@ -11198,7 +11147,7 @@
   {
     "id": "estadio-de-chacarita-juniors",
     "name": "Estadio de Chacarita Juniors",
-    "city": "Villa Maipú",
+    "city": null,
     "countryCode": "ARG",
     "capacity": 26530,
     "tenantClubs": [
@@ -11213,26 +11162,6 @@
     "capacity": 26512,
     "tenantClubs": [
       "real-valladolid"
-    ]
-  },
-  {
-    "id": "tad-gormley-stadium",
-    "name": "Tad Gormley Stadium",
-    "city": null,
-    "countryCode": "USA",
-    "capacity": 26500,
-    "tenantClubs": [
-      "louisiana-high-school-athletic-association"
-    ]
-  },
-  {
-    "id": "malmo-stadion",
-    "name": "Malmö stadion",
-    "city": "Stadionområdet",
-    "countryCode": "SWE",
-    "capacity": 26500,
-    "tenantClubs": [
-      "malmo-ff"
     ]
   },
   {
@@ -11253,6 +11182,26 @@
     "capacity": 26500,
     "tenantClubs": [
       "munster-rugby"
+    ]
+  },
+  {
+    "id": "tad-gormley-stadium",
+    "name": "Tad Gormley Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 26500,
+    "tenantClubs": [
+      "louisiana-high-school-athletic-association"
+    ]
+  },
+  {
+    "id": "malmo-stadion",
+    "name": "Malmö stadion",
+    "city": null,
+    "countryCode": "SWE",
+    "capacity": 26500,
+    "tenantClubs": [
+      "malmo-ff"
     ]
   },
   {
@@ -11289,7 +11238,7 @@
   {
     "id": "selhurst-park",
     "name": "Selhurst Park",
-    "city": "Selhurst",
+    "city": null,
     "countryCode": "GBR",
     "capacity": 26255,
     "tenantClubs": [
@@ -11348,43 +11297,13 @@
     ]
   },
   {
-    "id": "kopetdag-stadium",
-    "name": "Köpetdag Stadium",
+    "id": "stadio-del-conero",
+    "name": "Stadio del Conero",
     "city": null,
-    "countryCode": "TKM",
+    "countryCode": "ITA",
     "capacity": 26000,
     "tenantClubs": [
-      "kopetdag-asgabat"
-    ]
-  },
-  {
-    "id": "estadio-nuevo-mirandilla",
-    "name": "Estadio Nuevo Mirandilla",
-    "city": null,
-    "countryCode": "ESP",
-    "capacity": 26000,
-    "tenantClubs": [
-      "cadiz-club-de-futbol"
-    ]
-  },
-  {
-    "id": "rabindra-sarobar-stadium",
-    "name": "Rabindra Sarobar Stadium",
-    "city": null,
-    "countryCode": "IND",
-    "capacity": 26000,
-    "tenantClubs": [
-      "tollygunge-agragami"
-    ]
-  },
-  {
-    "id": "tql-stadium",
-    "name": "TQL Stadium",
-    "city": null,
-    "countryCode": "USA",
-    "capacity": 26000,
-    "tenantClubs": [
-      "fc-cincinnati"
+      "ssc-ancona"
     ]
   },
   {
@@ -11398,6 +11317,52 @@
     ]
   },
   {
+    "id": "nanchang-bayi-stadium",
+    "name": "Nanchang Bayi Stadium",
+    "city": null,
+    "countryCode": "CHN",
+    "capacity": 26000,
+    "tenantClubs": []
+  },
+  {
+    "id": "estadio-nuevo-mirandilla",
+    "name": "Estadio Nuevo Mirandilla",
+    "city": null,
+    "countryCode": "ESP",
+    "capacity": 26000,
+    "tenantClubs": [
+      "cadiz-club-de-futbol"
+    ]
+  },
+  {
+    "id": "kopetdag-stadium",
+    "name": "Köpetdag Stadium",
+    "city": null,
+    "countryCode": "TKM",
+    "capacity": 26000,
+    "tenantClubs": [
+      "kopetdag-asgabat"
+    ]
+  },
+  {
+    "id": "osir-ska-ka",
+    "name": "OSiR Skałka",
+    "city": null,
+    "countryCode": "POL",
+    "capacity": 26000,
+    "tenantClubs": []
+  },
+  {
+    "id": "rabindra-sarobar-stadium",
+    "name": "Rabindra Sarobar Stadium",
+    "city": null,
+    "countryCode": "IND",
+    "capacity": 26000,
+    "tenantClubs": [
+      "tollygunge-agragami"
+    ]
+  },
+  {
     "id": "folsom-field",
     "name": "Folsom Field",
     "city": null,
@@ -11408,28 +11373,10 @@
     ]
   },
   {
-    "id": "stadio-del-conero",
-    "name": "Stadio del Conero",
+    "id": "cheonan-stadium",
+    "name": "Cheonan Stadium",
     "city": null,
-    "countryCode": "ITA",
-    "capacity": 26000,
-    "tenantClubs": [
-      "ssc-ancona"
-    ]
-  },
-  {
-    "id": "nanchang-bayi-stadium",
-    "name": "Nanchang Bayi Stadium",
-    "city": null,
-    "countryCode": "CHN",
-    "capacity": 26000,
-    "tenantClubs": []
-  },
-  {
-    "id": "osir-ska-ka",
-    "name": "OSiR Skałka",
-    "city": null,
-    "countryCode": "POL",
+    "countryCode": "KOR",
     "capacity": 26000,
     "tenantClubs": []
   },
@@ -11444,12 +11391,14 @@
     ]
   },
   {
-    "id": "cheonan-stadium",
-    "name": "Cheonan Stadium",
+    "id": "tql-stadium",
+    "name": "TQL Stadium",
     "city": null,
-    "countryCode": "KOR",
+    "countryCode": "USA",
     "capacity": 26000,
-    "tenantClubs": []
+    "tenantClubs": [
+      "fc-cincinnati"
+    ]
   },
   {
     "id": "welford-road-stadium",
@@ -11487,7 +11436,7 @@
   {
     "id": "craven-cottage",
     "name": "Craven Cottage",
-    "city": "Fulham",
+    "city": null,
     "countryCode": "GBR",
     "capacity": 25700,
     "tenantClubs": [
@@ -11540,11 +11489,21 @@
   {
     "id": "maverik-stadium-utah-state",
     "name": "Maverik Stadium, Utah State",
-    "city": "Utah State University",
+    "city": null,
     "countryCode": "USA",
     "capacity": 25513,
     "tenantClubs": [
       "utah-state-aggies-football"
+    ]
+  },
+  {
+    "id": "stade-de-la-maladiere-1924",
+    "name": "Stade de la Maladière (1924)",
+    "city": "Neuchâtel",
+    "countryCode": "CHE",
+    "capacity": 25500,
+    "tenantClubs": [
+      "neuchatel-xamax"
     ]
   },
   {
@@ -11570,19 +11529,9 @@
     ]
   },
   {
-    "id": "stade-de-la-maladiere-1924",
-    "name": "Stade de la Maladière (1924)",
-    "city": "Neuchâtel",
-    "countryCode": "CHE",
-    "capacity": 25500,
-    "tenantClubs": [
-      "neuchatel-xamax"
-    ]
-  },
-  {
     "id": "mersin-arena",
     "name": "Mersin Arena",
-    "city": "Yenişehir",
+    "city": null,
     "countryCode": "TUR",
     "capacity": 25497,
     "tenantClubs": [
@@ -11662,7 +11611,7 @@
   {
     "id": "sports-illustrated-stadium",
     "name": "Sports Illustrated Stadium",
-    "city": "Harrison",
+    "city": null,
     "countryCode": "USA",
     "capacity": 25189,
     "tenantClubs": [
@@ -11692,17 +11641,6 @@
     ]
   },
   {
-    "id": "q494388",
-    "name": "Q494388",
-    "city": null,
-    "countryCode": "GBR",
-    "capacity": 25133,
-    "tenantClubs": [
-      "wigan-athletic-f-c",
-      "wigan-warriors"
-    ]
-  },
-  {
     "id": "stadionul-dinamo",
     "name": "Stadionul Dinamo",
     "city": null,
@@ -11715,7 +11653,7 @@
   {
     "id": "yongchuan-sports-center",
     "name": "Yongchuan Sports Center",
-    "city": "Yongchuan District",
+    "city": "Chongqing",
     "countryCode": "CHN",
     "capacity": 25017,
     "tenantClubs": []
@@ -11723,7 +11661,7 @@
   {
     "id": "percival-molson-memorial-stadium",
     "name": "Percival Molson Memorial Stadium",
-    "city": "Mont-Royal Heritage Site",
+    "city": "Montreal",
     "countryCode": "CAN",
     "capacity": 25012,
     "tenantClubs": [
@@ -11733,214 +11671,13 @@
     ]
   },
   {
-    "id": "thupatemee-stadium",
-    "name": "Thupatemee Stadium",
-    "city": "Lam Luk Ka",
-    "countryCode": "THA",
-    "capacity": 25000,
-    "tenantClubs": [
-      "air-force-united-f-c"
-    ]
-  },
-  {
-    "id": "hm-pitje-stadium",
-    "name": "HM Pitje Stadium",
-    "city": "Mamelodi",
-    "countryCode": "ZAF",
-    "capacity": 25000,
-    "tenantClubs": []
-  },
-  {
-    "id": "stadion-rote-erde",
-    "name": "Stadion Rote Erde",
+    "id": "stade-mohamed-boumezrag",
+    "name": "Stade Mohamed Boumezrag",
     "city": null,
-    "countryCode": "DEU",
+    "countryCode": "DZA",
     "capacity": 25000,
     "tenantClubs": [
-      "borussia-dortmund"
-    ]
-  },
-  {
-    "id": "segiri-stadium",
-    "name": "Segiri Stadium",
-    "city": null,
-    "countryCode": "IDN",
-    "capacity": 25000,
-    "tenantClubs": [
-      "bali-united-f-c"
-    ]
-  },
-  {
-    "id": "estadio-sao-januario",
-    "name": "Estádio São Januário",
-    "city": "Rio de Janeiro",
-    "countryCode": "BRA",
-    "capacity": 25000,
-    "tenantClubs": [
-      "cr-vasco-da-gama"
-    ]
-  },
-  {
-    "id": "wilis-stadium",
-    "name": "Wilis Stadium",
-    "city": "Madiun",
-    "countryCode": "IDN",
-    "capacity": 25000,
-    "tenantClubs": [
-      "jakarta-fc-1928"
-    ]
-  },
-  {
-    "id": "giyani-stadium",
-    "name": "Giyani Stadium",
-    "city": null,
-    "countryCode": "ZAF",
-    "capacity": 25000,
-    "tenantClubs": [
-      "black-leopards-f-c"
-    ]
-  },
-  {
-    "id": "shangri-la-county-stadium",
-    "name": "Shangri-La County Stadium",
-    "city": null,
-    "countryCode": "CHN",
-    "capacity": 25000,
-    "tenantClubs": []
-  },
-  {
-    "id": "petro-sport-stadium",
-    "name": "Petro Sport Stadium",
-    "city": null,
-    "countryCode": "EGY",
-    "capacity": 25000,
-    "tenantClubs": [
-      "enppi-sc"
-    ]
-  },
-  {
-    "id": "heriberto-jara-corona-stadium",
-    "name": "Heriberto Jara Corona Stadium",
-    "city": null,
-    "countryCode": "MEX",
-    "capacity": 25000,
-    "tenantClubs": []
-  },
-  {
-    "id": "q5848038",
-    "name": "Q5848038",
-    "city": null,
-    "countryCode": "ARG",
-    "capacity": 25000,
-    "tenantClubs": [
-      "club-atletico-chaco-for-ever"
-    ]
-  },
-  {
-    "id": "okinawa-athletic-stadium",
-    "name": "Okinawa Athletic Stadium",
-    "city": "Okinawa Comprehensive Athletic Park",
-    "countryCode": "JPN",
-    "capacity": 25000,
-    "tenantClubs": [
-      "fc-ryukyu-okinawa"
-    ]
-  },
-  {
-    "id": "williams-stadium",
-    "name": "Williams Stadium",
-    "city": null,
-    "countryCode": "USA",
-    "capacity": 25000,
-    "tenantClubs": [
-      "liberty-flames-football"
-    ]
-  },
-  {
-    "id": "ganja-city-stadium",
-    "name": "Ganja City Stadium",
-    "city": null,
-    "countryCode": "AZE",
-    "capacity": 25000,
-    "tenantClubs": [
-      "kapaz-pfc"
-    ]
-  },
-  {
-    "id": "green-park-stadium",
-    "name": "Green Park Stadium",
-    "city": "Kanpur",
-    "countryCode": "IND",
-    "capacity": 25000,
-    "tenantClubs": []
-  },
-  {
-    "id": "kochi-haruno-athletic-stadium",
-    "name": "Kochi Haruno Athletic Stadium",
-    "city": null,
-    "countryCode": "JPN",
-    "capacity": 25000,
-    "tenantClubs": [
-      "kochi-united-sc"
-    ]
-  },
-  {
-    "id": "iksan-public-stadium",
-    "name": "Iksan Public Stadium",
-    "city": null,
-    "countryCode": "KOR",
-    "capacity": 25000,
-    "tenantClubs": [
-      "hallelujah-fc"
-    ]
-  },
-  {
-    "id": "xorazm-stadium",
-    "name": "Xorazm Stadium",
-    "city": null,
-    "countryCode": "UZB",
-    "capacity": 25000,
-    "tenantClubs": [
-      "fc-khorazm"
-    ]
-  },
-  {
-    "id": "estadio-reales-tamarindos",
-    "name": "Estadio Reales Tamarindos",
-    "city": null,
-    "countryCode": "ECU",
-    "capacity": 25000,
-    "tenantClubs": []
-  },
-  {
-    "id": "kuantan-singingi-sport-centre-stadium",
-    "name": "Kuantan Singingi Sport Centre Stadium",
-    "city": null,
-    "countryCode": "IDN",
-    "capacity": 25000,
-    "tenantClubs": [
-      "psps-riau"
-    ]
-  },
-  {
-    "id": "stadio-antonio-molinari",
-    "name": "Stadio Antonio Molinari",
-    "city": null,
-    "countryCode": "ITA",
-    "capacity": 25000,
-    "tenantClubs": [
-      "campobasso-fc",
-      "q126956491"
-    ]
-  },
-  {
-    "id": "enyimba-international-stadium",
-    "name": "Enyimba International Stadium",
-    "city": null,
-    "countryCode": "NGA",
-    "capacity": 25000,
-    "tenantClubs": [
-      "enyimba-international-f-c"
+      "aso-chlef"
     ]
   },
   {
@@ -11952,154 +11689,53 @@
     "tenantClubs": []
   },
   {
-    "id": "nnamdi-azikiwe-stadium",
-    "name": "Nnamdi Azikiwe Stadium",
+    "id": "stade-jules-lemaire",
+    "name": "Stade Jules Lemaire",
     "city": null,
-    "countryCode": "NGA",
+    "countryCode": "FRA",
     "capacity": 25000,
     "tenantClubs": [
-      "enugu-rangers"
+      "sc-fives"
     ]
   },
   {
-    "id": "petaling-jaya-stadium",
-    "name": "Petaling Jaya Stadium",
-    "city": "Petaling Jaya",
-    "countryCode": "MYS",
+    "id": "centennial-stadium-resistencia",
+    "name": "Centennial Stadium, Resistencia",
+    "city": null,
+    "countryCode": "ARG",
     "capacity": 25000,
     "tenantClubs": [
-      "airasia-f-c",
-      "felda-united-f-c"
+      "club-atletico-sarmiento-resistencia"
     ]
   },
   {
-    "id": "takhti-stadium-tabriz",
-    "name": "Takhti Stadium (Tabriz)",
-    "city": null,
-    "countryCode": "IRN",
+    "id": "shuangliu-sports-centre",
+    "name": "Shuangliu Sports Centre",
+    "city": "Chengdu",
+    "countryCode": "CHN",
     "capacity": 25000,
     "tenantClubs": [
-      "machine-sazi-f-c"
+      "chengdu-rongcheng-f-c"
     ]
   },
   {
-    "id": "chira-nakhon-stadium",
-    "name": "Chira Nakhon Stadium",
-    "city": null,
-    "countryCode": "THA",
+    "id": "hazza-bin-zayed-stadium",
+    "name": "Hazza bin Zayed Stadium",
+    "city": "Al Ain",
+    "countryCode": "ARE",
     "capacity": 25000,
     "tenantClubs": [
-      "hat-yai-f-c"
+      "al-ain-fc"
     ]
   },
   {
-    "id": "estadio-do-junco",
-    "name": "Estádio do Junco",
+    "id": "cramton-bowl",
+    "name": "Cramton Bowl",
     "city": null,
-    "countryCode": "BRA",
-    "capacity": 25000,
-    "tenantClubs": []
-  },
-  {
-    "id": "tun-abdul-razak-stadium",
-    "name": "Tun Abdul Razak Stadium",
-    "city": "Bandar Tun Razak, Jengka",
-    "countryCode": "MYS",
-    "capacity": 25000,
-    "tenantClubs": []
-  },
-  {
-    "id": "stadion-an-der-gellertstra-e",
-    "name": "Stadion an der Gellertstraße",
-    "city": "Gellertstraße",
-    "countryCode": "DEU",
+    "countryCode": "USA",
     "capacity": 25000,
     "tenantClubs": [
-      "chemnitzer-fc"
-    ]
-  },
-  {
-    "id": "estadio-municipal-irmao-gino-maria-rossi",
-    "name": "Estádio Municipal Irmão Gino Maria Rossi",
-    "city": null,
-    "countryCode": "BRA",
-    "capacity": 25000,
-    "tenantClubs": []
-  },
-  {
-    "id": "q9255475",
-    "name": "Q9255475",
-    "city": null,
-    "countryCode": "BRA",
-    "capacity": 25000,
-    "tenantClubs": []
-  },
-  {
-    "id": "cegeka-arena",
-    "name": "Cegeka Arena",
-    "city": "Genk",
-    "countryCode": "BEL",
-    "capacity": 25000,
-    "tenantClubs": [
-      "jong-genk",
-      "k-r-c-genk"
-    ]
-  },
-  {
-    "id": "stade-du-28-septembre",
-    "name": "Stade du 28 Septembre",
-    "city": null,
-    "countryCode": "GIN",
-    "capacity": 25000,
-    "tenantClubs": [
-      "guinea-men-s-national-football-team"
-    ]
-  },
-  {
-    "id": "stade-8-mai-1945",
-    "name": "Stade 8 Mai 1945",
-    "city": null,
-    "countryCode": "DZA",
-    "capacity": 25000,
-    "tenantClubs": [
-      "es-setif"
-    ]
-  },
-  {
-    "id": "nogueirao",
-    "name": "Nogueirão",
-    "city": null,
-    "countryCode": "BRA",
-    "capacity": 25000,
-    "tenantClubs": []
-  },
-  {
-    "id": "estadio-domingo-burgueno",
-    "name": "Estadio Domingo Burgueño",
-    "city": null,
-    "countryCode": "URY",
-    "capacity": 25000,
-    "tenantClubs": [
-      "deportivo-maldonado"
-    ]
-  },
-  {
-    "id": "quan-khu-7-stadium",
-    "name": "Quan khu 7 Stadium",
-    "city": null,
-    "countryCode": "VNM",
-    "capacity": 25000,
-    "tenantClubs": []
-  },
-  {
-    "id": "amman-international-stadium",
-    "name": "Amman International Stadium",
-    "city": null,
-    "countryCode": "JOR",
-    "capacity": 25000,
-    "tenantClubs": [
-      "al-faisaly-sc",
-      "jordan-men-s-national-football-team"
+      "salute-to-veterans-bowl"
     ]
   },
   {
@@ -12110,6 +11746,67 @@
     "capacity": 25000,
     "tenantClubs": [
       "club-brugge-k-v"
+    ]
+  },
+  {
+    "id": "hfc-bank-stadium",
+    "name": "HFC Bank Stadium",
+    "city": "Suva",
+    "countryCode": "FJI",
+    "capacity": 25000,
+    "tenantClubs": [
+      "cook-islands-women-s-national-football-team",
+      "fiji-men-s-national-football-team"
+    ]
+  },
+  {
+    "id": "suez-stadium",
+    "name": "Suez Stadium",
+    "city": "Suez",
+    "countryCode": "EGY",
+    "capacity": 25000,
+    "tenantClubs": [
+      "petrojet-fc"
+    ]
+  },
+  {
+    "id": "stadio-pino-zaccheria",
+    "name": "Stadio Pino Zaccheria",
+    "city": null,
+    "countryCode": "ITA",
+    "capacity": 25000,
+    "tenantClubs": [
+      "calcio-foggia-1920"
+    ]
+  },
+  {
+    "id": "abubarkar-tafawa-balewa-stadium",
+    "name": "Abubarkar Tafawa Balewa Stadium",
+    "city": null,
+    "countryCode": "NGA",
+    "capacity": 25000,
+    "tenantClubs": [
+      "wikki-tourists-f-c"
+    ]
+  },
+  {
+    "id": "thupatemee-stadium",
+    "name": "Thupatemee Stadium",
+    "city": null,
+    "countryCode": "THA",
+    "capacity": 25000,
+    "tenantClubs": [
+      "air-force-united-f-c"
+    ]
+  },
+  {
+    "id": "stade-messaoud-zougar",
+    "name": "Stade Messaoud-Zougar",
+    "city": null,
+    "countryCode": "DZA",
+    "capacity": 25000,
+    "tenantClubs": [
+      "mc-el-eulma"
     ]
   },
   {
@@ -12124,13 +11821,44 @@
     ]
   },
   {
-    "id": "shuangliu-sports-centre",
-    "name": "Shuangliu Sports Centre",
-    "city": "Shuangliu District",
+    "id": "shangri-la-county-stadium",
+    "name": "Shangri-La County Stadium",
+    "city": null,
     "countryCode": "CHN",
     "capacity": 25000,
+    "tenantClubs": []
+  },
+  {
+    "id": "lawson-tama-stadium",
+    "name": "Lawson Tama Stadium",
+    "city": null,
+    "countryCode": "SLB",
+    "capacity": 25000,
     "tenantClubs": [
-      "chengdu-rongcheng-f-c"
+      "solomon-islands-men-s-national-football-team"
+    ]
+  },
+  {
+    "id": "sporting-park",
+    "name": "Sporting Park",
+    "city": "Kansas City",
+    "countryCode": "USA",
+    "capacity": 25000,
+    "tenantClubs": [
+      "fc-kansas-city",
+      "kansas-city-current",
+      "sporting-kansas-city",
+      "sporting-kansas-city-ii"
+    ]
+  },
+  {
+    "id": "segiri-stadium",
+    "name": "Segiri Stadium",
+    "city": null,
+    "countryCode": "IDN",
+    "capacity": 25000,
+    "tenantClubs": [
+      "bali-united-f-c"
     ]
   },
   {
@@ -12144,182 +11872,85 @@
     ]
   },
   {
-    "id": "al-hilal-stadium",
-    "name": "Al-Hilal Stadium",
+    "id": "takhti-stadium-tabriz",
+    "name": "Takhti Stadium (Tabriz)",
     "city": null,
-    "countryCode": "SDN",
+    "countryCode": "IRN",
     "capacity": 25000,
     "tenantClubs": [
-      "al-hilal-club"
+      "machine-sazi-f-c"
     ]
   },
   {
-    "id": "q23893327",
-    "name": "Q23893327",
+    "id": "sydney-showground-stadium",
+    "name": "Sydney Showground Stadium",
+    "city": "Sydney Olympic Park",
+    "countryCode": "AUS",
+    "capacity": 25000,
+    "tenantClubs": [
+      "greater-western-sydney-giants",
+      "sydney-royal-easter-show",
+      "sydney-thunder"
+    ]
+  },
+  {
+    "id": "estadio-fragata-presidente-sarmiento",
+    "name": "Estadio Fragata Presidente Sarmiento",
     "city": null,
-    "countryCode": "DEU",
+    "countryCode": "ARG",
+    "capacity": 25000,
+    "tenantClubs": [
+      "club-almirante-brown"
+    ]
+  },
+  {
+    "id": "dsc-cricket-stadium",
+    "name": "DSC Cricket Stadium",
+    "city": "Dubai",
+    "countryCode": "ARE",
     "capacity": 25000,
     "tenantClubs": []
   },
   {
-    "id": "sugathadasa-stadium",
-    "name": "Sugathadasa Stadium",
+    "id": "xorazm-stadium",
+    "name": "Xorazm Stadium",
     "city": null,
-    "countryCode": "LKA",
+    "countryCode": "UZB",
     "capacity": 25000,
     "tenantClubs": [
-      "sri-lanka-men-s-national-football-team"
+      "fc-khorazm"
     ]
   },
   {
-    "id": "olympiysky-sports-complex",
-    "name": "Olympiysky Sports Complex",
+    "id": "the-darlington-arena",
+    "name": "The Darlington Arena",
     "city": null,
-    "countryCode": "RUS",
+    "countryCode": "GBR",
     "capacity": 25000,
     "tenantClubs": [
-      "kremlin-cup"
+      "darlington-f-c"
     ]
   },
   {
-    "id": "trelawny-stadium",
-    "name": "Trelawny Stadium",
-    "city": "Trelawny Parish",
-    "countryCode": "JAM",
-    "capacity": 25000,
-    "tenantClubs": []
-  },
-  {
-    "id": "prince-mohammed-bin-abdul-aziz-stadium",
-    "name": "Prince Mohammed bin Abdul Aziz Stadium",
+    "id": "williams-stadium",
+    "name": "Williams Stadium",
     "city": null,
-    "countryCode": "SAU",
-    "capacity": 25000,
-    "tenantClubs": []
-  },
-  {
-    "id": "king-abdullah-sport-city-stadium",
-    "name": "King Abdullah Sport City Stadium",
-    "city": "Burayda",
-    "countryCode": "SAU",
+    "countryCode": "USA",
     "capacity": 25000,
     "tenantClubs": [
-      "al-raed-fc",
-      "al-taawon-fc"
+      "liberty-flames-football"
     ]
   },
   {
-    "id": "bodenseestadion",
-    "name": "Bodenseestadion",
+    "id": "amman-international-stadium",
+    "name": "Amman International Stadium",
     "city": null,
-    "countryCode": "DEU",
+    "countryCode": "JOR",
     "capacity": 25000,
     "tenantClubs": [
-      "sc-konstanz-wollmatingen"
+      "al-faisaly-sc",
+      "jordan-men-s-national-football-team"
     ]
-  },
-  {
-    "id": "u-j-esuene-stadium",
-    "name": "U. J. Esuene Stadium",
-    "city": null,
-    "countryCode": "NGA",
-    "capacity": 25000,
-    "tenantClubs": []
-  },
-  {
-    "id": "stadion-am-bieberer-berg",
-    "name": "Stadion am Bieberer Berg",
-    "city": null,
-    "countryCode": "DEU",
-    "capacity": 25000,
-    "tenantClubs": [
-      "kickers-offenbach"
-    ]
-  },
-  {
-    "id": "q9255260",
-    "name": "Q9255260",
-    "city": null,
-    "countryCode": "BRA",
-    "capacity": 25000,
-    "tenantClubs": []
-  },
-  {
-    "id": "ivaylo-stadium",
-    "name": "Ivaylo Stadium",
-    "city": "Veliko Tarnovo",
-    "countryCode": "BGR",
-    "capacity": 25000,
-    "tenantClubs": [
-      "f-c-etar"
-    ]
-  },
-  {
-    "id": "stade-messaoud-zougar",
-    "name": "Stade Messaoud-Zougar",
-    "city": null,
-    "countryCode": "DZA",
-    "capacity": 25000,
-    "tenantClubs": [
-      "mc-el-eulma"
-    ]
-  },
-  {
-    "id": "stade-jules-lemaire",
-    "name": "Stade Jules Lemaire",
-    "city": null,
-    "countryCode": "FRA",
-    "capacity": 25000,
-    "tenantClubs": [
-      "sc-fives"
-    ]
-  },
-  {
-    "id": "estadio-departamental-libertad",
-    "name": "Estadio Departamental Libertad",
-    "city": "Pasto",
-    "countryCode": "COL",
-    "capacity": 25000,
-    "tenantClubs": [
-      "deportivo-pasto"
-    ]
-  },
-  {
-    "id": "q9186140",
-    "name": "Q9186140",
-    "city": null,
-    "countryCode": "BRA",
-    "capacity": 25000,
-    "tenantClubs": []
-  },
-  {
-    "id": "hfc-bank-stadium",
-    "name": "HFC Bank Stadium",
-    "city": "Suva",
-    "countryCode": "FJI",
-    "capacity": 25000,
-    "tenantClubs": [
-      "cook-islands-women-s-national-football-team",
-      "fiji-men-s-national-football-team"
-    ]
-  },
-  {
-    "id": "lawson-tama-stadium",
-    "name": "Lawson Tama Stadium",
-    "city": null,
-    "countryCode": "SLB",
-    "capacity": 25000,
-    "tenantClubs": [
-      "solomon-islands-men-s-national-football-team"
-    ]
-  },
-  {
-    "id": "uhuru-stadium",
-    "name": "Uhuru Stadium",
-    "city": "Kurasini",
-    "countryCode": "TZA",
-    "capacity": 25000,
-    "tenantClubs": []
   },
   {
     "id": "estadio-e-torres-belon",
@@ -12332,14 +11963,359 @@
     ]
   },
   {
+    "id": "enyimba-international-stadium",
+    "name": "Enyimba International Stadium",
+    "city": null,
+    "countryCode": "NGA",
+    "capacity": 25000,
+    "tenantClubs": [
+      "enyimba-international-f-c"
+    ]
+  },
+  {
+    "id": "changlimithang-stadium",
+    "name": "Changlimithang Stadium",
+    "city": null,
+    "countryCode": "BTN",
+    "capacity": 25000,
+    "tenantClubs": [
+      "bhutan-men-s-national-football-team",
+      "druk-pol-fc",
+      "druk-star-f-c",
+      "thimphu-city-fc"
+    ]
+  },
+  {
+    "id": "etihad-park",
+    "name": "Etihad Park",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 25000,
+    "tenantClubs": [
+      "new-york-city-fc"
+    ]
+  },
+  {
+    "id": "ivaylo-stadium",
+    "name": "Ivaylo Stadium",
+    "city": null,
+    "countryCode": "BGR",
+    "capacity": 25000,
+    "tenantClubs": [
+      "f-c-etar"
+    ]
+  },
+  {
+    "id": "tun-abdul-razak-stadium",
+    "name": "Tun Abdul Razak Stadium",
+    "city": null,
+    "countryCode": "MYS",
+    "capacity": 25000,
+    "tenantClubs": []
+  },
+  {
+    "id": "uhuru-stadium",
+    "name": "Uhuru Stadium",
+    "city": null,
+    "countryCode": "TZA",
+    "capacity": 25000,
+    "tenantClubs": []
+  },
+  {
+    "id": "quan-khu-7-stadium",
+    "name": "Quan khu 7 Stadium",
+    "city": null,
+    "countryCode": "VNM",
+    "capacity": 25000,
+    "tenantClubs": []
+  },
+  {
+    "id": "estadio-departamental-libertad",
+    "name": "Estadio Departamental Libertad",
+    "city": "Pasto",
+    "countryCode": "COL",
+    "capacity": 25000,
+    "tenantClubs": [
+      "deportivo-pasto"
+    ]
+  },
+  {
+    "id": "shohada-stadium-qods",
+    "name": "Shohada Stadium (Qods)",
+    "city": null,
+    "countryCode": "IRN",
+    "capacity": 25000,
+    "tenantClubs": [
+      "paykan-f-c"
+    ]
+  },
+  {
+    "id": "tsk-stadion",
+    "name": "TSK stadion",
+    "city": null,
+    "countryCode": "RUS",
+    "capacity": 25000,
+    "tenantClubs": [
+      "fc-ryazan"
+    ]
+  },
+  {
+    "id": "al-hilal-stadium",
+    "name": "Al-Hilal Stadium",
+    "city": null,
+    "countryCode": "SDN",
+    "capacity": 25000,
+    "tenantClubs": [
+      "al-hilal-club"
+    ]
+  },
+  {
+    "id": "independence-stadium-nam",
+    "name": "Independence Stadium",
+    "city": null,
+    "countryCode": "NAM",
+    "capacity": 25000,
+    "tenantClubs": []
+  },
+  {
+    "id": "olympiysky-sports-complex",
+    "name": "Olympiysky Sports Complex",
+    "city": null,
+    "countryCode": "RUS",
+    "capacity": 25000,
+    "tenantClubs": [
+      "kremlin-cup"
+    ]
+  },
+  {
+    "id": "nnamdi-azikiwe-stadium",
+    "name": "Nnamdi Azikiwe Stadium",
+    "city": null,
+    "countryCode": "NGA",
+    "capacity": 25000,
+    "tenantClubs": [
+      "enugu-rangers"
+    ]
+  },
+  {
+    "id": "ganja-city-stadium",
+    "name": "Ganja City Stadium",
+    "city": null,
+    "countryCode": "AZE",
+    "capacity": 25000,
+    "tenantClubs": [
+      "kapaz-pfc"
+    ]
+  },
+  {
+    "id": "bo-stadium",
+    "name": "Bo Stadium",
+    "city": "Bo",
+    "countryCode": "SLE",
+    "capacity": 25000,
+    "tenantClubs": [
+      "sierra-leone-men-s-national-football-team"
+    ]
+  },
+  {
+    "id": "stadion-am-bieberer-berg",
+    "name": "Stadion am Bieberer Berg",
+    "city": null,
+    "countryCode": "DEU",
+    "capacity": 25000,
+    "tenantClubs": [
+      "kickers-offenbach"
+    ]
+  },
+  {
     "id": "petrokimia-stadium",
     "name": "Petrokimia Stadium",
-    "city": "Gresik",
+    "city": null,
     "countryCode": "IDN",
     "capacity": 25000,
     "tenantClubs": [
       "persegres-gresik-united"
     ]
+  },
+  {
+    "id": "belmore-sports-ground",
+    "name": "Belmore Sports Ground",
+    "city": null,
+    "countryCode": "AUS",
+    "capacity": 25000,
+    "tenantClubs": [
+      "canterbury-bankstown-bulldogs",
+      "sydney-olympic-fc"
+    ]
+  },
+  {
+    "id": "giyani-stadium",
+    "name": "Giyani Stadium",
+    "city": null,
+    "countryCode": "ZAF",
+    "capacity": 25000,
+    "tenantClubs": [
+      "black-leopards-f-c"
+    ]
+  },
+  {
+    "id": "stadio-antonio-molinari",
+    "name": "Stadio Antonio Molinari",
+    "city": null,
+    "countryCode": "ITA",
+    "capacity": 25000,
+    "tenantClubs": [
+      "campobasso-fc",
+      "q126956491"
+    ]
+  },
+  {
+    "id": "bassel-al-assad-stadium-homs",
+    "name": "Bassel al-Assad Stadium (Homs)",
+    "city": null,
+    "countryCode": "SYR",
+    "capacity": 25000,
+    "tenantClubs": []
+  },
+  {
+    "id": "imam-reza-stadium",
+    "name": "Imam Reza Stadium",
+    "city": null,
+    "countryCode": "IRN",
+    "capacity": 25000,
+    "tenantClubs": [
+      "shahr-khodro-f-c"
+    ]
+  },
+  {
+    "id": "stadio-ciro-vigorito",
+    "name": "Stadio Ciro Vigorito",
+    "city": null,
+    "countryCode": "ITA",
+    "capacity": 25000,
+    "tenantClubs": [
+      "benevento-calcio"
+    ]
+  },
+  {
+    "id": "estadio-juan-carlos-duran",
+    "name": "Estadio Juan Carlos Durán",
+    "city": "Santa Cruz de la Sierra",
+    "countryCode": "BOL",
+    "capacity": 25000,
+    "tenantClubs": [
+      "real-santa-cruz"
+    ]
+  },
+  {
+    "id": "green-park-stadium",
+    "name": "Green Park Stadium",
+    "city": "Kanpur",
+    "countryCode": "IND",
+    "capacity": 25000,
+    "tenantClubs": []
+  },
+  {
+    "id": "iwate-prefectural-baseball-stadium",
+    "name": "Iwate Prefectural Baseball Stadium",
+    "city": null,
+    "countryCode": "JPN",
+    "capacity": 25000,
+    "tenantClubs": []
+  },
+  {
+    "id": "estadio-municipal-irmao-gino-maria-rossi",
+    "name": "Estádio Municipal Irmão Gino Maria Rossi",
+    "city": null,
+    "countryCode": "BRA",
+    "capacity": 25000,
+    "tenantClubs": []
+  },
+  {
+    "id": "mandala-krida-stadium",
+    "name": "Mandala Krida Stadium",
+    "city": "Yogyakarta",
+    "countryCode": "IDN",
+    "capacity": 25000,
+    "tenantClubs": []
+  },
+  {
+    "id": "biju-patnaik-hockey-stadium",
+    "name": "Biju Patnaik Hockey Stadium",
+    "city": null,
+    "countryCode": "IND",
+    "capacity": 25000,
+    "tenantClubs": [
+      "india-men-s-national-field-hockey-team"
+    ]
+  },
+  {
+    "id": "americo-montanini-stadium",
+    "name": "Américo Montanini Stadium",
+    "city": null,
+    "countryCode": "COL",
+    "capacity": 25000,
+    "tenantClubs": [
+      "atletico-bucaramanga"
+    ]
+  },
+  {
+    "id": "queen-s-park-oval-port-of-spain",
+    "name": "Queen's Park Oval, Port of Spain",
+    "city": null,
+    "countryCode": "TTO",
+    "capacity": 25000,
+    "tenantClubs": [
+      "trinidad-and-tobago-national-cricket-team"
+    ]
+  },
+  {
+    "id": "estadio-domingo-burgueno",
+    "name": "Estadio Domingo Burgueño",
+    "city": null,
+    "countryCode": "URY",
+    "capacity": 25000,
+    "tenantClubs": [
+      "deportivo-maldonado"
+    ]
+  },
+  {
+    "id": "kuantan-singingi-sport-centre-stadium",
+    "name": "Kuantan Singingi Sport Centre Stadium",
+    "city": null,
+    "countryCode": "IDN",
+    "capacity": 25000,
+    "tenantClubs": [
+      "psps-riau"
+    ]
+  },
+  {
+    "id": "kochi-haruno-athletic-stadium",
+    "name": "Kochi Haruno Athletic Stadium",
+    "city": null,
+    "countryCode": "JPN",
+    "capacity": 25000,
+    "tenantClubs": [
+      "kochi-united-sc"
+    ]
+  },
+  {
+    "id": "estadio-waldemiro-wagner",
+    "name": "Estádio Waldemiro Wagner",
+    "city": null,
+    "countryCode": "BRA",
+    "capacity": 25000,
+    "tenantClubs": [
+      "atletico-clube-paranavai"
+    ]
+  },
+  {
+    "id": "hm-pitje-stadium",
+    "name": "HM Pitje Stadium",
+    "city": "City of Tshwane Metropolitan Municipality",
+    "countryCode": "ZAF",
+    "capacity": 25000,
+    "tenantClubs": []
   },
   {
     "id": "stade-du-hainaut",
@@ -12349,16 +12325,6 @@
     "capacity": 25000,
     "tenantClubs": [
       "valenciennes-f-c"
-    ]
-  },
-  {
-    "id": "hazza-bin-zayed-stadium",
-    "name": "Hazza bin Zayed Stadium",
-    "city": "Al Ain",
-    "countryCode": "ARE",
-    "capacity": 25000,
-    "tenantClubs": [
-      "al-ain-fc"
     ]
   },
   {
@@ -12382,264 +12348,22 @@
     ]
   },
   {
-    "id": "new-laos-national-stadium",
-    "name": "New Laos National Stadium",
+    "id": "u-j-esuene-stadium",
+    "name": "U. J. Esuene Stadium",
     "city": null,
-    "countryCode": "LAO",
-    "capacity": 25000,
-    "tenantClubs": [
-      "2009-southeast-asian-games"
-    ]
-  },
-  {
-    "id": "estadio-ricardo-saprissa-ayma",
-    "name": "Estadio Ricardo Saprissa Aymá",
-    "city": null,
-    "countryCode": "CRI",
-    "capacity": 25000,
-    "tenantClubs": [
-      "deportivo-saprissa"
-    ]
-  },
-  {
-    "id": "estadio-luis-troccoli",
-    "name": "Estadio Luis Tróccoli",
-    "city": null,
-    "countryCode": "URY",
-    "capacity": 25000,
-    "tenantClubs": [
-      "c-a-cerro"
-    ]
-  },
-  {
-    "id": "the-darlington-arena",
-    "name": "The Darlington Arena",
-    "city": "Darlington",
-    "countryCode": "GBR",
-    "capacity": 25000,
-    "tenantClubs": [
-      "darlington-f-c"
-    ]
-  },
-  {
-    "id": "americo-montanini-stadium",
-    "name": "Américo Montanini Stadium",
-    "city": null,
-    "countryCode": "COL",
-    "capacity": 25000,
-    "tenantClubs": [
-      "atletico-bucaramanga"
-    ]
-  },
-  {
-    "id": "stadio-pino-zaccheria",
-    "name": "Stadio Pino Zaccheria",
-    "city": null,
-    "countryCode": "ITA",
-    "capacity": 25000,
-    "tenantClubs": [
-      "calcio-foggia-1920"
-    ]
-  },
-  {
-    "id": "bassel-al-assad-stadium-homs",
-    "name": "Bassel al-Assad Stadium (Homs)",
-    "city": null,
-    "countryCode": "SYR",
+    "countryCode": "NGA",
     "capacity": 25000,
     "tenantClubs": []
   },
   {
-    "id": "unique-san-nicolas-stadium",
-    "name": "Unique San Nicolás Stadium",
-    "city": "San Nicolás, Buenos Aires",
-    "countryCode": "ARG",
-    "capacity": 25000,
-    "tenantClubs": []
-  },
-  {
-    "id": "heiwadai-athletic-stadium",
-    "name": "Heiwadai Athletic Stadium",
+    "id": "stade-8-mai-1945",
+    "name": "Stade 8 Mai 1945",
     "city": null,
-    "countryCode": "JPN",
-    "capacity": 25000,
-    "tenantClubs": []
-  },
-  {
-    "id": "iwate-prefectural-baseball-stadium",
-    "name": "Iwate Prefectural Baseball Stadium",
-    "city": null,
-    "countryCode": "JPN",
-    "capacity": 25000,
-    "tenantClubs": []
-  },
-  {
-    "id": "changlimithang-stadium",
-    "name": "Changlimithang Stadium",
-    "city": null,
-    "countryCode": "BTN",
+    "countryCode": "DZA",
     "capacity": 25000,
     "tenantClubs": [
-      "bhutan-men-s-national-football-team",
-      "druk-pol-fc",
-      "druk-star-f-c",
-      "thimphu-city-fc"
+      "es-setif"
     ]
-  },
-  {
-    "id": "estadio-waldemiro-wagner",
-    "name": "Estádio Waldemiro Wagner",
-    "city": null,
-    "countryCode": "BRA",
-    "capacity": 25000,
-    "tenantClubs": [
-      "atletico-clube-paranavai"
-    ]
-  },
-  {
-    "id": "imam-reza-stadium",
-    "name": "Imam Reza Stadium",
-    "city": null,
-    "countryCode": "IRN",
-    "capacity": 25000,
-    "tenantClubs": [
-      "shahr-khodro-f-c"
-    ]
-  },
-  {
-    "id": "stadio-ciro-vigorito",
-    "name": "Stadio Ciro Vigorito",
-    "city": null,
-    "countryCode": "ITA",
-    "capacity": 25000,
-    "tenantClubs": [
-      "benevento-calcio"
-    ]
-  },
-  {
-    "id": "etihad-park",
-    "name": "Etihad Park",
-    "city": "Willets Point",
-    "countryCode": "USA",
-    "capacity": 25000,
-    "tenantClubs": [
-      "new-york-city-fc"
-    ]
-  },
-  {
-    "id": "q2291675",
-    "name": "Q2291675",
-    "city": null,
-    "countryCode": "DEU",
-    "capacity": 25000,
-    "tenantClubs": [
-      "sv-motor-altenburg"
-    ]
-  },
-  {
-    "id": "queen-s-park-oval-port-of-spain",
-    "name": "Queen's Park Oval, Port of Spain",
-    "city": null,
-    "countryCode": "TTO",
-    "capacity": 25000,
-    "tenantClubs": [
-      "trinidad-and-tobago-national-cricket-team"
-    ]
-  },
-  {
-    "id": "q9341123",
-    "name": "Q9341123",
-    "city": null,
-    "countryCode": "POL",
-    "capacity": 25000,
-    "tenantClubs": [
-      "garbarnia-krakow"
-    ]
-  },
-  {
-    "id": "biju-patnaik-hockey-stadium",
-    "name": "Biju Patnaik Hockey Stadium",
-    "city": null,
-    "countryCode": "IND",
-    "capacity": 25000,
-    "tenantClubs": [
-      "india-men-s-national-field-hockey-team"
-    ]
-  },
-  {
-    "id": "letzigrund",
-    "name": "Letzigrund",
-    "city": "Zurich",
-    "countryCode": "CHE",
-    "capacity": 25000,
-    "tenantClubs": [
-      "fc-zurich"
-    ]
-  },
-  {
-    "id": "parque-asturias",
-    "name": "Parque Asturias",
-    "city": null,
-    "countryCode": "MEX",
-    "capacity": 25000,
-    "tenantClubs": [
-      "asturias-f-c"
-    ]
-  },
-  {
-    "id": "thong-nhat-stadium",
-    "name": "Thong Nhat Stadium",
-    "city": null,
-    "countryCode": "VNM",
-    "capacity": 25000,
-    "tenantClubs": [
-      "ho-chi-minh-city-f-c",
-      "sai-gon-f-c"
-    ]
-  },
-  {
-    "id": "ksu-stadium",
-    "name": "KSU Stadium",
-    "city": null,
-    "countryCode": "SAU",
-    "capacity": 25000,
-    "tenantClubs": [
-      "al-nassr"
-    ]
-  },
-  {
-    "id": "tsk-stadion",
-    "name": "TSK stadion",
-    "city": null,
-    "countryCode": "RUS",
-    "capacity": 25000,
-    "tenantClubs": [
-      "fc-ryazan"
-    ]
-  },
-  {
-    "id": "bir-shreshtha-mustafa-kamal-stadium",
-    "name": "Bir Shreshtha Mustafa Kamal Stadium",
-    "city": null,
-    "countryCode": "BGD",
-    "capacity": 25000,
-    "tenantClubs": []
-  },
-  {
-    "id": "mandala-krida-stadium",
-    "name": "Mandala Krida Stadium",
-    "city": "Yogyakarta",
-    "countryCode": "IDN",
-    "capacity": 25000,
-    "tenantClubs": []
-  },
-  {
-    "id": "stadion",
-    "name": "Stadion",
-    "city": null,
-    "countryCode": "DEU",
-    "capacity": 25000,
-    "tenantClubs": []
   },
   {
     "id": "obafemi-awolowo-stadium",
@@ -12652,26 +12376,105 @@
     ]
   },
   {
-    "id": "sporting-park",
-    "name": "Sporting Park",
-    "city": "Kansas City",
-    "countryCode": "USA",
+    "id": "chira-nakhon-stadium",
+    "name": "Chira Nakhon Stadium",
+    "city": null,
+    "countryCode": "THA",
     "capacity": 25000,
     "tenantClubs": [
-      "fc-kansas-city",
-      "kansas-city-current",
-      "sporting-kansas-city",
-      "sporting-kansas-city-ii"
+      "hat-yai-f-c"
     ]
   },
   {
-    "id": "shohada-stadium-qods",
-    "name": "Shohada Stadium (Qods)",
-    "city": "Qods",
-    "countryCode": "IRN",
+    "id": "benteng-stadium",
+    "name": "Benteng Stadium",
+    "city": null,
+    "countryCode": "IDN",
     "capacity": 25000,
     "tenantClubs": [
-      "paykan-f-c"
+      "persikota-tangerang"
+    ]
+  },
+  {
+    "id": "stadion",
+    "name": "Stadion",
+    "city": null,
+    "countryCode": "DEU",
+    "capacity": 25000,
+    "tenantClubs": []
+  },
+  {
+    "id": "asiut-university-stadium",
+    "name": "Asiut University Stadium",
+    "city": null,
+    "countryCode": "EGY",
+    "capacity": 25000,
+    "tenantClubs": [
+      "asyut-petroleum"
+    ]
+  },
+  {
+    "id": "nogueirao",
+    "name": "Nogueirão",
+    "city": null,
+    "countryCode": "BRA",
+    "capacity": 25000,
+    "tenantClubs": []
+  },
+  {
+    "id": "okinawa-athletic-stadium",
+    "name": "Okinawa Athletic Stadium",
+    "city": "Okinawa",
+    "countryCode": "JPN",
+    "capacity": 25000,
+    "tenantClubs": [
+      "fc-ryukyu-okinawa"
+    ]
+  },
+  {
+    "id": "sugathadasa-stadium",
+    "name": "Sugathadasa Stadium",
+    "city": null,
+    "countryCode": "LKA",
+    "capacity": 25000,
+    "tenantClubs": [
+      "sri-lanka-men-s-national-football-team"
+    ]
+  },
+  {
+    "id": "heriberto-jara-corona-stadium",
+    "name": "Heriberto Jara Corona Stadium",
+    "city": null,
+    "countryCode": "MEX",
+    "capacity": 25000,
+    "tenantClubs": []
+  },
+  {
+    "id": "siliwangi-stadium",
+    "name": "Siliwangi Stadium",
+    "city": "Bandung",
+    "countryCode": "IDN",
+    "capacity": 25000,
+    "tenantClubs": [
+      "persib-bandung"
+    ]
+  },
+  {
+    "id": "unique-san-nicolas-stadium",
+    "name": "Unique San Nicolás Stadium",
+    "city": "Buenos Aires",
+    "countryCode": "ARG",
+    "capacity": 25000,
+    "tenantClubs": []
+  },
+  {
+    "id": "ksu-stadium",
+    "name": "KSU Stadium",
+    "city": null,
+    "countryCode": "SAU",
+    "capacity": 25000,
+    "tenantClubs": [
+      "al-nassr"
     ]
   },
   {
@@ -12686,179 +12489,23 @@
     ]
   },
   {
-    "id": "lithuania-national-stadium",
-    "name": "Lithuania National Stadium",
+    "id": "stade-du-28-septembre",
+    "name": "Stade du 28 Septembre",
     "city": null,
-    "countryCode": "LTU",
+    "countryCode": "GIN",
     "capacity": 25000,
-    "tenantClubs": []
+    "tenantClubs": [
+      "guinea-men-s-national-football-team"
+    ]
   },
   {
-    "id": "abubarkar-tafawa-balewa-stadium",
-    "name": "Abubarkar Tafawa Balewa Stadium",
+    "id": "parque-asturias",
+    "name": "Parque Asturias",
     "city": null,
-    "countryCode": "NGA",
+    "countryCode": "MEX",
     "capacity": 25000,
     "tenantClubs": [
-      "wikki-tourists-f-c"
-    ]
-  },
-  {
-    "id": "estadio-fragata-presidente-sarmiento",
-    "name": "Estadio Fragata Presidente Sarmiento",
-    "city": null,
-    "countryCode": "ARG",
-    "capacity": 25000,
-    "tenantClubs": [
-      "club-almirante-brown"
-    ]
-  },
-  {
-    "id": "dsc-cricket-stadium",
-    "name": "DSC Cricket Stadium",
-    "city": "Dubai Sports City",
-    "countryCode": "ARE",
-    "capacity": 25000,
-    "tenantClubs": []
-  },
-  {
-    "id": "cramton-bowl",
-    "name": "Cramton Bowl",
-    "city": null,
-    "countryCode": "USA",
-    "capacity": 25000,
-    "tenantClubs": [
-      "salute-to-veterans-bowl"
-    ]
-  },
-  {
-    "id": "centennial-stadium-resistencia",
-    "name": "Centennial Stadium, Resistencia",
-    "city": null,
-    "countryCode": "ARG",
-    "capacity": 25000,
-    "tenantClubs": [
-      "club-atletico-sarmiento-resistencia"
-    ]
-  },
-  {
-    "id": "benteng-stadium",
-    "name": "Benteng Stadium",
-    "city": null,
-    "countryCode": "IDN",
-    "capacity": 25000,
-    "tenantClubs": [
-      "persikota-tangerang"
-    ]
-  },
-  {
-    "id": "suez-stadium",
-    "name": "Suez Stadium",
-    "city": "Suez",
-    "countryCode": "EGY",
-    "capacity": 25000,
-    "tenantClubs": [
-      "petrojet-fc"
-    ]
-  },
-  {
-    "id": "hasakah-municipal-stadium",
-    "name": "Hasakah Municipal Stadium",
-    "city": null,
-    "countryCode": "SYR",
-    "capacity": 25000,
-    "tenantClubs": [
-      "al-jazeera-sc-hasakah"
-    ]
-  },
-  {
-    "id": "asiut-university-stadium",
-    "name": "Asiut University Stadium",
-    "city": null,
-    "countryCode": "EGY",
-    "capacity": 25000,
-    "tenantClubs": [
-      "asyut-petroleum"
-    ]
-  },
-  {
-    "id": "stade-mohamed-boumezrag",
-    "name": "Stade Mohamed Boumezrag",
-    "city": null,
-    "countryCode": "DZA",
-    "capacity": 25000,
-    "tenantClubs": [
-      "aso-chlef"
-    ]
-  },
-  {
-    "id": "siliwangi-stadium",
-    "name": "Siliwangi Stadium",
-    "city": "Bandung",
-    "countryCode": "IDN",
-    "capacity": 25000,
-    "tenantClubs": [
-      "persib-bandung"
-    ]
-  },
-  {
-    "id": "sydney-showground-stadium",
-    "name": "Sydney Showground Stadium",
-    "city": "Sydney Olympic Park",
-    "countryCode": "AUS",
-    "capacity": 25000,
-    "tenantClubs": [
-      "greater-western-sydney-giants",
-      "sydney-royal-easter-show",
-      "sydney-thunder"
-    ]
-  },
-  {
-    "id": "akita-prefectural-baseball-stadium",
-    "name": "Akita Prefectural Baseball Stadium",
-    "city": null,
-    "countryCode": "JPN",
-    "capacity": 25000,
-    "tenantClubs": [
-      "japanese-high-school-baseball-championship"
-    ]
-  },
-  {
-    "id": "estadio-juan-carlos-duran",
-    "name": "Estadio Juan Carlos Durán",
-    "city": "Santa Cruz de la Sierra",
-    "countryCode": "BOL",
-    "capacity": 25000,
-    "tenantClubs": [
-      "real-santa-cruz"
-    ]
-  },
-  {
-    "id": "20-years-of-independence-stadium",
-    "name": "20 Years of Independence Stadium",
-    "city": null,
-    "countryCode": "TJK",
-    "capacity": 25000,
-    "tenantClubs": [
-      "fk-khujand"
-    ]
-  },
-  {
-    "id": "independence-stadium-nam",
-    "name": "Independence Stadium",
-    "city": null,
-    "countryCode": "NAM",
-    "capacity": 25000,
-    "tenantClubs": []
-  },
-  {
-    "id": "bo-stadium",
-    "name": "Bo Stadium",
-    "city": "Bo",
-    "countryCode": "SLE",
-    "capacity": 25000,
-    "tenantClubs": [
-      "sierra-leone-men-s-national-football-team"
+      "asturias-f-c"
     ]
   },
   {
@@ -12872,14 +12519,243 @@
     ]
   },
   {
-    "id": "belmore-sports-ground",
-    "name": "Belmore Sports Ground",
-    "city": "Belmore",
-    "countryCode": "AUS",
+    "id": "hasakah-municipal-stadium",
+    "name": "Hasakah Municipal Stadium",
+    "city": null,
+    "countryCode": "SYR",
     "capacity": 25000,
     "tenantClubs": [
-      "canterbury-bankstown-bulldogs",
-      "sydney-olympic-fc"
+      "al-jazeera-sc-hasakah"
+    ]
+  },
+  {
+    "id": "stadion-rote-erde",
+    "name": "Stadion Rote Erde",
+    "city": null,
+    "countryCode": "DEU",
+    "capacity": 25000,
+    "tenantClubs": [
+      "borussia-dortmund"
+    ]
+  },
+  {
+    "id": "akita-prefectural-baseball-stadium",
+    "name": "Akita Prefectural Baseball Stadium",
+    "city": null,
+    "countryCode": "JPN",
+    "capacity": 25000,
+    "tenantClubs": [
+      "japanese-high-school-baseball-championship"
+    ]
+  },
+  {
+    "id": "20-years-of-independence-stadium",
+    "name": "20 Years of Independence Stadium",
+    "city": null,
+    "countryCode": "TJK",
+    "capacity": 25000,
+    "tenantClubs": [
+      "fk-khujand"
+    ]
+  },
+  {
+    "id": "new-laos-national-stadium",
+    "name": "New Laos National Stadium",
+    "city": null,
+    "countryCode": "LAO",
+    "capacity": 25000,
+    "tenantClubs": [
+      "2009-southeast-asian-games"
+    ]
+  },
+  {
+    "id": "petro-sport-stadium",
+    "name": "Petro Sport Stadium",
+    "city": null,
+    "countryCode": "EGY",
+    "capacity": 25000,
+    "tenantClubs": [
+      "enppi-sc"
+    ]
+  },
+  {
+    "id": "iksan-public-stadium",
+    "name": "Iksan Public Stadium",
+    "city": null,
+    "countryCode": "KOR",
+    "capacity": 25000,
+    "tenantClubs": [
+      "hallelujah-fc"
+    ]
+  },
+  {
+    "id": "bir-shreshtha-mustafa-kamal-stadium",
+    "name": "Bir Shreshtha Mustafa Kamal Stadium",
+    "city": null,
+    "countryCode": "BGD",
+    "capacity": 25000,
+    "tenantClubs": []
+  },
+  {
+    "id": "wilis-stadium",
+    "name": "Wilis Stadium",
+    "city": "Madiun",
+    "countryCode": "IDN",
+    "capacity": 25000,
+    "tenantClubs": [
+      "jakarta-fc-1928"
+    ]
+  },
+  {
+    "id": "estadio-sao-januario",
+    "name": "Estádio São Januário",
+    "city": "Rio de Janeiro",
+    "countryCode": "BRA",
+    "capacity": 25000,
+    "tenantClubs": [
+      "cr-vasco-da-gama"
+    ]
+  },
+  {
+    "id": "letzigrund",
+    "name": "Letzigrund",
+    "city": "Zurich",
+    "countryCode": "CHE",
+    "capacity": 25000,
+    "tenantClubs": [
+      "fc-zurich"
+    ]
+  },
+  {
+    "id": "estadio-reales-tamarindos",
+    "name": "Estadio Reales Tamarindos",
+    "city": null,
+    "countryCode": "ECU",
+    "capacity": 25000,
+    "tenantClubs": []
+  },
+  {
+    "id": "bodenseestadion",
+    "name": "Bodenseestadion",
+    "city": null,
+    "countryCode": "DEU",
+    "capacity": 25000,
+    "tenantClubs": [
+      "sc-konstanz-wollmatingen"
+    ]
+  },
+  {
+    "id": "cegeka-arena",
+    "name": "Cegeka Arena",
+    "city": null,
+    "countryCode": "BEL",
+    "capacity": 25000,
+    "tenantClubs": [
+      "jong-genk",
+      "k-r-c-genk"
+    ]
+  },
+  {
+    "id": "lithuania-national-stadium",
+    "name": "Lithuania National Stadium",
+    "city": null,
+    "countryCode": "LTU",
+    "capacity": 25000,
+    "tenantClubs": []
+  },
+  {
+    "id": "estadio-luis-troccoli",
+    "name": "Estadio Luis Tróccoli",
+    "city": null,
+    "countryCode": "URY",
+    "capacity": 25000,
+    "tenantClubs": [
+      "c-a-cerro"
+    ]
+  },
+  {
+    "id": "king-abdullah-sport-city-stadium",
+    "name": "King Abdullah Sport City Stadium",
+    "city": "Burayda",
+    "countryCode": "SAU",
+    "capacity": 25000,
+    "tenantClubs": [
+      "al-raed-fc",
+      "al-taawon-fc"
+    ]
+  },
+  {
+    "id": "estadio-ricardo-saprissa-ayma",
+    "name": "Estadio Ricardo Saprissa Aymá",
+    "city": null,
+    "countryCode": "CRI",
+    "capacity": 25000,
+    "tenantClubs": [
+      "deportivo-saprissa"
+    ]
+  },
+  {
+    "id": "trelawny-stadium",
+    "name": "Trelawny Stadium",
+    "city": null,
+    "countryCode": "JAM",
+    "capacity": 25000,
+    "tenantClubs": []
+  },
+  {
+    "id": "estadio-do-junco",
+    "name": "Estádio do Junco",
+    "city": null,
+    "countryCode": "BRA",
+    "capacity": 25000,
+    "tenantClubs": []
+  },
+  {
+    "id": "heiwadai-athletic-stadium",
+    "name": "Heiwadai Athletic Stadium",
+    "city": null,
+    "countryCode": "JPN",
+    "capacity": 25000,
+    "tenantClubs": []
+  },
+  {
+    "id": "prince-mohammed-bin-abdul-aziz-stadium",
+    "name": "Prince Mohammed bin Abdul Aziz Stadium",
+    "city": null,
+    "countryCode": "SAU",
+    "capacity": 25000,
+    "tenantClubs": []
+  },
+  {
+    "id": "stadion-an-der-gellertstra-e",
+    "name": "Stadion an der Gellertstraße",
+    "city": "Chemnitz",
+    "countryCode": "DEU",
+    "capacity": 25000,
+    "tenantClubs": [
+      "chemnitzer-fc"
+    ]
+  },
+  {
+    "id": "petaling-jaya-stadium",
+    "name": "Petaling Jaya Stadium",
+    "city": "Petaling Jaya",
+    "countryCode": "MYS",
+    "capacity": 25000,
+    "tenantClubs": [
+      "airasia-f-c",
+      "felda-united-f-c"
+    ]
+  },
+  {
+    "id": "thong-nhat-stadium",
+    "name": "Thong Nhat Stadium",
+    "city": null,
+    "countryCode": "VNM",
+    "capacity": 25000,
+    "tenantClubs": [
+      "ho-chi-minh-city-f-c",
+      "sai-gon-f-c"
     ]
   },
   {
@@ -12946,7 +12822,7 @@
   {
     "id": "chichibunomiya-rugby-stadium",
     "name": "Chichibunomiya Rugby Stadium",
-    "city": "Meiji Shrine Outer Garden",
+    "city": "Tokyo",
     "countryCode": "JPN",
     "capacity": 24871,
     "tenantClubs": [
@@ -12994,16 +12870,6 @@
     ]
   },
   {
-    "id": "estadio-elias-aguirre",
-    "name": "Estadio Elías Aguirre",
-    "city": "Chiclayo",
-    "countryCode": "PER",
-    "capacity": 24500,
-    "tenantClubs": [
-      "club-juan-aurich"
-    ]
-  },
-  {
     "id": "kirklees-stadium",
     "name": "Kirklees Stadium",
     "city": "Huddersfield",
@@ -13021,6 +12887,16 @@
     "countryCode": "JPN",
     "capacity": 24500,
     "tenantClubs": []
+  },
+  {
+    "id": "estadio-elias-aguirre",
+    "name": "Estadio Elías Aguirre",
+    "city": "Chiclayo",
+    "countryCode": "PER",
+    "capacity": 24500,
+    "tenantClubs": [
+      "club-juan-aurich"
+    ]
   },
   {
     "id": "deepdale",
@@ -13056,7 +12932,7 @@
   {
     "id": "ferro-carril-oeste-stadium",
     "name": "Ferro Carril Oeste Stadium",
-    "city": "Caballito",
+    "city": "Buenos Aires",
     "countryCode": "ARG",
     "capacity": 24442,
     "tenantClubs": [
@@ -13118,16 +12994,6 @@
     "tenantClubs": []
   },
   {
-    "id": "paulson-stadium",
-    "name": "Paulson Stadium",
-    "city": null,
-    "countryCode": "USA",
-    "capacity": 24300,
-    "tenantClubs": [
-      "georgia-southern-eagles"
-    ]
-  },
-  {
     "id": "argentine",
     "name": "Argentine",
     "city": "Salta",
@@ -13135,6 +13001,16 @@
     "capacity": 24300,
     "tenantClubs": [
       "gimnasia-y-tiro"
+    ]
+  },
+  {
+    "id": "paulson-stadium",
+    "name": "Paulson Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 24300,
+    "tenantClubs": [
+      "georgia-southern-eagles"
     ]
   },
   {
@@ -13170,20 +13046,9 @@
     ]
   },
   {
-    "id": "diego-armando-maradona-stadium",
-    "name": "Diego Armando Maradona Stadium",
-    "city": "Villa General Mitre",
-    "countryCode": "ARG",
-    "capacity": 24000,
-    "tenantClubs": [
-      "argentinos-juniors",
-      "argentinos-juniors-women"
-    ]
-  },
-  {
     "id": "audi-field",
     "name": "Audi Field",
-    "city": "Buzzard Point",
+    "city": "Washington, D.C.",
     "countryCode": "USA",
     "capacity": 24000,
     "tenantClubs": [
@@ -13193,22 +13058,84 @@
     ]
   },
   {
-    "id": "q125963312",
-    "name": "Q125963312",
+    "id": "jsu-stadium",
+    "name": "JSU Stadium",
     "city": null,
-    "countryCode": "BOL",
-    "capacity": 24000,
-    "tenantClubs": []
-  },
-  {
-    "id": "dreisamstadion",
-    "name": "Dreisamstadion",
-    "city": null,
-    "countryCode": "DEU",
+    "countryCode": "USA",
     "capacity": 24000,
     "tenantClubs": [
-      "sc-freiburg",
-      "sc-freiburg-ii"
+      "jacksonville-state-gamecocks",
+      "jacksonville-state-gamecocks-football"
+    ]
+  },
+  {
+    "id": "estadio-mansiche",
+    "name": "Estadio Mansiche",
+    "city": null,
+    "countryCode": "PER",
+    "capacity": 24000,
+    "tenantClubs": [
+      "cd-universidad-cesar-vallejo"
+    ]
+  },
+  {
+    "id": "bahrain-national-stadium",
+    "name": "Bahrain National Stadium",
+    "city": "Riffa",
+    "countryCode": "BHR",
+    "capacity": 24000,
+    "tenantClubs": [
+      "bahrain-men-s-national-football-team"
+    ]
+  },
+  {
+    "id": "stade-24-novembre",
+    "name": "Stade 24 Novembre",
+    "city": null,
+    "countryCode": "COD",
+    "capacity": 24000,
+    "tenantClubs": [
+      "daring-club-motema-pembe"
+    ]
+  },
+  {
+    "id": "dobsonville-stadium",
+    "name": "Dobsonville Stadium",
+    "city": null,
+    "countryCode": "ZAF",
+    "capacity": 24000,
+    "tenantClubs": [
+      "moroka-swallows-f-c"
+    ]
+  },
+  {
+    "id": "kenan-memorial-stadium",
+    "name": "Kenan Memorial Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 24000,
+    "tenantClubs": [
+      "north-carolina-tar-heels"
+    ]
+  },
+  {
+    "id": "stadio-silvio-appiani",
+    "name": "Stadio Silvio Appiani",
+    "city": null,
+    "countryCode": "ITA",
+    "capacity": 24000,
+    "tenantClubs": [
+      "calcio-padova"
+    ]
+  },
+  {
+    "id": "memorial-stadium-usa-2",
+    "name": "Memorial Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 24000,
+    "tenantClubs": [
+      "mesquite-high-school"
     ]
   },
   {
@@ -13222,16 +13149,18 @@
     ]
   },
   {
-    "id": "coliseo-live",
-    "name": "Coliseo Live",
-    "city": null,
-    "countryCode": "COL",
+    "id": "peden-stadium",
+    "name": "Peden Stadium",
+    "city": "Athens",
+    "countryCode": "USA",
     "capacity": 24000,
-    "tenantClubs": []
+    "tenantClubs": [
+      "ohio-bobcats"
+    ]
   },
   {
-    "id": "matsue-athletic-stadium",
-    "name": "Matsue Athletic Stadium",
+    "id": "mie-prefecture-arena",
+    "name": "Mie Prefecture Arena",
     "city": null,
     "countryCode": "JPN",
     "capacity": 24000,
@@ -13248,89 +13177,38 @@
     ]
   },
   {
-    "id": "jsu-stadium",
-    "name": "JSU Stadium",
+    "id": "coliseo-live",
+    "name": "Coliseo Live",
     "city": null,
-    "countryCode": "USA",
+    "countryCode": "COL",
+    "capacity": 24000,
+    "tenantClubs": []
+  },
+  {
+    "id": "diego-armando-maradona-stadium",
+    "name": "Diego Armando Maradona Stadium",
+    "city": "Buenos Aires",
+    "countryCode": "ARG",
     "capacity": 24000,
     "tenantClubs": [
-      "jacksonville-state-gamecocks",
-      "jacksonville-state-gamecocks-football"
+      "argentinos-juniors",
+      "argentinos-juniors-women"
     ]
   },
   {
-    "id": "stade-24-novembre",
-    "name": "Stade 24 Novembre",
+    "id": "dreisamstadion",
+    "name": "Dreisamstadion",
     "city": null,
-    "countryCode": "COD",
+    "countryCode": "DEU",
     "capacity": 24000,
     "tenantClubs": [
-      "daring-club-motema-pembe"
+      "sc-freiburg",
+      "sc-freiburg-ii"
     ]
   },
   {
-    "id": "bahrain-national-stadium",
-    "name": "Bahrain National Stadium",
-    "city": "Riffa",
-    "countryCode": "BHR",
-    "capacity": 24000,
-    "tenantClubs": [
-      "bahrain-men-s-national-football-team"
-    ]
-  },
-  {
-    "id": "stadio-silvio-appiani",
-    "name": "Stadio Silvio Appiani",
-    "city": null,
-    "countryCode": "ITA",
-    "capacity": 24000,
-    "tenantClubs": [
-      "calcio-padova"
-    ]
-  },
-  {
-    "id": "kenan-memorial-stadium",
-    "name": "Kenan Memorial Stadium",
-    "city": null,
-    "countryCode": "USA",
-    "capacity": 24000,
-    "tenantClubs": [
-      "north-carolina-tar-heels"
-    ]
-  },
-  {
-    "id": "peden-stadium",
-    "name": "Peden Stadium",
-    "city": "Ohio University",
-    "countryCode": "USA",
-    "capacity": 24000,
-    "tenantClubs": [
-      "ohio-bobcats"
-    ]
-  },
-  {
-    "id": "dobsonville-stadium",
-    "name": "Dobsonville Stadium",
-    "city": null,
-    "countryCode": "ZAF",
-    "capacity": 24000,
-    "tenantClubs": [
-      "moroka-swallows-f-c"
-    ]
-  },
-  {
-    "id": "estadio-mansiche",
-    "name": "Estadio Mansiche",
-    "city": null,
-    "countryCode": "PER",
-    "capacity": 24000,
-    "tenantClubs": [
-      "cd-universidad-cesar-vallejo"
-    ]
-  },
-  {
-    "id": "mie-prefecture-arena",
-    "name": "Mie Prefecture Arena",
+    "id": "matsue-athletic-stadium",
+    "name": "Matsue Athletic Stadium",
     "city": null,
     "countryCode": "JPN",
     "capacity": 24000,
@@ -13347,21 +13225,11 @@
   {
     "id": "estadio-dr-magalhaes-pessoa",
     "name": "Estádio Dr. Magalhães Pessoa",
-    "city": "Leiria",
+    "city": null,
     "countryCode": "PRT",
     "capacity": 23888,
     "tenantClubs": [
       "u-d-leiria"
-    ]
-  },
-  {
-    "id": "stadio-dino-manuzzi",
-    "name": "Stadio Dino Manuzzi",
-    "city": null,
-    "countryCode": "ITA",
-    "capacity": 23860,
-    "tenantClubs": [
-      "cesena-fc"
     ]
   },
   {
@@ -13372,6 +13240,16 @@
     "capacity": 23860,
     "tenantClubs": [
       "hallescher-fc"
+    ]
+  },
+  {
+    "id": "stadio-dino-manuzzi",
+    "name": "Stadio Dino Manuzzi",
+    "city": null,
+    "countryCode": "ITA",
+    "capacity": 23860,
+    "tenantClubs": [
+      "cesena-fc"
     ]
   },
   {
@@ -13414,7 +13292,7 @@
   {
     "id": "huskie-stadium",
     "name": "Huskie Stadium",
-    "city": "Northern Illinois University",
+    "city": "DeKalb",
     "countryCode": "USA",
     "capacity": 23595,
     "tenantClubs": [
@@ -13424,7 +13302,7 @@
   {
     "id": "pampeloponnisiako-stadium",
     "name": "Pampeloponnisiako Stadium",
-    "city": "Koukouli, Patras",
+    "city": "Patras",
     "countryCode": "GRC",
     "capacity": 23588,
     "tenantClubs": [
@@ -13434,7 +13312,7 @@
   {
     "id": "el-sadar-stadium",
     "name": "El Sadar Stadium",
-    "city": "Pamplona",
+    "city": null,
     "countryCode": "ESP",
     "capacity": 23576,
     "tenantClubs": [
@@ -13473,16 +13351,6 @@
     ]
   },
   {
-    "id": "east-bengal-ground",
-    "name": "East Bengal Ground",
-    "city": "Maidan",
-    "countryCode": "IND",
-    "capacity": 23500,
-    "tenantClubs": [
-      "east-bengal-club"
-    ]
-  },
-  {
     "id": "fitton-field",
     "name": "Fitton Field",
     "city": "Worcester",
@@ -13490,6 +13358,16 @@
     "capacity": 23500,
     "tenantClubs": [
       "holy-cross-crusaders-football"
+    ]
+  },
+  {
+    "id": "east-bengal-ground",
+    "name": "East Bengal Ground",
+    "city": "Kolkata",
+    "countryCode": "IND",
+    "capacity": 23500,
+    "tenantClubs": [
+      "east-bengal-club"
     ]
   },
   {
@@ -13616,87 +13494,33 @@
     ]
   },
   {
-    "id": "brookvale-oval",
-    "name": "Brookvale Oval",
-    "city": "Pittwater Road",
-    "countryCode": "AUS",
+    "id": "estadio-eduardo-santos",
+    "name": "Estadio Eduardo Santos",
+    "city": "Santa Marta",
+    "countryCode": "COL",
     "capacity": 23000,
     "tenantClubs": [
-      "manly-warringah-sea-eagles"
+      "union-magdalena"
     ]
   },
   {
-    "id": "suphanburi-municipality-stadium",
-    "name": "Suphanburi Municipality Stadium",
+    "id": "estadio-parque-artigas",
+    "name": "Estadio Parque Artigas",
     "city": null,
-    "countryCode": "THA",
+    "countryCode": "URY",
     "capacity": 23000,
     "tenantClubs": [
-      "suphanburi-f-c"
+      "paysandu-f-c"
     ]
-  },
-  {
-    "id": "oppenheimer-stadium",
-    "name": "Oppenheimer Stadium",
-    "city": null,
-    "countryCode": "ZAF",
-    "capacity": 23000,
-    "tenantClubs": []
-  },
-  {
-    "id": "q2147912",
-    "name": "Q2147912",
-    "city": null,
-    "countryCode": "DEU",
-    "capacity": 23000,
-    "tenantClubs": [
-      "msv-moers"
-    ]
-  },
-  {
-    "id": "q5847768",
-    "name": "Q5847768",
-    "city": null,
-    "countryCode": "ARG",
-    "capacity": 23000,
-    "tenantClubs": []
-  },
-  {
-    "id": "estadio-carlos-gonzalez",
-    "name": "Estadio Carlos González",
-    "city": null,
-    "countryCode": "MEX",
-    "capacity": 23000,
-    "tenantClubs": [
-      "dorados-de-sinaloa"
-    ]
-  },
-  {
-    "id": "alamo-stadium",
-    "name": "Alamo Stadium",
-    "city": null,
-    "countryCode": "USA",
-    "capacity": 23000,
-    "tenantClubs": []
   },
   {
     "id": "nicolae-rainea-stadium",
     "name": "Nicolae Rainea Stadium",
-    "city": "Galați County",
+    "city": null,
     "countryCode": "ROU",
     "capacity": 23000,
     "tenantClubs": [
       "sc-otelul-galati"
-    ]
-  },
-  {
-    "id": "spartak-stadium",
-    "name": "Spartak Stadium",
-    "city": null,
-    "countryCode": "KGZ",
-    "capacity": 23000,
-    "tenantClubs": [
-      "kyrgyzstan-men-s-national-football-team"
     ]
   },
   {
@@ -13710,13 +13534,23 @@
     ]
   },
   {
-    "id": "estadio-eduardo-santos",
-    "name": "Estadio Eduardo Santos",
-    "city": "Santa Marta",
-    "countryCode": "COL",
+    "id": "suphanburi-municipality-stadium",
+    "name": "Suphanburi Municipality Stadium",
+    "city": null,
+    "countryCode": "THA",
     "capacity": 23000,
     "tenantClubs": [
-      "union-magdalena"
+      "suphanburi-f-c"
+    ]
+  },
+  {
+    "id": "brookvale-oval",
+    "name": "Brookvale Oval",
+    "city": null,
+    "countryCode": "AUS",
+    "capacity": 23000,
+    "tenantClubs": [
+      "manly-warringah-sea-eagles"
     ]
   },
   {
@@ -13728,14 +13562,22 @@
     "tenantClubs": []
   },
   {
-    "id": "estadio-parque-artigas",
-    "name": "Estadio Parque Artigas",
+    "id": "spartak-stadium",
+    "name": "Spartak Stadium",
     "city": null,
-    "countryCode": "URY",
+    "countryCode": "KGZ",
     "capacity": 23000,
     "tenantClubs": [
-      "paysandu-f-c"
+      "kyrgyzstan-men-s-national-football-team"
     ]
+  },
+  {
+    "id": "oppenheimer-stadium",
+    "name": "Oppenheimer Stadium",
+    "city": null,
+    "countryCode": "ZAF",
+    "capacity": 23000,
+    "tenantClubs": []
   },
   {
     "id": "eva-peron-stadium",
@@ -13745,6 +13587,24 @@
     "capacity": 23000,
     "tenantClubs": [
       "club-atletico-sarmiento"
+    ]
+  },
+  {
+    "id": "alamo-stadium",
+    "name": "Alamo Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 23000,
+    "tenantClubs": []
+  },
+  {
+    "id": "estadio-carlos-gonzalez",
+    "name": "Estadio Carlos González",
+    "city": null,
+    "countryCode": "MEX",
+    "capacity": 23000,
+    "tenantClubs": [
+      "dorados-de-sinaloa"
     ]
   },
   {
@@ -13778,16 +13638,6 @@
     ]
   },
   {
-    "id": "q1483145",
-    "name": "Q1483145",
-    "city": null,
-    "countryCode": "DEU",
-    "capacity": 22800,
-    "tenantClubs": [
-      "stv-horst-emscher"
-    ]
-  },
-  {
     "id": "duhok-stadium",
     "name": "Duhok Stadium",
     "city": null,
@@ -13810,7 +13660,7 @@
   {
     "id": "gsp-stadium",
     "name": "GSP Stadium",
-    "city": "Strovolos",
+    "city": null,
     "countryCode": "CYP",
     "capacity": 22709,
     "tenantClubs": [
@@ -13823,20 +13673,12 @@
   {
     "id": "panthessaliko-stadium",
     "name": "Panthessaliko Stadium",
-    "city": "Nea Ionia",
+    "city": null,
     "countryCode": "GRC",
     "capacity": 22700,
     "tenantClubs": [
       "volos-n-f-c"
     ]
-  },
-  {
-    "id": "saida-municipal-stadium",
-    "name": "Saida Municipal Stadium",
-    "city": null,
-    "countryCode": "LBN",
-    "capacity": 22600,
-    "tenantClubs": []
   },
   {
     "id": "arena-conda",
@@ -13847,6 +13689,14 @@
     "tenantClubs": [
       "associacao-chapecoense-de-futebol"
     ]
+  },
+  {
+    "id": "saida-municipal-stadium",
+    "name": "Saida Municipal Stadium",
+    "city": null,
+    "countryCode": "LBN",
+    "capacity": 22600,
+    "tenantClubs": []
   },
   {
     "id": "historic-crew-stadium",
@@ -13872,7 +13722,7 @@
   {
     "id": "arthur-ashe-stadium",
     "name": "Arthur Ashe Stadium",
-    "city": "USTA Billie Jean King National Tennis Center",
+    "city": "New York City",
     "countryCode": "USA",
     "capacity": 22547,
     "tenantClubs": [
@@ -13892,7 +13742,7 @@
   {
     "id": "leag-energie-stadion",
     "name": "LEAG Energie Stadion",
-    "city": "Sandow",
+    "city": "Cottbus",
     "countryCode": "DEU",
     "capacity": 22528,
     "tenantClubs": [
@@ -13900,32 +13750,12 @@
     ]
   },
   {
-    "id": "estadio-gonzalo-pozo-ripalda",
-    "name": "Estadio Gonzalo Pozo Ripalda",
+    "id": "jack-spinks-stadium",
+    "name": "Jack Spinks Stadium",
     "city": null,
-    "countryCode": "ECU",
-    "capacity": 22500,
-    "tenantClubs": []
-  },
-  {
-    "id": "eleda-stadion",
-    "name": "Eleda Stadion",
-    "city": "Stadionområdet",
-    "countryCode": "SWE",
-    "capacity": 22500,
-    "tenantClubs": [
-      "malmo-ff-herr"
-    ]
-  },
-  {
-    "id": "energizer-park",
-    "name": "Energizer Park",
-    "city": "Downtown West",
     "countryCode": "USA",
     "capacity": 22500,
-    "tenantClubs": [
-      "st-louis-city-sc"
-    ]
+    "tenantClubs": []
   },
   {
     "id": "estadio-chamartin",
@@ -13936,6 +13766,32 @@
     "tenantClubs": [
       "real-madrid-club-de-futbol"
     ]
+  },
+  {
+    "id": "central-stadium-rus-3",
+    "name": "Central Stadium",
+    "city": null,
+    "countryCode": "RUS",
+    "capacity": 22500,
+    "tenantClubs": [
+      "fc-yenisey-krasnoyarsk"
+    ]
+  },
+  {
+    "id": "air-albania-stadium",
+    "name": "Air Albania Stadium",
+    "city": null,
+    "countryCode": "ALB",
+    "capacity": 22500,
+    "tenantClubs": []
+  },
+  {
+    "id": "estadio-gonzalo-pozo-ripalda",
+    "name": "Estadio Gonzalo Pozo Ripalda",
+    "city": null,
+    "countryCode": "ECU",
+    "capacity": 22500,
+    "tenantClubs": []
   },
   {
     "id": "hamilton-stadium",
@@ -13949,20 +13805,14 @@
     ]
   },
   {
-    "id": "jack-spinks-stadium",
-    "name": "Jack Spinks Stadium",
-    "city": "Lorman",
+    "id": "energizer-park",
+    "name": "Energizer Park",
+    "city": "St. Louis",
     "countryCode": "USA",
     "capacity": 22500,
-    "tenantClubs": []
-  },
-  {
-    "id": "air-albania-stadium",
-    "name": "Air Albania Stadium",
-    "city": null,
-    "countryCode": "ALB",
-    "capacity": 22500,
-    "tenantClubs": []
+    "tenantClubs": [
+      "st-louis-city-sc"
+    ]
   },
   {
     "id": "penrith-stadium",
@@ -13972,6 +13822,16 @@
     "capacity": 22500,
     "tenantClubs": [
       "penrith-panthers"
+    ]
+  },
+  {
+    "id": "eleda-stadion",
+    "name": "Eleda Stadion",
+    "city": null,
+    "countryCode": "SWE",
+    "capacity": 22500,
+    "tenantClubs": [
+      "malmo-ff-herr"
     ]
   },
   {
@@ -14015,14 +13875,6 @@
     ]
   },
   {
-    "id": "ska-arena",
-    "name": "SKA Arena",
-    "city": null,
-    "countryCode": "RUS",
-    "capacity": 22300,
-    "tenantClubs": []
-  },
-  {
     "id": "estadio-olimpico-benito-juarez",
     "name": "Estadio Olímpico Benito Juárez",
     "city": null,
@@ -14035,9 +13887,17 @@
     ]
   },
   {
+    "id": "ska-arena",
+    "name": "SKA Arena",
+    "city": null,
+    "countryCode": "RUS",
+    "capacity": 22300,
+    "tenantClubs": []
+  },
+  {
     "id": "olympic-stadium-x",
     "name": "Olympic Stadium",
-    "city": "Amsterdam Oud-Zuid",
+    "city": null,
     "countryCode": null,
     "capacity": 22288,
     "tenantClubs": [
@@ -14072,7 +13932,7 @@
   {
     "id": "gradski-vrt-stadium",
     "name": "Gradski Vrt Stadium",
-    "city": "Novi grad (Osijek)",
+    "city": "Osijek",
     "countryCode": "HRV",
     "capacity": 22050,
     "tenantClubs": [
@@ -14112,80 +13972,145 @@
     ]
   },
   {
-    "id": "barasat-stadium",
-    "name": "Barasat Stadium",
-    "city": "Barasat",
-    "countryCode": "IND",
+    "id": "dinamo-stadium",
+    "name": "Dinamo Stadium",
+    "city": null,
+    "countryCode": "BLR",
     "capacity": 22000,
     "tenantClubs": [
-      "mohun-bagan-ac"
+      "belarus-men-s-national-football-team",
+      "fc-dinamo-minsk"
     ]
   },
   {
-    "id": "q10276944",
-    "name": "Q10276944",
+    "id": "evgrapi-shevardnadze-stadium",
+    "name": "Evgrapi Shevardnadze Stadium",
+    "city": null,
+    "countryCode": "GEO",
+    "capacity": 22000,
+    "tenantClubs": [
+      "fc-guria-lanchkhuti"
+    ]
+  },
+  {
+    "id": "roumde-adjia-stadium",
+    "name": "Roumdé Adjia Stadium",
+    "city": "Garoua",
+    "countryCode": "CMR",
+    "capacity": 22000,
+    "tenantClubs": [
+      "coton-sport-fc-de-garoua"
+    ]
+  },
+  {
+    "id": "lokomotiv-stadium",
+    "name": "Lokomotiv Stadium",
+    "city": null,
+    "countryCode": "BGR",
+    "capacity": 22000,
+    "tenantClubs": [
+      "fc-lokomotiv-1929-sofia"
+    ]
+  },
+  {
+    "id": "stade-regional-nyamirambo",
+    "name": "Stade Régional Nyamirambo",
+    "city": null,
+    "countryCode": "RWA",
+    "capacity": 22000,
+    "tenantClubs": [
+      "as-kigali",
+      "gorilla-f-c",
+      "q111979186",
+      "q125149128",
+      "s-c-kiyovu-sports"
+    ]
+  },
+  {
+    "id": "estadio-guillermo-plazas-alcid",
+    "name": "Estadio Guillermo Plazas Alcid",
+    "city": "Neiva",
+    "countryCode": "COL",
+    "capacity": 22000,
+    "tenantClubs": [
+      "atletico-huila"
+    ]
+  },
+  {
+    "id": "estadio-ignacio-zaragoza",
+    "name": "Estadio Ignacio Zaragoza",
+    "city": null,
+    "countryCode": "MEX",
+    "capacity": 22000,
+    "tenantClubs": [
+      "pericos-de-puebla"
+    ]
+  },
+  {
+    "id": "estadio-del-bicentenario",
+    "name": "Estadio del Bicentenario",
+    "city": "Tepic",
+    "countryCode": "MEX",
+    "capacity": 22000,
+    "tenantClubs": []
+  },
+  {
+    "id": "ninh-binh-stadium",
+    "name": "Ninh Binh Stadium",
+    "city": null,
+    "countryCode": "VNM",
+    "capacity": 22000,
+    "tenantClubs": [
+      "vissai-ninh-binh-f-c"
+    ]
+  },
+  {
+    "id": "haras-el-hodoud-stadium",
+    "name": "Haras El Hodoud Stadium",
+    "city": null,
+    "countryCode": "EGY",
+    "capacity": 22000,
+    "tenantClubs": [
+      "el-raja-marsa-matruh",
+      "haras-el-hodood-sc"
+    ]
+  },
+  {
+    "id": "juan-ramon-loubriel-stadium",
+    "name": "Juan Ramón Loubriel Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 22000,
+    "tenantClubs": [
+      "bayamon-fc"
+    ]
+  },
+  {
+    "id": "takhti-stadium-abadan",
+    "name": "Takhti Stadium (Abadan)",
+    "city": null,
+    "countryCode": "IRN",
+    "capacity": 22000,
+    "tenantClubs": [
+      "sanat-naft-f-c"
+    ]
+  },
+  {
+    "id": "estadio-doutor-herminio-ometto",
+    "name": "Estádio Doutor Hermínio Ometto",
     "city": null,
     "countryCode": "BRA",
     "capacity": 22000,
     "tenantClubs": []
   },
   {
-    "id": "olen-park",
-    "name": "Olën Park",
+    "id": "pam-brink-stadium",
+    "name": "PAM Brink Stadium",
     "city": null,
     "countryCode": "ZAF",
     "capacity": 22000,
     "tenantClubs": [
-      "platinum-city-f-c"
-    ]
-  },
-  {
-    "id": "mohammed-al-hamad-stadium",
-    "name": "Mohammed Al-Hamad Stadium",
-    "city": "Hawally",
-    "countryCode": "KWT",
-    "capacity": 22000,
-    "tenantClubs": [
-      "qadsia-sc"
-    ]
-  },
-  {
-    "id": "stade-de-franceville",
-    "name": "Stade de Franceville",
-    "city": null,
-    "countryCode": "GAB",
-    "capacity": 22000,
-    "tenantClubs": []
-  },
-  {
-    "id": "stade-de-la-cavee-verte",
-    "name": "Stade de la Cavée Verte",
-    "city": null,
-    "countryCode": "FRA",
-    "capacity": 22000,
-    "tenantClubs": [
-      "le-havre-ac"
-    ]
-  },
-  {
-    "id": "fossetts-farm-stadium",
-    "name": "Fossetts Farm Stadium",
-    "city": null,
-    "countryCode": "GBR",
-    "capacity": 22000,
-    "tenantClubs": [
-      "southend-united-f-c"
-    ]
-  },
-  {
-    "id": "intwari-stadium",
-    "name": "Intwari Stadium",
-    "city": null,
-    "countryCode": "BDI",
-    "capacity": 22000,
-    "tenantClubs": [
-      "prince-louis-f-c",
-      "vital-o-fc"
+      "thanda-royal-zulu-f-c"
     ]
   },
   {
@@ -14207,71 +14132,65 @@
     ]
   },
   {
-    "id": "evgrapi-shevardnadze-stadium",
-    "name": "Evgrapi Shevardnadze Stadium",
+    "id": "delaware-stadium",
+    "name": "Delaware Stadium",
     "city": null,
-    "countryCode": "GEO",
+    "countryCode": "USA",
     "capacity": 22000,
     "tenantClubs": [
-      "fc-guria-lanchkhuti"
+      "delaware-fightin-blue-hens-football"
     ]
   },
   {
-    "id": "pam-brink-stadium",
-    "name": "PAM Brink Stadium",
+    "id": "moulay-el-hassan-stadium",
+    "name": "Moulay El Hassan Stadium",
     "city": null,
-    "countryCode": "ZAF",
+    "countryCode": "MAR",
     "capacity": 22000,
     "tenantClubs": [
-      "thanda-royal-zulu-f-c"
+      "fus-de-rabat"
     ]
   },
   {
-    "id": "vicarage-road",
-    "name": "Vicarage Road",
+    "id": "bmo-stadium",
+    "name": "BMO Stadium",
     "city": null,
-    "countryCode": "GBR",
+    "countryCode": "USA",
     "capacity": 22000,
     "tenantClubs": [
-      "watford-f-c"
+      "angel-city-fc",
+      "los-angeles-fc"
     ]
   },
   {
-    "id": "arena-vfg",
-    "name": "Arena VFG",
+    "id": "city-stadium",
+    "name": "City Stadium",
     "city": null,
-    "countryCode": "MEX",
-    "capacity": 22000,
-    "tenantClubs": []
-  },
-  {
-    "id": "cairo-military-academy-stadium",
-    "name": "Cairo Military Academy Stadium",
-    "city": null,
-    "countryCode": "EGY",
+    "countryCode": "USA",
     "capacity": 22000,
     "tenantClubs": [
-      "tala-ea-el-gaish-sc"
+      "richmond-kickers",
+      "richmond-spiders"
     ]
   },
   {
-    "id": "estadio-de-los-juegos-mediterraneos",
-    "name": "Estadio de los Juegos Mediterraneos",
+    "id": "chernomorets-stadium",
+    "name": "Chernomorets Stadium",
     "city": null,
-    "countryCode": "ESP",
+    "countryCode": "BGR",
     "capacity": 22000,
     "tenantClubs": [
-      "union-deportiva-almeria"
+      "fc-chernomorets-burgas"
     ]
   },
   {
-    "id": "estadio-guillermo-plazas-alcid",
-    "name": "Estadio Guillermo Plazas Alcid",
-    "city": "Neiva",
-    "countryCode": "COL",
+    "id": "stade-de-la-cavee-verte",
+    "name": "Stade de la Cavée Verte",
+    "city": null,
+    "countryCode": "FRA",
     "capacity": 22000,
     "tenantClubs": [
-      "atletico-huila"
+      "le-havre-ac"
     ]
   },
   {
@@ -14285,114 +14204,24 @@
     ]
   },
   {
-    "id": "dinamo-stadium",
-    "name": "Dinamo Stadium",
+    "id": "estadio-de-los-juegos-mediterraneos",
+    "name": "Estadio de los Juegos Mediterraneos",
     "city": null,
-    "countryCode": "BLR",
+    "countryCode": "ESP",
     "capacity": 22000,
     "tenantClubs": [
-      "belarus-men-s-national-football-team",
-      "fc-dinamo-minsk"
+      "union-deportiva-almeria"
     ]
   },
   {
-    "id": "roumde-adjia-stadium",
-    "name": "Roumdé Adjia Stadium",
-    "city": "Garoua",
-    "countryCode": "CMR",
+    "id": "chatsworth-stadium",
+    "name": "Chatsworth Stadium",
+    "city": "eThekwini Metropolitan Municipality",
+    "countryCode": "ZAF",
     "capacity": 22000,
     "tenantClubs": [
-      "coton-sport-fc-de-garoua"
-    ]
-  },
-  {
-    "id": "sabah-al-salem-stadium",
-    "name": "Sabah Al Salem Stadium",
-    "city": null,
-    "countryCode": "KWT",
-    "capacity": 22000,
-    "tenantClubs": [
-      "al-arabi-sc"
-    ]
-  },
-  {
-    "id": "parque-necaxa",
-    "name": "Parque Necaxa",
-    "city": null,
-    "countryCode": "MEX",
-    "capacity": 22000,
-    "tenantClubs": [
-      "club-necaxa"
-    ]
-  },
-  {
-    "id": "lokomotiv-stadium",
-    "name": "Lokomotiv Stadium",
-    "city": null,
-    "countryCode": "BGR",
-    "capacity": 22000,
-    "tenantClubs": [
-      "fc-lokomotiv-1929-sofia"
-    ]
-  },
-  {
-    "id": "mohun-bagan-ground",
-    "name": "Mohun Bagan Ground",
-    "city": null,
-    "countryCode": "IND",
-    "capacity": 22000,
-    "tenantClubs": [
-      "mohun-bagan-ac"
-    ]
-  },
-  {
-    "id": "estadio-doutor-herminio-ometto",
-    "name": "Estádio Doutor Hermínio Ometto",
-    "city": null,
-    "countryCode": "BRA",
-    "capacity": 22000,
-    "tenantClubs": []
-  },
-  {
-    "id": "stade-regional-nyamirambo",
-    "name": "Stade Régional Nyamirambo",
-    "city": null,
-    "countryCode": "RWA",
-    "capacity": 22000,
-    "tenantClubs": [
-      "as-kigali",
-      "gorilla-f-c",
-      "q111979186",
-      "q125149128",
-      "s-c-kiyovu-sports"
-    ]
-  },
-  {
-    "id": "guru-gobind-singh-stadium",
-    "name": "Guru Gobind Singh Stadium",
-    "city": null,
-    "countryCode": "IND",
-    "capacity": 22000,
-    "tenantClubs": [
-      "national-games-of-india"
-    ]
-  },
-  {
-    "id": "bullring-by-the-sea",
-    "name": "Bullring by the Sea",
-    "city": null,
-    "countryCode": "MEX",
-    "capacity": 22000,
-    "tenantClubs": []
-  },
-  {
-    "id": "estadio-zequinha-roriz",
-    "name": "Estádio Zequinha Roriz",
-    "city": "Luziânia",
-    "countryCode": "BRA",
-    "capacity": 22000,
-    "tenantClubs": [
-      "associacao-atletica-luziania"
+      "lamontville-golden-arrows-f-c",
+      "real-kings-f-c"
     ]
   },
   {
@@ -14406,41 +14235,70 @@
     ]
   },
   {
-    "id": "kitakami-stadium",
-    "name": "Kitakami Stadium",
-    "city": "Kitakami",
-    "countryCode": "JPN",
+    "id": "estadio-zequinha-roriz",
+    "name": "Estádio Zequinha Roriz",
+    "city": "Luziânia",
+    "countryCode": "BRA",
+    "capacity": 22000,
+    "tenantClubs": [
+      "associacao-atletica-luziania"
+    ]
+  },
+  {
+    "id": "mahamasina-municipal-stadium",
+    "name": "Mahamasina Municipal Stadium",
+    "city": null,
+    "countryCode": "MDG",
+    "capacity": 22000,
+    "tenantClubs": [
+      "madagascar-men-s-national-football-team",
+      "madagascar-national-rugby-union-team"
+    ]
+  },
+  {
+    "id": "stephen-keshi-stadium",
+    "name": "Stephen Keshi Stadium",
+    "city": null,
+    "countryCode": "NGA",
     "capacity": 22000,
     "tenantClubs": []
   },
   {
-    "id": "takhti-stadium-abadan",
-    "name": "Takhti Stadium (Abadan)",
+    "id": "bullring-by-the-sea",
+    "name": "Bullring by the Sea",
     "city": null,
-    "countryCode": "IRN",
+    "countryCode": "MEX",
+    "capacity": 22000,
+    "tenantClubs": []
+  },
+  {
+    "id": "vicarage-road",
+    "name": "Vicarage Road",
+    "city": null,
+    "countryCode": "GBR",
     "capacity": 22000,
     "tenantClubs": [
-      "sanat-naft-f-c"
+      "watford-f-c"
     ]
   },
   {
-    "id": "delaware-stadium",
-    "name": "Delaware Stadium",
+    "id": "guru-gobind-singh-stadium",
+    "name": "Guru Gobind Singh Stadium",
     "city": null,
-    "countryCode": "USA",
+    "countryCode": "IND",
     "capacity": 22000,
     "tenantClubs": [
-      "delaware-fightin-blue-hens-football"
+      "national-games-of-india"
     ]
   },
   {
-    "id": "juan-ramon-loubriel-stadium",
-    "name": "Juan Ramón Loubriel Stadium",
-    "city": "Cerro Gordo",
-    "countryCode": "USA",
+    "id": "parque-necaxa",
+    "name": "Parque Necaxa",
+    "city": null,
+    "countryCode": "MEX",
     "capacity": 22000,
     "tenantClubs": [
-      "bayamon-fc"
+      "club-necaxa"
     ]
   },
   {
@@ -14456,88 +14314,12 @@
     ]
   },
   {
-    "id": "belite-orli-stadium",
-    "name": "Belite Orli Stadium",
-    "city": "Pleven",
-    "countryCode": "BGR",
+    "id": "stade-de-franceville",
+    "name": "Stade de Franceville",
+    "city": null,
+    "countryCode": "GAB",
     "capacity": 22000,
     "tenantClubs": []
-  },
-  {
-    "id": "lobatse-stadium",
-    "name": "Lobatse Stadium",
-    "city": null,
-    "countryCode": "BWA",
-    "capacity": 22000,
-    "tenantClubs": []
-  },
-  {
-    "id": "fuling-stadium",
-    "name": "Fuling Stadium",
-    "city": null,
-    "countryCode": "CHN",
-    "capacity": 22000,
-    "tenantClubs": []
-  },
-  {
-    "id": "ninh-binh-stadium",
-    "name": "Ninh Binh Stadium",
-    "city": null,
-    "countryCode": "VNM",
-    "capacity": 22000,
-    "tenantClubs": [
-      "vissai-ninh-binh-f-c"
-    ]
-  },
-  {
-    "id": "stephen-keshi-stadium",
-    "name": "Stephen Keshi Stadium",
-    "city": null,
-    "countryCode": "NGA",
-    "capacity": 22000,
-    "tenantClubs": []
-  },
-  {
-    "id": "chernomorets-stadium",
-    "name": "Chernomorets Stadium",
-    "city": null,
-    "countryCode": "BGR",
-    "capacity": 22000,
-    "tenantClubs": [
-      "fc-chernomorets-burgas"
-    ]
-  },
-  {
-    "id": "city-stadium",
-    "name": "City Stadium",
-    "city": null,
-    "countryCode": "USA",
-    "capacity": 22000,
-    "tenantClubs": [
-      "richmond-kickers",
-      "richmond-spiders"
-    ]
-  },
-  {
-    "id": "bmo-stadium",
-    "name": "BMO Stadium",
-    "city": null,
-    "countryCode": "USA",
-    "capacity": 22000,
-    "tenantClubs": [
-      "angel-city-fc",
-      "los-angeles-fc"
-    ]
-  },
-  {
-    "id": "estadio-ignacio-zaragoza",
-    "name": "Estadio Ignacio Zaragoza",
-    "city": null,
-    "countryCode": "MEX",
-    "capacity": 22000,
-    "tenantClubs": [
-      "pericos-de-puebla"
-    ]
   },
   {
     "id": "estadio-olimpico-de-la-uach",
@@ -14552,50 +14334,31 @@
     ]
   },
   {
-    "id": "mahamasina-municipal-stadium",
-    "name": "Mahamasina Municipal Stadium",
+    "id": "lobatse-stadium",
+    "name": "Lobatse Stadium",
     "city": null,
-    "countryCode": "MDG",
+    "countryCode": "BWA",
+    "capacity": 22000,
+    "tenantClubs": []
+  },
+  {
+    "id": "mohammed-al-hamad-stadium",
+    "name": "Mohammed Al-Hamad Stadium",
+    "city": null,
+    "countryCode": "KWT",
     "capacity": 22000,
     "tenantClubs": [
-      "madagascar-men-s-national-football-team",
-      "madagascar-national-rugby-union-team"
+      "qadsia-sc"
     ]
   },
   {
     "id": "estadio-venustiano-carranza",
     "name": "Estadio Venustiano Carranza",
-    "city": "Morelia",
+    "city": null,
     "countryCode": "MEX",
     "capacity": 22000,
     "tenantClubs": [
       "club-atletico-morelia"
-    ]
-  },
-  {
-    "id": "akita-prefectural-central-park-athletic-stadium",
-    "name": "Akita Prefectural Central Park Athletic Stadium",
-    "city": null,
-    "countryCode": "JPN",
-    "capacity": 22000,
-    "tenantClubs": []
-  },
-  {
-    "id": "estadio-del-bicentenario",
-    "name": "Estadio del Bicentenario",
-    "city": "Tepic",
-    "countryCode": "MEX",
-    "capacity": 22000,
-    "tenantClubs": []
-  },
-  {
-    "id": "moulay-el-hassan-stadium",
-    "name": "Moulay El Hassan Stadium",
-    "city": null,
-    "countryCode": "MAR",
-    "capacity": 22000,
-    "tenantClubs": [
-      "fus-de-rabat"
     ]
   },
   {
@@ -14609,9 +14372,76 @@
     ]
   },
   {
+    "id": "intwari-stadium",
+    "name": "Intwari Stadium",
+    "city": null,
+    "countryCode": "BDI",
+    "capacity": 22000,
+    "tenantClubs": [
+      "prince-louis-f-c",
+      "vital-o-fc"
+    ]
+  },
+  {
+    "id": "belite-orli-stadium",
+    "name": "Belite Orli Stadium",
+    "city": "Pleven",
+    "countryCode": "BGR",
+    "capacity": 22000,
+    "tenantClubs": []
+  },
+  {
+    "id": "arena-vfg",
+    "name": "Arena VFG",
+    "city": null,
+    "countryCode": "MEX",
+    "capacity": 22000,
+    "tenantClubs": []
+  },
+  {
+    "id": "fossetts-farm-stadium",
+    "name": "Fossetts Farm Stadium",
+    "city": null,
+    "countryCode": "GBR",
+    "capacity": 22000,
+    "tenantClubs": [
+      "southend-united-f-c"
+    ]
+  },
+  {
+    "id": "barasat-stadium",
+    "name": "Barasat Stadium",
+    "city": "Barasat",
+    "countryCode": "IND",
+    "capacity": 22000,
+    "tenantClubs": [
+      "mohun-bagan-ac"
+    ]
+  },
+  {
+    "id": "olen-park",
+    "name": "Olën Park",
+    "city": null,
+    "countryCode": "ZAF",
+    "capacity": 22000,
+    "tenantClubs": [
+      "platinum-city-f-c"
+    ]
+  },
+  {
+    "id": "cairo-military-academy-stadium",
+    "name": "Cairo Military Academy Stadium",
+    "city": null,
+    "countryCode": "EGY",
+    "capacity": 22000,
+    "tenantClubs": [
+      "tala-ea-el-gaish-sc"
+    ]
+  },
+  {
     "id": "bassendean-oval",
     "name": "Bassendean Oval",
-    "city": "Bassendean",
+    "city": null,
     "countryCode": "AUS",
     "capacity": 22000,
     "tenantClubs": [
@@ -14619,26 +14449,48 @@
     ]
   },
   {
-    "id": "haras-el-hodoud-stadium",
-    "name": "Haras El Hodoud Stadium",
+    "id": "fuling-stadium",
+    "name": "Fuling Stadium",
     "city": null,
-    "countryCode": "EGY",
+    "countryCode": "CHN",
+    "capacity": 22000,
+    "tenantClubs": []
+  },
+  {
+    "id": "sabah-al-salem-stadium",
+    "name": "Sabah Al Salem Stadium",
+    "city": null,
+    "countryCode": "KWT",
     "capacity": 22000,
     "tenantClubs": [
-      "el-raja-marsa-matruh",
-      "haras-el-hodood-sc"
+      "al-arabi-sc"
     ]
   },
   {
-    "id": "chatsworth-stadium",
-    "name": "Chatsworth Stadium",
-    "city": "Chatsworth",
-    "countryCode": "ZAF",
+    "id": "akita-prefectural-central-park-athletic-stadium",
+    "name": "Akita Prefectural Central Park Athletic Stadium",
+    "city": null,
+    "countryCode": "JPN",
+    "capacity": 22000,
+    "tenantClubs": []
+  },
+  {
+    "id": "mohun-bagan-ground",
+    "name": "Mohun Bagan Ground",
+    "city": null,
+    "countryCode": "IND",
     "capacity": 22000,
     "tenantClubs": [
-      "lamontville-golden-arrows-f-c",
-      "real-kings-f-c"
+      "mohun-bagan-ac"
     ]
+  },
+  {
+    "id": "kitakami-stadium",
+    "name": "Kitakami Stadium",
+    "city": null,
+    "countryCode": "JPN",
+    "capacity": 22000,
+    "tenantClubs": []
   },
   {
     "id": "konya-ataturk-stadium",
@@ -14724,7 +14576,7 @@
   {
     "id": "stadion-an-der-alten-forsterei",
     "name": "Stadion An der Alten Försterei",
-    "city": "Köpenick",
+    "city": "Berlin",
     "countryCode": "DEU",
     "capacity": 21704,
     "tenantClubs": [
@@ -14763,6 +14615,16 @@
     ]
   },
   {
+    "id": "kyoto-stadium",
+    "name": "Kyoto Stadium",
+    "city": null,
+    "countryCode": "JPN",
+    "capacity": 21600,
+    "tenantClubs": [
+      "kyoto-sanga-fc"
+    ]
+  },
+  {
     "id": "estadio-willie-davids",
     "name": "Estádio Willie Davids",
     "city": "Maringá",
@@ -14771,16 +14633,6 @@
     "tenantClubs": [
       "aruko-sports-brasil",
       "gremio-de-esportes-maringa"
-    ]
-  },
-  {
-    "id": "kyoto-stadium",
-    "name": "Kyoto Stadium",
-    "city": "Kameoka",
-    "countryCode": "JPN",
-    "capacity": 21600,
-    "tenantClubs": [
-      "kyoto-sanga-fc"
     ]
   },
   {
@@ -14806,9 +14658,41 @@
     ]
   },
   {
+    "id": "hans-walter-wild-stadion",
+    "name": "Hans-Walter-Wild-Stadion",
+    "city": null,
+    "countryCode": "DEU",
+    "capacity": 21500,
+    "tenantClubs": [
+      "spvgg-bayreuth"
+    ]
+  },
+  {
+    "id": "gemeentelijk-sportpark-kaalheide",
+    "name": "Gemeentelijk Sportpark Kaalheide",
+    "city": null,
+    "countryCode": null,
+    "capacity": 21500,
+    "tenantClubs": [
+      "roda-jc",
+      "roda-jc-kerkrade"
+    ]
+  },
+  {
+    "id": "brec-memorial-stadium",
+    "name": "BREC Memorial Stadium",
+    "city": "Baton Rouge",
+    "countryCode": "USA",
+    "capacity": 21500,
+    "tenantClubs": [
+      "louisiana-bayou-storm-surge",
+      "louisiana-high-school-athletic-association"
+    ]
+  },
+  {
     "id": "lotto-park",
     "name": "Lotto Park",
-    "city": "Astrid Park",
+    "city": "Brussels-Capital Region",
     "countryCode": "BEL",
     "capacity": 21500,
     "tenantClubs": [
@@ -14824,38 +14708,6 @@
     "tenantClubs": [
       "club-de-gimnasia-y-esgrima-la-plata",
       "gimnasia-y-esgrima-la-plata-women"
-    ]
-  },
-  {
-    "id": "gemeentelijk-sportpark-kaalheide",
-    "name": "Gemeentelijk Sportpark Kaalheide",
-    "city": null,
-    "countryCode": null,
-    "capacity": 21500,
-    "tenantClubs": [
-      "roda-jc",
-      "roda-jc-kerkrade"
-    ]
-  },
-  {
-    "id": "hans-walter-wild-stadion",
-    "name": "Hans-Walter-Wild-Stadion",
-    "city": null,
-    "countryCode": "DEU",
-    "capacity": 21500,
-    "tenantClubs": [
-      "spvgg-bayreuth"
-    ]
-  },
-  {
-    "id": "brec-memorial-stadium",
-    "name": "BREC Memorial Stadium",
-    "city": "Baton Rouge",
-    "countryCode": "USA",
-    "capacity": 21500,
-    "tenantClubs": [
-      "louisiana-bayou-storm-surge",
-      "louisiana-high-school-athletic-association"
     ]
   },
   {
@@ -14897,7 +14749,7 @@
   {
     "id": "nilphamari-stadium",
     "name": "Nilphamari Stadium",
-    "city": "Nilphamari District",
+    "city": null,
     "countryCode": "BGD",
     "capacity": 21359,
     "tenantClubs": [
@@ -14927,7 +14779,7 @@
   {
     "id": "nd-soft-stadium-yamagata",
     "name": "ND Soft Stadium Yamagata",
-    "city": "Tendō-shi",
+    "city": null,
     "countryCode": "JPN",
     "capacity": 21292,
     "tenantClubs": [
@@ -14990,7 +14842,7 @@
   {
     "id": "fratton-park",
     "name": "Fratton Park",
-    "city": "Milton",
+    "city": null,
     "countryCode": "GBR",
     "capacity": 21100,
     "tenantClubs": [
@@ -15037,54 +14889,6 @@
     ]
   },
   {
-    "id": "prince-sultan-bin-fahd-stadium",
-    "name": "Prince Sultan bin Fahd Stadium",
-    "city": null,
-    "countryCode": "SAU",
-    "capacity": 21000,
-    "tenantClubs": [
-      "al-ahli-fc"
-    ]
-  },
-  {
-    "id": "estadio-25-de-noviembre",
-    "name": "Estadio 25 de Noviembre",
-    "city": "Moquegua",
-    "countryCode": "PER",
-    "capacity": 21000,
-    "tenantClubs": [
-      "san-simon-de-moquegua"
-    ]
-  },
-  {
-    "id": "railyards-stadium",
-    "name": "Railyards Stadium",
-    "city": "Sacramento Railyards",
-    "countryCode": "USA",
-    "capacity": 21000,
-    "tenantClubs": []
-  },
-  {
-    "id": "cooks-gardens",
-    "name": "Cooks Gardens",
-    "city": null,
-    "countryCode": "NZL",
-    "capacity": 21000,
-    "tenantClubs": [
-      "wanganui-rugby-football-union"
-    ]
-  },
-  {
-    "id": "osaka-expo-70-stadium",
-    "name": "Osaka Expo '70 Stadium",
-    "city": "Expo '70 Commemorative Park",
-    "countryCode": "JPN",
-    "capacity": 21000,
-    "tenantClubs": [
-      "gamba-osaka"
-    ]
-  },
-  {
     "id": "sydney-superdome",
     "name": "Sydney SuperDome",
     "city": "Sydney Olympic Park",
@@ -15092,42 +14896,6 @@
     "capacity": 21000,
     "tenantClubs": [
       "sydney-kings"
-    ]
-  },
-  {
-    "id": "suez-canal-stadium",
-    "name": "Suez Canal Stadium",
-    "city": null,
-    "countryCode": "EGY",
-    "capacity": 21000,
-    "tenantClubs": []
-  },
-  {
-    "id": "prince-moulay-abdellah-olympic-annex-stadium",
-    "name": "Prince Moulay Abdellah Olympic Annex Stadium",
-    "city": null,
-    "countryCode": "MAR",
-    "capacity": 21000,
-    "tenantClubs": []
-  },
-  {
-    "id": "alerus-center",
-    "name": "Alerus Center",
-    "city": null,
-    "countryCode": "USA",
-    "capacity": 21000,
-    "tenantClubs": [
-      "north-dakota-fighting-hawks-football"
-    ]
-  },
-  {
-    "id": "louis-crews-stadium",
-    "name": "Louis Crews Stadium",
-    "city": "Normal",
-    "countryCode": "USA",
-    "capacity": 21000,
-    "tenantClubs": [
-      "national-collegiate-athletic-association"
     ]
   },
   {
@@ -15139,6 +14907,14 @@
     "tenantClubs": [
       "aberdeen-f-c"
     ]
+  },
+  {
+    "id": "suez-canal-stadium",
+    "name": "Suez Canal Stadium",
+    "city": null,
+    "countryCode": "EGY",
+    "capacity": 21000,
+    "tenantClubs": []
   },
   {
     "id": "american-legion-memorial-stadium",
@@ -15157,13 +14933,71 @@
     ]
   },
   {
+    "id": "doctores-jose-y-antonio-castiglione-stadium",
+    "name": "Doctores José y Antonio Castiglione Stadium",
+    "city": null,
+    "countryCode": "ARG",
+    "capacity": 21000,
+    "tenantClubs": [
+      "club-atletico-mitre"
+    ]
+  },
+  {
+    "id": "alerus-center",
+    "name": "Alerus Center",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 21000,
+    "tenantClubs": [
+      "north-dakota-fighting-hawks-football"
+    ]
+  },
+  {
     "id": "bell-field",
     "name": "Bell Field",
-    "city": "Oregon State University",
+    "city": "Corvallis",
     "countryCode": "USA",
     "capacity": 21000,
     "tenantClubs": [
       "oregon-state-beavers-football"
+    ]
+  },
+  {
+    "id": "railyards-stadium",
+    "name": "Railyards Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 21000,
+    "tenantClubs": []
+  },
+  {
+    "id": "cooks-gardens",
+    "name": "Cooks Gardens",
+    "city": null,
+    "countryCode": "NZL",
+    "capacity": 21000,
+    "tenantClubs": [
+      "wanganui-rugby-football-union"
+    ]
+  },
+  {
+    "id": "prince-sultan-bin-fahd-stadium",
+    "name": "Prince Sultan bin Fahd Stadium",
+    "city": null,
+    "countryCode": "SAU",
+    "capacity": 21000,
+    "tenantClubs": [
+      "al-ahli-fc"
+    ]
+  },
+  {
+    "id": "osaka-expo-70-stadium",
+    "name": "Osaka Expo '70 Stadium",
+    "city": "Suita",
+    "countryCode": "JPN",
+    "capacity": 21000,
+    "tenantClubs": [
+      "gamba-osaka"
     ]
   },
   {
@@ -15175,13 +15009,23 @@
     "tenantClubs": []
   },
   {
-    "id": "doctores-jose-y-antonio-castiglione-stadium",
-    "name": "Doctores José y Antonio Castiglione Stadium",
+    "id": "louis-crews-stadium",
+    "name": "Louis Crews Stadium",
     "city": null,
-    "countryCode": "ARG",
+    "countryCode": "USA",
     "capacity": 21000,
     "tenantClubs": [
-      "club-atletico-mitre"
+      "national-collegiate-athletic-association"
+    ]
+  },
+  {
+    "id": "estadio-25-de-noviembre",
+    "name": "Estadio 25 de Noviembre",
+    "city": "Moquegua",
+    "countryCode": "PER",
+    "capacity": 21000,
+    "tenantClubs": [
+      "san-simon-de-moquegua"
     ]
   },
   {
@@ -15205,6 +15049,14 @@
     ]
   },
   {
+    "id": "prince-moulay-abdellah-olympic-annex-stadium",
+    "name": "Prince Moulay Abdellah Olympic Annex Stadium",
+    "city": null,
+    "countryCode": "MAR",
+    "capacity": 21000,
+    "tenantClubs": []
+  },
+  {
     "id": "stadio-san-vito",
     "name": "Stadio San Vito",
     "city": null,
@@ -15218,7 +15070,7 @@
   {
     "id": "incheon-football-stadium",
     "name": "Incheon Football Stadium",
-    "city": "Old downtown area of Jung District, Incheon",
+    "city": "Incheon",
     "countryCode": "KOR",
     "capacity": 20891,
     "tenantClubs": [
@@ -15236,7 +15088,7 @@
   {
     "id": "fortuna-arena",
     "name": "Fortuna Arena",
-    "city": "Vršovice",
+    "city": "Prague",
     "countryCode": "CZE",
     "capacity": 20800,
     "tenantClubs": [
@@ -15272,16 +15124,6 @@
     "capacity": 20737,
     "tenantClubs": [
       "florida-panthers"
-    ]
-  },
-  {
-    "id": "q16303221",
-    "name": "Q16303221",
-    "city": null,
-    "countryCode": "ARG",
-    "capacity": 20704,
-    "tenantClubs": [
-      "altos-hornos-zapla"
     ]
   },
   {
@@ -15348,7 +15190,7 @@
   {
     "id": "zdzis-aw-krzyszkowiak-stadium",
     "name": "Zdzisław Krzyszkowiak Stadium",
-    "city": "Gdanska Street",
+    "city": "Bydgoszcz",
     "countryCode": "POL",
     "capacity": 20559,
     "tenantClubs": [
@@ -15397,13 +15239,15 @@
     ]
   },
   {
-    "id": "stadion-des-friedens-leipzig",
-    "name": "Stadion des Friedens (Leipzig)",
-    "city": null,
-    "countryCode": "DEU",
+    "id": "toyota-stadium-usa",
+    "name": "Toyota Stadium",
+    "city": "Frisco",
+    "countryCode": "USA",
     "capacity": 20500,
     "tenantClubs": [
-      "sg-motor-gohlis-nord"
+      "fc-dallas",
+      "frisco-independent-school-district",
+      "north-texas-sc"
     ]
   },
   {
@@ -15417,19 +15261,9 @@
     ]
   },
   {
-    "id": "q2-stadium",
-    "name": "Q2 Stadium",
-    "city": null,
-    "countryCode": "USA",
-    "capacity": 20500,
-    "tenantClubs": [
-      "austin-fc"
-    ]
-  },
-  {
     "id": "yodoko-sakura-stadium",
     "name": "Yodoko Sakura Stadium",
-    "city": "Nagai Park",
+    "city": "Osaka",
     "countryCode": "JPN",
     "capacity": 20500,
     "tenantClubs": [
@@ -15448,15 +15282,23 @@
     ]
   },
   {
-    "id": "toyota-stadium-usa",
-    "name": "Toyota Stadium",
-    "city": "Frisco",
+    "id": "stadion-des-friedens-leipzig",
+    "name": "Stadion des Friedens (Leipzig)",
+    "city": null,
+    "countryCode": "DEU",
+    "capacity": 20500,
+    "tenantClubs": [
+      "sg-motor-gohlis-nord"
+    ]
+  },
+  {
+    "id": "q2-stadium",
+    "name": "Q2 Stadium",
+    "city": null,
     "countryCode": "USA",
     "capacity": 20500,
     "tenantClubs": [
-      "fc-dallas",
-      "frisco-independent-school-district",
-      "north-texas-sc"
+      "austin-fc"
     ]
   },
   {
@@ -15472,7 +15314,7 @@
   {
     "id": "pocarisweat-stadium",
     "name": "Pocarisweat Stadium",
-    "city": "Naruto",
+    "city": null,
     "countryCode": "JPN",
     "capacity": 20441,
     "tenantClubs": [
@@ -15513,7 +15355,7 @@
   {
     "id": "matsumotodaira-football-stadium",
     "name": "Matsumotodaira Football Stadium",
-    "city": "Matsumotodaira Park",
+    "city": "Matsumoto",
     "countryCode": "JPN",
     "capacity": 20396,
     "tenantClubs": [
@@ -15554,7 +15396,7 @@
   {
     "id": "stadion-am-bruchweg",
     "name": "Stadion am Bruchweg",
-    "city": "Q137375049",
+    "city": "Mainz",
     "countryCode": "DEU",
     "capacity": 20300,
     "tenantClubs": [
@@ -15627,7 +15469,7 @@
   {
     "id": "the-den",
     "name": "The Den",
-    "city": "Bermondsey",
+    "city": null,
     "countryCode": "GBR",
     "capacity": 20146,
     "tenantClubs": [
@@ -15749,7 +15591,7 @@
   {
     "id": "gursel-aksel-stadium",
     "name": "Gürsel Aksel Stadium",
-    "city": "Mehmet Ali Akman",
+    "city": null,
     "countryCode": "TUR",
     "capacity": 20040,
     "tenantClubs": [
@@ -15787,1013 +15629,6 @@
     ]
   },
   {
-    "id": "daren-sammy-cricket-ground",
-    "name": "Daren Sammy Cricket Ground",
-    "city": "Gros Islet",
-    "countryCode": "LCA",
-    "capacity": 20000,
-    "tenantClubs": [
-      "saint-lucia-men-s-national-football-team",
-      "west-indies-cricket-team"
-    ]
-  },
-  {
-    "id": "wheater-s-field",
-    "name": "Wheater's Field",
-    "city": "Broughton",
-    "countryCode": "GBR",
-    "capacity": 20000,
-    "tenantClubs": [
-      "broughton-rangers"
-    ]
-  },
-  {
-    "id": "kazhimukan-munaitpasov-stadium",
-    "name": "Kazhimukan Munaitpasov Stadium",
-    "city": null,
-    "countryCode": "KAZ",
-    "capacity": 20000,
-    "tenantClubs": [
-      "fc-ordabasy"
-    ]
-  },
-  {
-    "id": "n-stved-stadion",
-    "name": "Næstved Stadion",
-    "city": "Næstved",
-    "countryCode": "DNK",
-    "capacity": 20000,
-    "tenantClubs": [
-      "n-stved-bk"
-    ]
-  },
-  {
-    "id": "el-kraken",
-    "name": "El Kraken",
-    "city": "Mazatlán",
-    "countryCode": "MEX",
-    "capacity": 20000,
-    "tenantClubs": [
-      "mazatlan-futbol-club"
-    ]
-  },
-  {
-    "id": "stadion-lublinianki",
-    "name": "Stadion Lublinianki",
-    "city": null,
-    "countryCode": "POL",
-    "capacity": 20000,
-    "tenantClubs": [
-      "ks-lublinianka"
-    ]
-  },
-  {
-    "id": "chulalongkorn-university-stadium",
-    "name": "Chulalongkorn University Stadium",
-    "city": null,
-    "countryCode": "THA",
-    "capacity": 20000,
-    "tenantClubs": [
-      "bbcu-f-c"
-    ]
-  },
-  {
-    "id": "yamaguchi-ishin-park-stadium",
-    "name": "Yamaguchi Ishin Park Stadium",
-    "city": "Yamaguchi",
-    "countryCode": "JPN",
-    "capacity": 20000,
-    "tenantClubs": []
-  },
-  {
-    "id": "yangquan-stadium",
-    "name": "Yangquan Stadium",
-    "city": "Yangquan",
-    "countryCode": "CHN",
-    "capacity": 20000,
-    "tenantClubs": []
-  },
-  {
-    "id": "yulin-stadium",
-    "name": "Yulin Stadium",
-    "city": null,
-    "countryCode": "CHN",
-    "capacity": 20000,
-    "tenantClubs": []
-  },
-  {
-    "id": "aliu-mahama-sports-stadium-gha",
-    "name": "Aliu Mahama Sports Stadium",
-    "city": "Tamale",
-    "countryCode": "GHA",
-    "capacity": 20000,
-    "tenantClubs": [
-      "real-tamale-united",
-      "steadfast-f-c"
-    ]
-  },
-  {
-    "id": "q9255273",
-    "name": "Q9255273",
-    "city": null,
-    "countryCode": "BRA",
-    "capacity": 20000,
-    "tenantClubs": []
-  },
-  {
-    "id": "estadio-da-curuzu",
-    "name": "Estádio da Curuzú",
-    "city": "Belém",
-    "countryCode": "BRA",
-    "capacity": 20000,
-    "tenantClubs": [
-      "paysandu-sport-club"
-    ]
-  },
-  {
-    "id": "wonju-stadium",
-    "name": "Wonju Stadium",
-    "city": null,
-    "countryCode": "KOR",
-    "capacity": 20000,
-    "tenantClubs": [
-      "gangwon-fc"
-    ]
-  },
-  {
-    "id": "stade-de-marchan",
-    "name": "Stade de Marchan",
-    "city": null,
-    "countryCode": "MAR",
-    "capacity": 20000,
-    "tenantClubs": [
-      "ir-tanger"
-    ]
-  },
-  {
-    "id": "stade-buffalo",
-    "name": "Stade Buffalo",
-    "city": null,
-    "countryCode": "FRA",
-    "capacity": 20000,
-    "tenantClubs": []
-  },
-  {
-    "id": "olympic-stadium-of-nouakchott",
-    "name": "Olympic Stadium of Nouakchott",
-    "city": "Nouakchott",
-    "countryCode": "MRT",
-    "capacity": 20000,
-    "tenantClubs": [
-      "mauritania-men-s-national-football-team"
-    ]
-  },
-  {
-    "id": "estadio-plan-de-san-luis-potosi",
-    "name": "Estadio Plan de San Luis Potosí",
-    "city": "San Luis Potosí",
-    "countryCode": "MEX",
-    "capacity": 20000,
-    "tenantClubs": [
-      "san-luis-f-c"
-    ]
-  },
-  {
-    "id": "villareal-anaya-stadium",
-    "name": "Villareal Anaya Stadium",
-    "city": null,
-    "countryCode": "MEX",
-    "capacity": 20000,
-    "tenantClubs": [
-      "correcaminos-uat"
-    ]
-  },
-  {
-    "id": "stade-omnisports-idriss-mahamat-ouya",
-    "name": "Stade Omnisports Idriss Mahamat Ouya",
-    "city": "N'Djamena",
-    "countryCode": "TCD",
-    "capacity": 20000,
-    "tenantClubs": [
-      "chad-men-s-national-football-team"
-    ]
-  },
-  {
-    "id": "stade-de-port-gentil",
-    "name": "Stade de Port-Gentil",
-    "city": "Port-Gentil",
-    "countryCode": "GAB",
-    "capacity": 20000,
-    "tenantClubs": [
-      "2017-africa-cup-of-nations"
-    ]
-  },
-  {
-    "id": "ramadan-ben-abdelmalek-stadium",
-    "name": "Ramadan Ben-Abdelmalek Stadium",
-    "city": null,
-    "countryCode": "DZA",
-    "capacity": 20000,
-    "tenantClubs": [
-      "mo-constantine"
-    ]
-  },
-  {
-    "id": "stadium-15-october",
-    "name": "Stadium 15 October",
-    "city": null,
-    "countryCode": "TUN",
-    "capacity": 20000,
-    "tenantClubs": [
-      "ca-bizertine"
-    ]
-  },
-  {
-    "id": "drei-flusse-stadion",
-    "name": "Drei Flüsse Stadion",
-    "city": null,
-    "countryCode": "DEU",
-    "capacity": 20000,
-    "tenantClubs": [
-      "1-fc-passau"
-    ]
-  },
-  {
-    "id": "stade-mustapha-ben-jannet",
-    "name": "Stade Mustapha Ben Jannet",
-    "city": null,
-    "countryCode": "TUN",
-    "capacity": 20000,
-    "tenantClubs": [
-      "us-monastir"
-    ]
-  },
-  {
-    "id": "warri-stadium",
-    "name": "Warri Stadium",
-    "city": null,
-    "countryCode": "NGA",
-    "capacity": 20000,
-    "tenantClubs": []
-  },
-  {
-    "id": "nehru-stadium-tumkur",
-    "name": "Nehru Stadium, Tumkur",
-    "city": null,
-    "countryCode": "IND",
-    "capacity": 20000,
-    "tenantClubs": []
-  },
-  {
-    "id": "thammasat-stadium",
-    "name": "Thammasat Stadium",
-    "city": "Thammasat University",
-    "countryCode": "THA",
-    "capacity": 20000,
-    "tenantClubs": [
-      "police-united-f-c"
-    ]
-  },
-  {
-    "id": "rn-shetty-stadium",
-    "name": "RN Shetty Stadium",
-    "city": "Dharwad",
-    "countryCode": "IND",
-    "capacity": 20000,
-    "tenantClubs": []
-  },
-  {
-    "id": "phillips-field",
-    "name": "Phillips Field",
-    "city": null,
-    "countryCode": "USA",
-    "capacity": 20000,
-    "tenantClubs": [
-      "tampa-spartans-football"
-    ]
-  },
-  {
-    "id": "q21660604",
-    "name": "Q21660604",
-    "city": null,
-    "countryCode": "UZB",
-    "capacity": 20000,
-    "tenantClubs": [
-      "fc-neftchi-fergana"
-    ]
-  },
-  {
-    "id": "bafoussam-omnisports-stadium",
-    "name": "Bafoussam omnisports stadium",
-    "city": "Bafoussam",
-    "countryCode": "CMR",
-    "capacity": 20000,
-    "tenantClubs": []
-  },
-  {
-    "id": "stade-larbi-benbarek",
-    "name": "Stade Larbi Benbarek",
-    "city": null,
-    "countryCode": "MAR",
-    "capacity": 20000,
-    "tenantClubs": [
-      "wydad-athletic-club"
-    ]
-  },
-  {
-    "id": "stadion-msk-povazska-bystrica",
-    "name": "Štadión MŠK Považská Bystrica",
-    "city": null,
-    "countryCode": "SVK",
-    "capacity": 20000,
-    "tenantClubs": [
-      "fk-raven-povazska-bystrica"
-    ]
-  },
-  {
-    "id": "krishnagiri-stadium",
-    "name": "Krishnagiri Stadium",
-    "city": "Krishnagiri Village",
-    "countryCode": "IND",
-    "capacity": 20000,
-    "tenantClubs": []
-  },
-  {
-    "id": "utama-negeri-stadium",
-    "name": "Utama Negeri Stadium",
-    "city": "Kangar",
-    "countryCode": "MYS",
-    "capacity": 20000,
-    "tenantClubs": [
-      "perlis-fa"
-    ]
-  },
-  {
-    "id": "helmy-zamora-stadium",
-    "name": "Helmy Zamora Stadium",
-    "city": null,
-    "countryCode": "EGY",
-    "capacity": 20000,
-    "tenantClubs": [
-      "zamalek-sc"
-    ]
-  },
-  {
-    "id": "stade-d-honneur",
-    "name": "Stade d'Honneur",
-    "city": null,
-    "countryCode": "MAR",
-    "capacity": 20000,
-    "tenantClubs": [
-      "cod-meknes"
-    ]
-  },
-  {
-    "id": "el-mahalla-stadium",
-    "name": "El Mahalla Stadium",
-    "city": null,
-    "countryCode": "EGY",
-    "capacity": 20000,
-    "tenantClubs": [
-      "ghazl-el-mahalla-sc"
-    ]
-  },
-  {
-    "id": "q3495900",
-    "name": "Q3495900",
-    "city": null,
-    "countryCode": "CIV",
-    "capacity": 20000,
-    "tenantClubs": [
-      "sporting-club-de-gagnoa"
-    ]
-  },
-  {
-    "id": "habib-bouakeul-stadium",
-    "name": "Habib Bouakeul Stadium",
-    "city": null,
-    "countryCode": "DZA",
-    "capacity": 20000,
-    "tenantClubs": [
-      "asm-oran",
-      "scm-oran"
-    ]
-  },
-  {
-    "id": "stade-el-harti",
-    "name": "Stade El Harti",
-    "city": null,
-    "countryCode": "MAR",
-    "capacity": 20000,
-    "tenantClubs": [
-      "kacm"
-    ]
-  },
-  {
-    "id": "stade-barema-bocoum",
-    "name": "Stade Baréma Bocoum",
-    "city": null,
-    "countryCode": "MLI",
-    "capacity": 20000,
-    "tenantClubs": []
-  },
-  {
-    "id": "somhlolo-national-stadium",
-    "name": "Somhlolo National Stadium",
-    "city": null,
-    "countryCode": "SWZ",
-    "capacity": 20000,
-    "tenantClubs": [
-      "eswatini-men-s-national-football-team"
-    ]
-  },
-  {
-    "id": "lanxess-arena",
-    "name": "Lanxess Arena",
-    "city": null,
-    "countryCode": "DEU",
-    "capacity": 20000,
-    "tenantClubs": [
-      "kolner-haie"
-    ]
-  },
-  {
-    "id": "pairc-esler",
-    "name": "Páirc Esler",
-    "city": null,
-    "countryCode": "GBR",
-    "capacity": 20000,
-    "tenantClubs": []
-  },
-  {
-    "id": "thai-army-sports-stadium",
-    "name": "Thai Army Sports Stadium",
-    "city": "Phaya Thai",
-    "countryCode": "THA",
-    "capacity": 20000,
-    "tenantClubs": [
-      "army-united-f-c"
-    ]
-  },
-  {
-    "id": "brawijaya-stadium",
-    "name": "Brawijaya Stadium",
-    "city": null,
-    "countryCode": "IDN",
-    "capacity": 20000,
-    "tenantClubs": [
-      "persik-kediri"
-    ]
-  },
-  {
-    "id": "shenzhen-bay-sports-center",
-    "name": "Shenzhen Bay Sports Center",
-    "city": "Nanshan District",
-    "countryCode": "CHN",
-    "capacity": 20000,
-    "tenantClubs": [
-      "2011-summer-universiade"
-    ]
-  },
-  {
-    "id": "king-abdullah-stadium",
-    "name": "King Abdullah Stadium",
-    "city": null,
-    "countryCode": "JOR",
-    "capacity": 20000,
-    "tenantClubs": [
-      "jordan-men-s-national-football-team"
-    ]
-  },
-  {
-    "id": "yuanshen-sports-centre-stadium",
-    "name": "Yuanshen Sports Centre Stadium",
-    "city": "Pudong",
-    "countryCode": "CHN",
-    "capacity": 20000,
-    "tenantClubs": [
-      "shanghai-shenxin-f-c"
-    ]
-  },
-  {
-    "id": "alfred-kunze-sportpark",
-    "name": "Alfred-Kunze-Sportpark",
-    "city": null,
-    "countryCode": "DEU",
-    "capacity": 20000,
-    "tenantClubs": [
-      "bsg-chemie-leipzig",
-      "fc-sachsen-leipzig",
-      "q14855286",
-      "q22813494",
-      "sc-lokomotive-leipzig",
-      "tura-leipzig"
-    ]
-  },
-  {
-    "id": "witbank-stadium",
-    "name": "Witbank Stadium",
-    "city": null,
-    "countryCode": "ZAF",
-    "capacity": 20000,
-    "tenantClubs": [
-      "mpumalanga-black-aces-f-c"
-    ]
-  },
-  {
-    "id": "estadio-municipal-de-la-linea-de-la-concepcion",
-    "name": "Estadio Municipal de La Línea de la Concepción",
-    "city": null,
-    "countryCode": "ESP",
-    "capacity": 20000,
-    "tenantClubs": [
-      "rb-linense"
-    ]
-  },
-  {
-    "id": "paul-greifzu-stadium",
-    "name": "Paul Greifzu Stadium",
-    "city": "Dessau",
-    "countryCode": "DEU",
-    "capacity": 20000,
-    "tenantClubs": [
-      "1-lac-dessau",
-      "sv-dessau-05"
-    ]
-  },
-  {
-    "id": "sylvie-becaert-biathlon-stadium",
-    "name": "Sylvie Becaert Biathlon Stadium",
-    "city": null,
-    "countryCode": "FRA",
-    "capacity": 20000,
-    "tenantClubs": []
-  },
-  {
-    "id": "zhongshan-soccer-stadium",
-    "name": "Zhongshan Soccer Stadium",
-    "city": null,
-    "countryCode": "TWN",
-    "capacity": 20000,
-    "tenantClubs": [
-      "chinese-taipei-men-s-national-football-team"
-    ]
-  },
-  {
-    "id": "claro-arena",
-    "name": "Claro Arena",
-    "city": null,
-    "countryCode": "CHL",
-    "capacity": 20000,
-    "tenantClubs": [
-      "club-deportivo-universidad-catolica"
-    ]
-  },
-  {
-    "id": "estadio-roberto-natalio-carminatti",
-    "name": "Estadio Roberto Natalio Carminatti",
-    "city": null,
-    "countryCode": "ARG",
-    "capacity": 20000,
-    "tenantClubs": [
-      "club-olimpo"
-    ]
-  },
-  {
-    "id": "ibercaja-stadium",
-    "name": "Ibercaja Stadium",
-    "city": null,
-    "countryCode": "ESP",
-    "capacity": 20000,
-    "tenantClubs": [
-      "real-zaragoza"
-    ]
-  },
-  {
-    "id": "q135438868",
-    "name": "Q135438868",
-    "city": "Phú Trinh",
-    "countryCode": "VNM",
-    "capacity": 20000,
-    "tenantClubs": []
-  },
-  {
-    "id": "tundavala-national-stadium",
-    "name": "Tundavala National Stadium",
-    "city": null,
-    "countryCode": "AGO",
-    "capacity": 20000,
-    "tenantClubs": []
-  },
-  {
-    "id": "estadio-nacional-do-chiazi",
-    "name": "Estádio Nacional do Chiazi",
-    "city": "Cabinda",
-    "countryCode": "AGO",
-    "capacity": 20000,
-    "tenantClubs": []
-  },
-  {
-    "id": "hoegeng-stadium",
-    "name": "Hoegeng Stadium",
-    "city": null,
-    "countryCode": "IDN",
-    "capacity": 20000,
-    "tenantClubs": [
-      "persip-pekalongan"
-    ]
-  },
-  {
-    "id": "estadio-vila-capanema",
-    "name": "Estádio Vila Capanema",
-    "city": null,
-    "countryCode": "BRA",
-    "capacity": 20000,
-    "tenantClubs": [
-      "clube-atletico-ferroviario",
-      "parana-clube"
-    ]
-  },
-  {
-    "id": "yatta-international-stadium",
-    "name": "Yatta International Stadium",
-    "city": null,
-    "countryCode": "PSE",
-    "capacity": 20000,
-    "tenantClubs": [
-      "shabab-yatta"
-    ]
-  },
-  {
-    "id": "pingguo-stadium",
-    "name": "Pingguo Stadium",
-    "city": "Pingguo City",
-    "countryCode": "CHN",
-    "capacity": 20000,
-    "tenantClubs": [
-      "guangxi-pingguo-haliao-f-c"
-    ]
-  },
-  {
-    "id": "iwate-morioka-ballpark",
-    "name": "Iwate Morioka Ballpark",
-    "city": null,
-    "countryCode": "JPN",
-    "capacity": 20000,
-    "tenantClubs": [
-      "north-tohoku-university-baseball-federation"
-    ]
-  },
-  {
-    "id": "otunba-dipo-dina-international-stadium",
-    "name": "Otunba Dipo Dina International Stadium",
-    "city": "Ijebu Ode",
-    "countryCode": "NGA",
-    "capacity": 20000,
-    "tenantClubs": []
-  },
-  {
-    "id": "ashdod-stadium",
-    "name": "Ashdod Stadium",
-    "city": "Rova Park Lakhish",
-    "countryCode": "ISR",
-    "capacity": 20000,
-    "tenantClubs": [
-      "f-c-ashdod"
-    ]
-  },
-  {
-    "id": "miki-athletic-stadium",
-    "name": "Miki Athletic Stadium",
-    "city": null,
-    "countryCode": "JPN",
-    "capacity": 20000,
-    "tenantClubs": []
-  },
-  {
-    "id": "abdelkrim-kerroum-stadium",
-    "name": "Abdelkrim Kerroum Stadium",
-    "city": null,
-    "countryCode": "DZA",
-    "capacity": 20000,
-    "tenantClubs": [
-      "cc-sig"
-    ]
-  },
-  {
-    "id": "sekondi-takoradi-stadium",
-    "name": "Sekondi-Takoradi Stadium",
-    "city": "Sekondi-Takoradi",
-    "countryCode": "GHA",
-    "capacity": 20000,
-    "tenantClubs": [
-      "sekondi-hasaacas-f-c"
-    ]
-  },
-  {
-    "id": "seisa-ramabodu-stadium",
-    "name": "Seisa Ramabodu Stadium",
-    "city": null,
-    "countryCode": "ZAF",
-    "capacity": 20000,
-    "tenantClubs": [
-      "bloemfontein-celtic-f-c"
-    ]
-  },
-  {
-    "id": "pitbull-stadium",
-    "name": "Pitbull Stadium",
-    "city": null,
-    "countryCode": "USA",
-    "capacity": 20000,
-    "tenantClubs": [
-      "fiu-panthers",
-      "fiu-panthers-football",
-      "miami-fc"
-    ]
-  },
-  {
-    "id": "national-sports-stadium-mng",
-    "name": "National Sports Stadium",
-    "city": null,
-    "countryCode": "MNG",
-    "capacity": 20000,
-    "tenantClubs": [
-      "mongolia-men-s-national-football-team"
-    ]
-  },
-  {
-    "id": "polonia-bydgoszcz-stadium",
-    "name": "Polonia Bydgoszcz Stadium",
-    "city": null,
-    "countryCode": "POL",
-    "capacity": 20000,
-    "tenantClubs": [
-      "motorcycle-speedway"
-    ]
-  },
-  {
-    "id": "rondong-demang-stadium",
-    "name": "Rondong Demang Stadium",
-    "city": "Tenggarong",
-    "countryCode": "IDN",
-    "capacity": 20000,
-    "tenantClubs": [
-      "mitra-kukar-f-c"
-    ]
-  },
-  {
-    "id": "providence-stadium",
-    "name": "Providence Stadium",
-    "city": "Providence",
-    "countryCode": "GUY",
-    "capacity": 20000,
-    "tenantClubs": [
-      "west-indies-cricket-team"
-    ]
-  },
-  {
-    "id": "stadium-lichtenberg",
-    "name": "Stadium Lichtenberg",
-    "city": "Lichtenberg",
-    "countryCode": "DEU",
-    "capacity": 20000,
-    "tenantClubs": []
-  },
-  {
-    "id": "andres-quintana-roo-olympic-stadium",
-    "name": "Andrés Quintana Roo Olympic Stadium",
-    "city": null,
-    "countryCode": "MEX",
-    "capacity": 20000,
-    "tenantClubs": [
-      "atlante-f-c"
-    ]
-  },
-  {
-    "id": "district-stadium-chattogram",
-    "name": "District Stadium, Chattogram",
-    "city": "Chittagong",
-    "countryCode": "BGD",
-    "capacity": 20000,
-    "tenantClubs": []
-  },
-  {
-    "id": "planet-group-arena",
-    "name": "Planet Group arena",
-    "city": null,
-    "countryCode": "BEL",
-    "capacity": 20000,
-    "tenantClubs": [
-      "kaa-gent"
-    ]
-  },
-  {
-    "id": "sunset-stadium",
-    "name": "Sunset Stadium",
-    "city": null,
-    "countryCode": "ZMB",
-    "capacity": 20000,
-    "tenantClubs": [
-      "zanaco-f-c"
-    ]
-  },
-  {
-    "id": "limbe-stadium",
-    "name": "Limbe Stadium",
-    "city": null,
-    "countryCode": "CMR",
-    "capacity": 20000,
-    "tenantClubs": []
-  },
-  {
-    "id": "philippine-stadium",
-    "name": "Philippine Stadium",
-    "city": null,
-    "countryCode": "PHL",
-    "capacity": 20000,
-    "tenantClubs": [
-      "philippines-men-s-national-association-football-team"
-    ]
-  },
-  {
-    "id": "silli-stadium",
-    "name": "Silli Stadium",
-    "city": null,
-    "countryCode": "IND",
-    "capacity": 20000,
-    "tenantClubs": []
-  },
-  {
-    "id": "kalyani-stadium",
-    "name": "Kalyani Stadium",
-    "city": "Kalyani",
-    "countryCode": "IND",
-    "capacity": 20000,
-    "tenantClubs": [
-      "prayag-united-s-c"
-    ]
-  },
-  {
-    "id": "q16557592",
-    "name": "Q16557592",
-    "city": null,
-    "countryCode": "AFG",
-    "capacity": 20000,
-    "tenantClubs": []
-  },
-  {
-    "id": "stade-20-aout-1955",
-    "name": "Stade 20 Août 1955",
-    "city": null,
-    "countryCode": "DZA",
-    "capacity": 20000,
-    "tenantClubs": [
-      "ca-bordj-bou-arreridj"
-    ]
-  },
-  {
-    "id": "university-of-tehran-stadium",
-    "name": "University of Tehran Stadium",
-    "city": "Amir Abad",
-    "countryCode": "IRN",
-    "capacity": 20000,
-    "tenantClubs": []
-  },
-  {
-    "id": "dr-akhilesh-das-stadium",
-    "name": "Dr. Akhilesh Das Stadium",
-    "city": null,
-    "countryCode": "IND",
-    "capacity": 20000,
-    "tenantClubs": [
-      "uttar-pradesh-cricket-team"
-    ]
-  },
-  {
-    "id": "ptt-stadium",
-    "name": "PTT Stadium",
-    "city": "Mueang Rayong",
-    "countryCode": "THA",
-    "capacity": 20000,
-    "tenantClubs": [
-      "ptt-rayong"
-    ]
-  },
-  {
-    "id": "muhoroni-stadium",
-    "name": "Muhoroni Stadium",
-    "city": null,
-    "countryCode": "KEN",
-    "capacity": 20000,
-    "tenantClubs": []
-  },
-  {
-    "id": "stadion-stari-plac",
-    "name": "Stadion Stari plac",
-    "city": null,
-    "countryCode": "HRV",
-    "capacity": 20000,
-    "tenantClubs": [
-      "hnk-hajduk-split"
-    ]
-  },
-  {
-    "id": "tunas-bangsa-stadium",
-    "name": "Tunas Bangsa Stadium",
-    "city": null,
-    "countryCode": "IDN",
-    "capacity": 20000,
-    "tenantClubs": [
-      "psls-lhokseumawe"
-    ]
-  },
-  {
-    "id": "national-cricket-stadium",
-    "name": "National Cricket Stadium",
-    "city": "Grenada",
-    "countryCode": "GRD",
-    "capacity": 20000,
-    "tenantClubs": []
-  },
-  {
-    "id": "campos-de-sports-de-nunoa",
-    "name": "Campos de Sports de Ñuñoa",
-    "city": null,
-    "countryCode": "CHL",
-    "capacity": 20000,
-    "tenantClubs": [
-      "chile-men-s-national-football-team"
-    ]
-  },
-  {
-    "id": "len-clay-stadium",
-    "name": "Len Clay Stadium",
-    "city": "Obuasi",
-    "countryCode": "GHA",
-    "capacity": 20000,
-    "tenantClubs": [
-      "ashanti-gold-sc"
-    ]
-  },
-  {
-    "id": "new-clark-city-athletics-stadium",
-    "name": "New Clark City Athletics Stadium",
-    "city": "New Clark City",
-    "countryCode": "PHL",
-    "capacity": 20000,
-    "tenantClubs": []
-  },
-  {
-    "id": "langari-langarieva-stadium",
-    "name": "Langari Langarieva Stadium",
-    "city": null,
-    "countryCode": "TJK",
-    "capacity": 20000,
-    "tenantClubs": [
-      "ravshan-kulob"
-    ]
-  },
-  {
-    "id": "lake-tanganyika-stadium",
-    "name": "Lake Tanganyika Stadium",
-    "city": null,
-    "countryCode": "TZA",
-    "capacity": 20000,
-    "tenantClubs": []
-  },
-  {
-    "id": "kimbrough-memorial-stadium",
-    "name": "Kimbrough Memorial Stadium",
-    "city": "Canyon",
-    "countryCode": "USA",
-    "capacity": 20000,
-    "tenantClubs": [
-      "west-texas-a-m-buffaloes-football"
-    ]
-  },
-  {
-    "id": "kashiwanoha-park-stadium",
-    "name": "Kashiwanoha Park Stadium",
-    "city": "Kashiwanoha Park",
-    "countryCode": "JPN",
-    "capacity": 20000,
-    "tenantClubs": [
-      "kashiwa-reysol",
-      "nec-green-rockets-tokatsu"
-    ]
-  },
-  {
-    "id": "stadionul-municipal-rou",
-    "name": "Stadionul Municipal",
-    "city": null,
-    "countryCode": "ROU",
-    "capacity": 20000,
-    "tenantClubs": [
-      "afc-dacia-unirea-braila"
-    ]
-  },
-  {
     "id": "shahid-beheshti-stadium",
     "name": "Shahid Beheshti Stadium",
     "city": null,
@@ -16801,97 +15636,6 @@
     "capacity": 20000,
     "tenantClubs": [
       "iranjavan-f-c"
-    ]
-  },
-  {
-    "id": "jinju-public-stadium",
-    "name": "Jinju Public Stadium",
-    "city": null,
-    "countryCode": "KOR",
-    "capacity": 20000,
-    "tenantClubs": []
-  },
-  {
-    "id": "jamhuri-stadium",
-    "name": "Jamhuri Stadium",
-    "city": "Morogoro",
-    "countryCode": "TZA",
-    "capacity": 20000,
-    "tenantClubs": []
-  },
-  {
-    "id": "stadium-metallurg-1st-district",
-    "name": "Stadium Metallurg 1st District",
-    "city": null,
-    "countryCode": "TJK",
-    "capacity": 20000,
-    "tenantClubs": [
-      "regar-tadaz-tursunzoda"
-    ]
-  },
-  {
-    "id": "estadio-luiz-viana-filho-itabuna",
-    "name": "Estádio Luiz Viana Filho, Itabuna",
-    "city": null,
-    "countryCode": "BRA",
-    "capacity": 20000,
-    "tenantClubs": []
-  },
-  {
-    "id": "hama-municipal-stadium",
-    "name": "Hama Municipal Stadium",
-    "city": null,
-    "countryCode": "SYR",
-    "capacity": 20000,
-    "tenantClubs": [
-      "nawair-sc"
-    ]
-  },
-  {
-    "id": "lincoln-yards-stadium",
-    "name": "Lincoln Yards Stadium",
-    "city": null,
-    "countryCode": "USA",
-    "capacity": 20000,
-    "tenantClubs": [
-      "usl-chicago"
-    ]
-  },
-  {
-    "id": "gelora-bumi-kartini-stadium",
-    "name": "Gelora Bumi Kartini Stadium",
-    "city": "Jepara",
-    "countryCode": "IDN",
-    "capacity": 20000,
-    "tenantClubs": [
-      "persijap-jepara"
-    ]
-  },
-  {
-    "id": "gmr-stadium",
-    "name": "GMR Stadium",
-    "city": null,
-    "countryCode": "LBY",
-    "capacity": 20000,
-    "tenantClubs": []
-  },
-  {
-    "id": "la-peineta",
-    "name": "La Peineta",
-    "city": null,
-    "countryCode": "ESP",
-    "capacity": 20000,
-    "tenantClubs": []
-  },
-  {
-    "id": "stade-charlety",
-    "name": "Stade Charléty",
-    "city": "13th arrondissement of Paris",
-    "countryCode": "FRA",
-    "capacity": 20000,
-    "tenantClubs": [
-      "paris-fc",
-      "paris-saint-germain-rugby-league"
     ]
   },
   {
@@ -16906,6 +15650,24 @@
       "texas-longhorns-women-s-track-and-field",
       "texas-relays"
     ]
+  },
+  {
+    "id": "samuel-ogbemudia-stadium",
+    "name": "Samuel Ogbemudia Stadium",
+    "city": null,
+    "countryCode": "NGA",
+    "capacity": 20000,
+    "tenantClubs": [
+      "bendel-insurance-f-c"
+    ]
+  },
+  {
+    "id": "memorial-stadium-usa-3",
+    "name": "Memorial Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 20000,
+    "tenantClubs": []
   },
   {
     "id": "stade-municipale",
@@ -16944,12 +15706,14 @@
     ]
   },
   {
-    "id": "sheikh-zayed-cricket-stadium",
-    "name": "Sheikh Zayed Cricket Stadium",
-    "city": "Abu Dhabi",
-    "countryCode": "ARE",
+    "id": "ningineer-stadium",
+    "name": "Ningineer Stadium",
+    "city": "Matsuyama",
+    "countryCode": "JPN",
     "capacity": 20000,
-    "tenantClubs": []
+    "tenantClubs": [
+      "ehime-fc"
+    ]
   },
   {
     "id": "sheikh-amri-abeid-memorial-stadium",
@@ -16975,14 +15739,12 @@
     ]
   },
   {
-    "id": "samuel-ogbemudia-stadium",
-    "name": "Samuel Ogbemudia Stadium",
+    "id": "gmr-stadium",
+    "name": "GMR Stadium",
     "city": null,
-    "countryCode": "NGA",
+    "countryCode": "LBY",
     "capacity": 20000,
-    "tenantClubs": [
-      "bendel-insurance-f-c"
-    ]
+    "tenantClubs": []
   },
   {
     "id": "rajiv-gandhi-stadium-mualpui",
@@ -17007,7 +15769,7 @@
   {
     "id": "philsports-football-and-athletics-stadium",
     "name": "PhilSports Football and Athletics Stadium",
-    "city": "Pasig",
+    "city": "Metro Manila",
     "countryCode": "PHL",
     "capacity": 20000,
     "tenantClubs": [
@@ -17025,225 +15787,95 @@
     ]
   },
   {
-    "id": "ningineer-stadium",
-    "name": "Ningineer Stadium",
-    "city": "Matsuyama",
-    "countryCode": "JPN",
-    "capacity": 20000,
-    "tenantClubs": [
-      "ehime-fc"
-    ]
-  },
-  {
-    "id": "nagoya-city-minato-soccer-stadium",
-    "name": "Nagoya City Minato Soccer Stadium",
-    "city": null,
-    "countryCode": "JPN",
-    "capacity": 20000,
-    "tenantClubs": [
-      "fc-maruyasu-okazaki"
-    ]
-  },
-  {
-    "id": "moruleng-stadium",
-    "name": "Moruleng Stadium",
-    "city": null,
-    "countryCode": "ZAF",
-    "capacity": 20000,
-    "tenantClubs": [
-      "platinum-stars-f-c"
-    ]
-  },
-  {
-    "id": "hinata-athletic-stadium",
-    "name": "Hinata Athletic Stadium",
-    "city": null,
-    "countryCode": "JPN",
-    "capacity": 20000,
-    "tenantClubs": [
-      "minebea-mitsumi-fc"
-    ]
-  },
-  {
-    "id": "ashgabat-stadium",
-    "name": "Ashgabat Stadium",
-    "city": null,
-    "countryCode": "TKM",
-    "capacity": 20000,
-    "tenantClubs": [
-      "fc-asgabat"
-    ]
-  },
-  {
-    "id": "estadio-do-lumiar",
-    "name": "Estádio do Lumiar",
-    "city": null,
-    "countryCode": "PRT",
-    "capacity": 20000,
-    "tenantClubs": []
-  },
-  {
-    "id": "estadio-juca-ribeiro",
-    "name": "Estádio Juca Ribeiro",
-    "city": "Uberlândia",
-    "countryCode": "BRA",
-    "capacity": 20000,
-    "tenantClubs": [
-      "uberlandia-e-c"
-    ]
-  },
-  {
-    "id": "estadio-jonas-duarte",
-    "name": "Estádio Jonas Duarte",
-    "city": null,
-    "countryCode": "BRA",
-    "capacity": 20000,
-    "tenantClubs": [
-      "associacao-atletica-anapolina"
-    ]
-  },
-  {
-    "id": "rotorua-international-stadium",
-    "name": "Rotorua International Stadium",
-    "city": "Westbrook",
-    "countryCode": "NZL",
-    "capacity": 20000,
-    "tenantClubs": [
-      "bay-of-plenty-ru"
-    ]
-  },
-  {
-    "id": "ali-daei-stadium",
-    "name": "Ali Daei Stadium",
-    "city": null,
-    "countryCode": "IRN",
-    "capacity": 20000,
-    "tenantClubs": [
-      "zob-ahan-ardabil-f-c"
-    ]
-  },
-  {
-    "id": "shijingshan-stadium",
-    "name": "Shijingshan Stadium",
-    "city": null,
-    "countryCode": "CHN",
-    "capacity": 20000,
-    "tenantClubs": []
-  },
-  {
-    "id": "hamad-bin-khalifa-stadium",
-    "name": "Hamad bin Khalifa Stadium",
-    "city": null,
-    "countryCode": "QAT",
-    "capacity": 20000,
-    "tenantClubs": [
-      "al-ahli-sc"
-    ]
-  },
-  {
-    "id": "al-kut-olympic-stadium",
-    "name": "Al-Kut Olympic Stadium",
-    "city": "Kut",
-    "countryCode": "IRQ",
-    "capacity": 20000,
-    "tenantClubs": []
-  },
-  {
-    "id": "teladan-stadium",
-    "name": "Teladan Stadium",
-    "city": null,
+    "id": "gelora-bumi-kartini-stadium",
+    "name": "Gelora Bumi Kartini Stadium",
+    "city": "Jepara",
     "countryCode": "IDN",
     "capacity": 20000,
     "tenantClubs": [
-      "psms-medan"
+      "persijap-jepara"
     ]
   },
   {
-    "id": "al-muharraq-stadium",
-    "name": "Al Muharraq Stadium",
-    "city": "Arad",
-    "countryCode": "BHR",
-    "capacity": 20000,
-    "tenantClubs": [
-      "al-muharraq-sc"
-    ]
-  },
-  {
-    "id": "aswan-stadium",
-    "name": "Aswan Stadium",
-    "city": null,
-    "countryCode": "EGY",
-    "capacity": 20000,
-    "tenantClubs": [
-      "aswan-sc"
-    ]
-  },
-  {
-    "id": "huadu-sports-centre",
-    "name": "Huadu Sports Centre",
-    "city": null,
-    "countryCode": "CHN",
+    "id": "sheikh-zayed-cricket-stadium",
+    "name": "Sheikh Zayed Cricket Stadium",
+    "city": "Abu Dhabi",
+    "countryCode": "ARE",
     "capacity": 20000,
     "tenantClubs": []
   },
   {
-    "id": "estadio-24-de-setembro",
-    "name": "Estádio 24 de Setembro",
+    "id": "lincoln-yards-stadium",
+    "name": "Lincoln Yards Stadium",
     "city": null,
-    "countryCode": "GNB",
+    "countryCode": "USA",
     "capacity": 20000,
     "tenantClubs": [
-      "guinea-bissau-men-s-national-football-team"
+      "usl-chicago"
     ]
   },
   {
-    "id": "setsoto-stadium",
-    "name": "Setsoto Stadium",
+    "id": "lake-tanganyika-stadium",
+    "name": "Lake Tanganyika Stadium",
     "city": null,
-    "countryCode": "LSO",
-    "capacity": 20000,
-    "tenantClubs": [
-      "lesotho-men-s-national-football-team"
-    ]
-  },
-  {
-    "id": "prince-sultan-bin-abdulaziz-sports-city",
-    "name": "Prince Sultan bin Abdulaziz Sports City",
-    "city": "Abha",
-    "countryCode": "SAU",
+    "countryCode": "TZA",
     "capacity": 20000,
     "tenantClubs": []
   },
   {
-    "id": "avanhard-stadium",
-    "name": "Avanhard Stadium",
+    "id": "estadio-luiz-viana-filho-itabuna",
+    "name": "Estádio Luiz Viana Filho, Itabuna",
     "city": null,
-    "countryCode": "UKR",
+    "countryCode": "BRA",
+    "capacity": 20000,
+    "tenantClubs": []
+  },
+  {
+    "id": "ptt-stadium",
+    "name": "PTT Stadium",
+    "city": null,
+    "countryCode": "THA",
     "capacity": 20000,
     "tenantClubs": [
-      "nk-veres-rivne"
+      "ptt-rayong"
     ]
   },
   {
-    "id": "yuexiushan-stadium",
-    "name": "Yuexiushan Stadium",
+    "id": "muhoroni-stadium",
+    "name": "Muhoroni Stadium",
     "city": null,
-    "countryCode": "CHN",
+    "countryCode": "KEN",
+    "capacity": 20000,
+    "tenantClubs": []
+  },
+  {
+    "id": "philippine-stadium",
+    "name": "Philippine Stadium",
+    "city": null,
+    "countryCode": "PHL",
     "capacity": 20000,
     "tenantClubs": [
-      "guangdong-gz-power-f-c",
-      "guangzhou-city-f-c",
-      "guangzhou-f-c"
+      "philippines-men-s-national-association-football-team"
     ]
   },
   {
-    "id": "q3967962",
-    "name": "Q3967962",
+    "id": "estadio-la-barranquita",
+    "name": "Estadio La Barranquita",
     "city": null,
-    "countryCode": "POL",
+    "countryCode": "DOM",
     "capacity": 20000,
     "tenantClubs": [
-      "olimpia-poznan"
+      "club-barcelona-atletico"
+    ]
+  },
+  {
+    "id": "campos-de-sports-de-nunoa",
+    "name": "Campos de Sports de Ñuñoa",
+    "city": null,
+    "countryCode": "CHL",
+    "capacity": 20000,
+    "tenantClubs": [
+      "chile-men-s-national-football-team"
     ]
   },
   {
@@ -17257,43 +15889,164 @@
     ]
   },
   {
-    "id": "city-stadium-mys",
-    "name": "City Stadium",
-    "city": null,
-    "countryCode": "MYS",
+    "id": "len-clay-stadium",
+    "name": "Len Clay Stadium",
+    "city": "Obuasi",
+    "countryCode": "GHA",
     "capacity": 20000,
     "tenantClubs": [
-      "penang-f-c"
+      "ashanti-gold-sc"
     ]
   },
   {
-    "id": "suwon-baseball-stadium",
-    "name": "Suwon Baseball Stadium",
+    "id": "new-clark-city-athletics-stadium",
+    "name": "New Clark City Athletics Stadium",
+    "city": "Capas",
+    "countryCode": "PHL",
+    "capacity": 20000,
+    "tenantClubs": []
+  },
+  {
+    "id": "langari-langarieva-stadium",
+    "name": "Langari Langarieva Stadium",
+    "city": null,
+    "countryCode": "TJK",
+    "capacity": 20000,
+    "tenantClubs": [
+      "ravshan-kulob"
+    ]
+  },
+  {
+    "id": "nagoya-city-minato-soccer-stadium",
+    "name": "Nagoya City Minato Soccer Stadium",
+    "city": null,
+    "countryCode": "JPN",
+    "capacity": 20000,
+    "tenantClubs": [
+      "fc-maruyasu-okazaki"
+    ]
+  },
+  {
+    "id": "kimbrough-memorial-stadium",
+    "name": "Kimbrough Memorial Stadium",
+    "city": "Canyon",
+    "countryCode": "USA",
+    "capacity": 20000,
+    "tenantClubs": [
+      "west-texas-a-m-buffaloes-football"
+    ]
+  },
+  {
+    "id": "kashiwanoha-park-stadium",
+    "name": "Kashiwanoha Park Stadium",
+    "city": "Kashiwa",
+    "countryCode": "JPN",
+    "capacity": 20000,
+    "tenantClubs": [
+      "kashiwa-reysol",
+      "nec-green-rockets-tokatsu"
+    ]
+  },
+  {
+    "id": "stadionul-municipal-rou",
+    "name": "Stadionul Municipal",
+    "city": null,
+    "countryCode": "ROU",
+    "capacity": 20000,
+    "tenantClubs": [
+      "afc-dacia-unirea-braila"
+    ]
+  },
+  {
+    "id": "jinju-public-stadium",
+    "name": "Jinju Public Stadium",
     "city": null,
     "countryCode": "KOR",
     "capacity": 20000,
-    "tenantClubs": [
-      "kt-wiz"
-    ]
+    "tenantClubs": []
   },
   {
-    "id": "barikadimy-stadium",
-    "name": "Barikadimy Stadium",
+    "id": "la-peineta",
+    "name": "La Peineta",
     "city": null,
-    "countryCode": "MDG",
+    "countryCode": "ESP",
+    "capacity": 20000,
+    "tenantClubs": []
+  },
+  {
+    "id": "jamhuri-stadium",
+    "name": "Jamhuri Stadium",
+    "city": "Morogoro",
+    "countryCode": "TZA",
+    "capacity": 20000,
+    "tenantClubs": []
+  },
+  {
+    "id": "stadium-metallurg-1st-district",
+    "name": "Stadium Metallurg 1st District",
+    "city": null,
+    "countryCode": "TJK",
     "capacity": 20000,
     "tenantClubs": [
-      "as-fortior"
+      "regar-tadaz-tursunzoda"
     ]
   },
   {
-    "id": "charles-konan-banny-stadium",
-    "name": "Charles Konan Banny Stadium",
+    "id": "hama-municipal-stadium",
+    "name": "Hama Municipal Stadium",
     "city": null,
+    "countryCode": "SYR",
+    "capacity": 20000,
+    "tenantClubs": [
+      "nawair-sc"
+    ]
+  },
+  {
+    "id": "moruleng-stadium",
+    "name": "Moruleng Stadium",
+    "city": null,
+    "countryCode": "ZAF",
+    "capacity": 20000,
+    "tenantClubs": [
+      "platinum-stars-f-c"
+    ]
+  },
+  {
+    "id": "shijingshan-stadium",
+    "name": "Shijingshan Stadium",
+    "city": null,
+    "countryCode": "CHN",
+    "capacity": 20000,
+    "tenantClubs": []
+  },
+  {
+    "id": "ashgabat-stadium",
+    "name": "Ashgabat Stadium",
+    "city": null,
+    "countryCode": "TKM",
+    "capacity": 20000,
+    "tenantClubs": [
+      "fc-asgabat"
+    ]
+  },
+  {
+    "id": "laurent-pokou-stadium",
+    "name": "Laurent Pokou Stadium",
+    "city": "San-Pédro",
     "countryCode": "CIV",
     "capacity": 20000,
     "tenantClubs": [
       "ivory-coast-men-s-national-football-team"
+    ]
+  },
+  {
+    "id": "estadio-jonas-duarte",
+    "name": "Estádio Jonas Duarte",
+    "city": null,
+    "countryCode": "BRA",
+    "capacity": 20000,
+    "tenantClubs": [
+      "associacao-atletica-anapolina"
     ]
   },
   {
@@ -17319,7 +16072,7 @@
   {
     "id": "the-o2-arena",
     "name": "The O2 Arena",
-    "city": "Greenwich Peninsula",
+    "city": null,
     "countryCode": "GBR",
     "capacity": 20000,
     "tenantClubs": []
@@ -17354,24 +16107,23 @@
     "tenantClubs": []
   },
   {
-    "id": "clarke-stadium",
-    "name": "Clarke Stadium",
+    "id": "charles-konan-banny-stadium",
+    "name": "Charles Konan Banny Stadium",
     "city": null,
-    "countryCode": "CAN",
+    "countryCode": "CIV",
     "capacity": 20000,
     "tenantClubs": [
-      "edmonton-elks",
-      "fc-edmonton"
+      "ivory-coast-men-s-national-football-team"
     ]
   },
   {
-    "id": "clark-field",
-    "name": "Clark Field",
+    "id": "amadou-gon-coulibaly-stadium",
+    "name": "Amadou Gon Coulibaly Stadium",
     "city": null,
-    "countryCode": "USA",
+    "countryCode": "CIV",
     "capacity": 20000,
     "tenantClubs": [
-      "texas-longhorns-football"
+      "ivory-coast-men-s-national-football-team"
     ]
   },
   {
@@ -17445,33 +16197,696 @@
     "tenantClubs": []
   },
   {
-    "id": "laurent-pokou-stadium",
-    "name": "Laurent Pokou Stadium",
-    "city": "San-Pédro",
-    "countryCode": "CIV",
+    "id": "clark-field",
+    "name": "Clark Field",
+    "city": null,
+    "countryCode": "USA",
     "capacity": 20000,
     "tenantClubs": [
-      "ivory-coast-men-s-national-football-team"
+      "texas-longhorns-football"
     ]
   },
   {
-    "id": "amadou-gon-coulibaly-stadium",
-    "name": "Amadou Gon Coulibaly Stadium",
+    "id": "clarke-stadium",
+    "name": "Clarke Stadium",
     "city": null,
-    "countryCode": "CIV",
+    "countryCode": "CAN",
     "capacity": 20000,
     "tenantClubs": [
-      "ivory-coast-men-s-national-football-team"
+      "edmonton-elks",
+      "fc-edmonton"
     ]
   },
   {
-    "id": "estadio-la-barranquita",
-    "name": "Estadio La Barranquita",
+    "id": "hinata-athletic-stadium",
+    "name": "Hinata Athletic Stadium",
     "city": null,
-    "countryCode": "DOM",
+    "countryCode": "JPN",
     "capacity": 20000,
     "tenantClubs": [
-      "club-barcelona-atletico"
+      "minebea-mitsumi-fc"
+    ]
+  },
+  {
+    "id": "tunas-bangsa-stadium",
+    "name": "Tunas Bangsa Stadium",
+    "city": null,
+    "countryCode": "IDN",
+    "capacity": 20000,
+    "tenantClubs": [
+      "psls-lhokseumawe"
+    ]
+  },
+  {
+    "id": "yuexiushan-stadium",
+    "name": "Yuexiushan Stadium",
+    "city": null,
+    "countryCode": "CHN",
+    "capacity": 20000,
+    "tenantClubs": [
+      "guangdong-gz-power-f-c",
+      "guangzhou-city-f-c",
+      "guangzhou-f-c"
+    ]
+  },
+  {
+    "id": "stade-charlety",
+    "name": "Stade Charléty",
+    "city": "Paris",
+    "countryCode": "FRA",
+    "capacity": 20000,
+    "tenantClubs": [
+      "paris-fc",
+      "paris-saint-germain-rugby-league"
+    ]
+  },
+  {
+    "id": "estadio-do-lumiar",
+    "name": "Estádio do Lumiar",
+    "city": null,
+    "countryCode": "PRT",
+    "capacity": 20000,
+    "tenantClubs": []
+  },
+  {
+    "id": "estadio-juca-ribeiro",
+    "name": "Estádio Juca Ribeiro",
+    "city": "Uberlândia",
+    "countryCode": "BRA",
+    "capacity": 20000,
+    "tenantClubs": [
+      "uberlandia-e-c"
+    ]
+  },
+  {
+    "id": "suwon-baseball-stadium",
+    "name": "Suwon Baseball Stadium",
+    "city": null,
+    "countryCode": "KOR",
+    "capacity": 20000,
+    "tenantClubs": [
+      "kt-wiz"
+    ]
+  },
+  {
+    "id": "aswan-stadium",
+    "name": "Aswan Stadium",
+    "city": null,
+    "countryCode": "EGY",
+    "capacity": 20000,
+    "tenantClubs": [
+      "aswan-sc"
+    ]
+  },
+  {
+    "id": "rotorua-international-stadium",
+    "name": "Rotorua International Stadium",
+    "city": null,
+    "countryCode": "NZL",
+    "capacity": 20000,
+    "tenantClubs": [
+      "bay-of-plenty-ru"
+    ]
+  },
+  {
+    "id": "ali-daei-stadium",
+    "name": "Ali Daei Stadium",
+    "city": null,
+    "countryCode": "IRN",
+    "capacity": 20000,
+    "tenantClubs": [
+      "zob-ahan-ardabil-f-c"
+    ]
+  },
+  {
+    "id": "dr-akhilesh-das-stadium",
+    "name": "Dr. Akhilesh Das Stadium",
+    "city": null,
+    "countryCode": "IND",
+    "capacity": 20000,
+    "tenantClubs": [
+      "uttar-pradesh-cricket-team"
+    ]
+  },
+  {
+    "id": "al-muharraq-stadium",
+    "name": "Al Muharraq Stadium",
+    "city": null,
+    "countryCode": "BHR",
+    "capacity": 20000,
+    "tenantClubs": [
+      "al-muharraq-sc"
+    ]
+  },
+  {
+    "id": "hamad-bin-khalifa-stadium",
+    "name": "Hamad bin Khalifa Stadium",
+    "city": null,
+    "countryCode": "QAT",
+    "capacity": 20000,
+    "tenantClubs": [
+      "al-ahli-sc"
+    ]
+  },
+  {
+    "id": "barikadimy-stadium",
+    "name": "Barikadimy Stadium",
+    "city": null,
+    "countryCode": "MDG",
+    "capacity": 20000,
+    "tenantClubs": [
+      "as-fortior"
+    ]
+  },
+  {
+    "id": "teladan-stadium",
+    "name": "Teladan Stadium",
+    "city": null,
+    "countryCode": "IDN",
+    "capacity": 20000,
+    "tenantClubs": [
+      "psms-medan"
+    ]
+  },
+  {
+    "id": "huadu-sports-centre",
+    "name": "Huadu Sports Centre",
+    "city": null,
+    "countryCode": "CHN",
+    "capacity": 20000,
+    "tenantClubs": []
+  },
+  {
+    "id": "city-stadium-mys",
+    "name": "City Stadium",
+    "city": null,
+    "countryCode": "MYS",
+    "capacity": 20000,
+    "tenantClubs": [
+      "penang-f-c"
+    ]
+  },
+  {
+    "id": "estadio-24-de-setembro",
+    "name": "Estádio 24 de Setembro",
+    "city": null,
+    "countryCode": "GNB",
+    "capacity": 20000,
+    "tenantClubs": [
+      "guinea-bissau-men-s-national-football-team"
+    ]
+  },
+  {
+    "id": "setsoto-stadium",
+    "name": "Setsoto Stadium",
+    "city": null,
+    "countryCode": "LSO",
+    "capacity": 20000,
+    "tenantClubs": [
+      "lesotho-men-s-national-football-team"
+    ]
+  },
+  {
+    "id": "prince-sultan-bin-abdulaziz-sports-city",
+    "name": "Prince Sultan bin Abdulaziz Sports City",
+    "city": "Abha",
+    "countryCode": "SAU",
+    "capacity": 20000,
+    "tenantClubs": []
+  },
+  {
+    "id": "avanhard-stadium",
+    "name": "Avanhard Stadium",
+    "city": null,
+    "countryCode": "UKR",
+    "capacity": 20000,
+    "tenantClubs": [
+      "nk-veres-rivne"
+    ]
+  },
+  {
+    "id": "al-kut-olympic-stadium",
+    "name": "Al-Kut Olympic Stadium",
+    "city": "Kut",
+    "countryCode": "IRQ",
+    "capacity": 20000,
+    "tenantClubs": []
+  },
+  {
+    "id": "university-of-tehran-stadium",
+    "name": "University of Tehran Stadium",
+    "city": "Tehran",
+    "countryCode": "IRN",
+    "capacity": 20000,
+    "tenantClubs": []
+  },
+  {
+    "id": "stadium-lichtenberg",
+    "name": "Stadium Lichtenberg",
+    "city": "Berlin",
+    "countryCode": "DEU",
+    "capacity": 20000,
+    "tenantClubs": []
+  },
+  {
+    "id": "kalyani-stadium",
+    "name": "Kalyani Stadium",
+    "city": "Kalyani",
+    "countryCode": "IND",
+    "capacity": 20000,
+    "tenantClubs": [
+      "prayag-united-s-c"
+    ]
+  },
+  {
+    "id": "drei-flusse-stadion",
+    "name": "Drei Flüsse Stadion",
+    "city": null,
+    "countryCode": "DEU",
+    "capacity": 20000,
+    "tenantClubs": [
+      "1-fc-passau"
+    ]
+  },
+  {
+    "id": "warri-stadium",
+    "name": "Warri Stadium",
+    "city": null,
+    "countryCode": "NGA",
+    "capacity": 20000,
+    "tenantClubs": []
+  },
+  {
+    "id": "stadion-msk-povazska-bystrica",
+    "name": "Štadión MŠK Považská Bystrica",
+    "city": null,
+    "countryCode": "SVK",
+    "capacity": 20000,
+    "tenantClubs": [
+      "fk-raven-povazska-bystrica"
+    ]
+  },
+  {
+    "id": "nehru-stadium-tumkur",
+    "name": "Nehru Stadium, Tumkur",
+    "city": null,
+    "countryCode": "IND",
+    "capacity": 20000,
+    "tenantClubs": []
+  },
+  {
+    "id": "thammasat-stadium",
+    "name": "Thammasat Stadium",
+    "city": "Bangkok",
+    "countryCode": "THA",
+    "capacity": 20000,
+    "tenantClubs": [
+      "police-united-f-c"
+    ]
+  },
+  {
+    "id": "rn-shetty-stadium",
+    "name": "RN Shetty Stadium",
+    "city": "Dharwad",
+    "countryCode": "IND",
+    "capacity": 20000,
+    "tenantClubs": []
+  },
+  {
+    "id": "phillips-field",
+    "name": "Phillips Field",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 20000,
+    "tenantClubs": [
+      "tampa-spartans-football"
+    ]
+  },
+  {
+    "id": "bafoussam-omnisports-stadium",
+    "name": "Bafoussam omnisports stadium",
+    "city": "Bafoussam",
+    "countryCode": "CMR",
+    "capacity": 20000,
+    "tenantClubs": []
+  },
+  {
+    "id": "stade-larbi-benbarek",
+    "name": "Stade Larbi Benbarek",
+    "city": null,
+    "countryCode": "MAR",
+    "capacity": 20000,
+    "tenantClubs": [
+      "wydad-athletic-club"
+    ]
+  },
+  {
+    "id": "stade-mustapha-ben-jannet",
+    "name": "Stade Mustapha Ben Jannet",
+    "city": null,
+    "countryCode": "TUN",
+    "capacity": 20000,
+    "tenantClubs": [
+      "us-monastir"
+    ]
+  },
+  {
+    "id": "utama-negeri-stadium",
+    "name": "Utama Negeri Stadium",
+    "city": "Kangar",
+    "countryCode": "MYS",
+    "capacity": 20000,
+    "tenantClubs": [
+      "perlis-fa"
+    ]
+  },
+  {
+    "id": "lanxess-arena",
+    "name": "Lanxess Arena",
+    "city": null,
+    "countryCode": "DEU",
+    "capacity": 20000,
+    "tenantClubs": [
+      "kolner-haie"
+    ]
+  },
+  {
+    "id": "helmy-zamora-stadium",
+    "name": "Helmy Zamora Stadium",
+    "city": null,
+    "countryCode": "EGY",
+    "capacity": 20000,
+    "tenantClubs": [
+      "zamalek-sc"
+    ]
+  },
+  {
+    "id": "stadion-stari-plac",
+    "name": "Stadion Stari plac",
+    "city": null,
+    "countryCode": "HRV",
+    "capacity": 20000,
+    "tenantClubs": [
+      "hnk-hajduk-split"
+    ]
+  },
+  {
+    "id": "stade-d-honneur",
+    "name": "Stade d'Honneur",
+    "city": null,
+    "countryCode": "MAR",
+    "capacity": 20000,
+    "tenantClubs": [
+      "cod-meknes"
+    ]
+  },
+  {
+    "id": "el-mahalla-stadium",
+    "name": "El Mahalla Stadium",
+    "city": null,
+    "countryCode": "EGY",
+    "capacity": 20000,
+    "tenantClubs": [
+      "ghazl-el-mahalla-sc"
+    ]
+  },
+  {
+    "id": "habib-bouakeul-stadium",
+    "name": "Habib Bouakeul Stadium",
+    "city": null,
+    "countryCode": "DZA",
+    "capacity": 20000,
+    "tenantClubs": [
+      "asm-oran",
+      "scm-oran"
+    ]
+  },
+  {
+    "id": "stadium-15-october",
+    "name": "Stadium 15 October",
+    "city": null,
+    "countryCode": "TUN",
+    "capacity": 20000,
+    "tenantClubs": [
+      "ca-bizertine"
+    ]
+  },
+  {
+    "id": "ramadan-ben-abdelmalek-stadium",
+    "name": "Ramadan Ben-Abdelmalek Stadium",
+    "city": null,
+    "countryCode": "DZA",
+    "capacity": 20000,
+    "tenantClubs": [
+      "mo-constantine"
+    ]
+  },
+  {
+    "id": "stade-de-port-gentil",
+    "name": "Stade de Port-Gentil",
+    "city": "Port-Gentil",
+    "countryCode": "GAB",
+    "capacity": 20000,
+    "tenantClubs": [
+      "2017-africa-cup-of-nations"
+    ]
+  },
+  {
+    "id": "stade-omnisports-idriss-mahamat-ouya",
+    "name": "Stade Omnisports Idriss Mahamat Ouya",
+    "city": "N'Djamena",
+    "countryCode": "TCD",
+    "capacity": 20000,
+    "tenantClubs": [
+      "chad-men-s-national-football-team"
+    ]
+  },
+  {
+    "id": "estadio-da-curuzu",
+    "name": "Estádio da Curuzú",
+    "city": "Belém",
+    "countryCode": "BRA",
+    "capacity": 20000,
+    "tenantClubs": [
+      "paysandu-sport-club"
+    ]
+  },
+  {
+    "id": "stadion-lublinianki",
+    "name": "Stadion Lublinianki",
+    "city": null,
+    "countryCode": "POL",
+    "capacity": 20000,
+    "tenantClubs": [
+      "ks-lublinianka"
+    ]
+  },
+  {
+    "id": "daren-sammy-cricket-ground",
+    "name": "Daren Sammy Cricket Ground",
+    "city": null,
+    "countryCode": "LCA",
+    "capacity": 20000,
+    "tenantClubs": [
+      "saint-lucia-men-s-national-football-team",
+      "west-indies-cricket-team"
+    ]
+  },
+  {
+    "id": "yulin-stadium",
+    "name": "Yulin Stadium",
+    "city": null,
+    "countryCode": "CHN",
+    "capacity": 20000,
+    "tenantClubs": []
+  },
+  {
+    "id": "kazhimukan-munaitpasov-stadium",
+    "name": "Kazhimukan Munaitpasov Stadium",
+    "city": null,
+    "countryCode": "KAZ",
+    "capacity": 20000,
+    "tenantClubs": [
+      "fc-ordabasy"
+    ]
+  },
+  {
+    "id": "stade-de-marchan",
+    "name": "Stade de Marchan",
+    "city": null,
+    "countryCode": "MAR",
+    "capacity": 20000,
+    "tenantClubs": [
+      "ir-tanger"
+    ]
+  },
+  {
+    "id": "aliu-mahama-sports-stadium-gha",
+    "name": "Aliu Mahama Sports Stadium",
+    "city": "Tamale",
+    "countryCode": "GHA",
+    "capacity": 20000,
+    "tenantClubs": [
+      "real-tamale-united",
+      "steadfast-f-c"
+    ]
+  },
+  {
+    "id": "wheater-s-field",
+    "name": "Wheater's Field",
+    "city": null,
+    "countryCode": "GBR",
+    "capacity": 20000,
+    "tenantClubs": [
+      "broughton-rangers"
+    ]
+  },
+  {
+    "id": "stade-el-harti",
+    "name": "Stade El Harti",
+    "city": null,
+    "countryCode": "MAR",
+    "capacity": 20000,
+    "tenantClubs": [
+      "kacm"
+    ]
+  },
+  {
+    "id": "el-kraken",
+    "name": "El Kraken",
+    "city": "Mazatlán",
+    "countryCode": "MEX",
+    "capacity": 20000,
+    "tenantClubs": [
+      "mazatlan-futbol-club"
+    ]
+  },
+  {
+    "id": "yangquan-stadium",
+    "name": "Yangquan Stadium",
+    "city": "Yangquan",
+    "countryCode": "CHN",
+    "capacity": 20000,
+    "tenantClubs": []
+  },
+  {
+    "id": "wonju-stadium",
+    "name": "Wonju Stadium",
+    "city": null,
+    "countryCode": "KOR",
+    "capacity": 20000,
+    "tenantClubs": [
+      "gangwon-fc"
+    ]
+  },
+  {
+    "id": "chulalongkorn-university-stadium",
+    "name": "Chulalongkorn University Stadium",
+    "city": null,
+    "countryCode": "THA",
+    "capacity": 20000,
+    "tenantClubs": [
+      "bbcu-f-c"
+    ]
+  },
+  {
+    "id": "yamaguchi-ishin-park-stadium",
+    "name": "Yamaguchi Ishin Park Stadium",
+    "city": "Yamaguchi",
+    "countryCode": "JPN",
+    "capacity": 20000,
+    "tenantClubs": []
+  },
+  {
+    "id": "stade-buffalo",
+    "name": "Stade Buffalo",
+    "city": null,
+    "countryCode": "FRA",
+    "capacity": 20000,
+    "tenantClubs": []
+  },
+  {
+    "id": "olympic-stadium-of-nouakchott",
+    "name": "Olympic Stadium of Nouakchott",
+    "city": "Nouakchott",
+    "countryCode": "MRT",
+    "capacity": 20000,
+    "tenantClubs": [
+      "mauritania-men-s-national-football-team"
+    ]
+  },
+  {
+    "id": "estadio-plan-de-san-luis-potosi",
+    "name": "Estadio Plan de San Luis Potosí",
+    "city": "San Luis Potosí",
+    "countryCode": "MEX",
+    "capacity": 20000,
+    "tenantClubs": [
+      "san-luis-f-c"
+    ]
+  },
+  {
+    "id": "villareal-anaya-stadium",
+    "name": "Villareal Anaya Stadium",
+    "city": null,
+    "countryCode": "MEX",
+    "capacity": 20000,
+    "tenantClubs": [
+      "correcaminos-uat"
+    ]
+  },
+  {
+    "id": "n-stved-stadion",
+    "name": "Næstved Stadion",
+    "city": "Næstved",
+    "countryCode": "DNK",
+    "capacity": 20000,
+    "tenantClubs": [
+      "n-stved-bk"
+    ]
+  },
+  {
+    "id": "stade-barema-bocoum",
+    "name": "Stade Baréma Bocoum",
+    "city": null,
+    "countryCode": "MLI",
+    "capacity": 20000,
+    "tenantClubs": []
+  },
+  {
+    "id": "somhlolo-national-stadium",
+    "name": "Somhlolo National Stadium",
+    "city": null,
+    "countryCode": "SWZ",
+    "capacity": 20000,
+    "tenantClubs": [
+      "eswatini-men-s-national-football-team"
+    ]
+  },
+  {
+    "id": "krishnagiri-stadium",
+    "name": "Krishnagiri Stadium",
+    "city": null,
+    "countryCode": "IND",
+    "capacity": 20000,
+    "tenantClubs": []
+  },
+  {
+    "id": "otunba-dipo-dina-international-stadium",
+    "name": "Otunba Dipo Dina International Stadium",
+    "city": null,
+    "countryCode": "NGA",
+    "capacity": 20000,
+    "tenantClubs": []
+  },
+  {
+    "id": "ashdod-stadium",
+    "name": "Ashdod Stadium",
+    "city": "Ashdod",
+    "countryCode": "ISR",
+    "capacity": 20000,
+    "tenantClubs": [
+      "f-c-ashdod"
     ]
   },
   {
@@ -17485,5 +16900,386 @@
       "chicago-hounds",
       "chicago-stars-fc"
     ]
+  },
+  {
+    "id": "abdelkrim-kerroum-stadium",
+    "name": "Abdelkrim Kerroum Stadium",
+    "city": null,
+    "countryCode": "DZA",
+    "capacity": 20000,
+    "tenantClubs": [
+      "cc-sig"
+    ]
+  },
+  {
+    "id": "sekondi-takoradi-stadium",
+    "name": "Sekondi-Takoradi Stadium",
+    "city": "Sekondi-Takoradi",
+    "countryCode": "GHA",
+    "capacity": 20000,
+    "tenantClubs": [
+      "sekondi-hasaacas-f-c"
+    ]
+  },
+  {
+    "id": "estadio-vila-capanema",
+    "name": "Estádio Vila Capanema",
+    "city": null,
+    "countryCode": "BRA",
+    "capacity": 20000,
+    "tenantClubs": [
+      "clube-atletico-ferroviario",
+      "parana-clube"
+    ]
+  },
+  {
+    "id": "pitbull-stadium",
+    "name": "Pitbull Stadium",
+    "city": null,
+    "countryCode": "USA",
+    "capacity": 20000,
+    "tenantClubs": [
+      "fiu-panthers",
+      "fiu-panthers-football",
+      "miami-fc"
+    ]
+  },
+  {
+    "id": "national-sports-stadium-mng",
+    "name": "National Sports Stadium",
+    "city": null,
+    "countryCode": "MNG",
+    "capacity": 20000,
+    "tenantClubs": [
+      "mongolia-men-s-national-football-team"
+    ]
+  },
+  {
+    "id": "iwate-morioka-ballpark",
+    "name": "Iwate Morioka Ballpark",
+    "city": null,
+    "countryCode": "JPN",
+    "capacity": 20000,
+    "tenantClubs": [
+      "north-tohoku-university-baseball-federation"
+    ]
+  },
+  {
+    "id": "polonia-bydgoszcz-stadium",
+    "name": "Polonia Bydgoszcz Stadium",
+    "city": null,
+    "countryCode": "POL",
+    "capacity": 20000,
+    "tenantClubs": [
+      "motorcycle-speedway"
+    ]
+  },
+  {
+    "id": "providence-stadium",
+    "name": "Providence Stadium",
+    "city": null,
+    "countryCode": "GUY",
+    "capacity": 20000,
+    "tenantClubs": [
+      "west-indies-cricket-team"
+    ]
+  },
+  {
+    "id": "andres-quintana-roo-olympic-stadium",
+    "name": "Andrés Quintana Roo Olympic Stadium",
+    "city": null,
+    "countryCode": "MEX",
+    "capacity": 20000,
+    "tenantClubs": [
+      "atlante-f-c"
+    ]
+  },
+  {
+    "id": "district-stadium-chattogram",
+    "name": "District Stadium, Chattogram",
+    "city": "Chittagong",
+    "countryCode": "BGD",
+    "capacity": 20000,
+    "tenantClubs": []
+  },
+  {
+    "id": "planet-group-arena",
+    "name": "Planet Group arena",
+    "city": null,
+    "countryCode": "BEL",
+    "capacity": 20000,
+    "tenantClubs": [
+      "kaa-gent"
+    ]
+  },
+  {
+    "id": "sunset-stadium",
+    "name": "Sunset Stadium",
+    "city": null,
+    "countryCode": "ZMB",
+    "capacity": 20000,
+    "tenantClubs": [
+      "zanaco-f-c"
+    ]
+  },
+  {
+    "id": "sylvie-becaert-biathlon-stadium",
+    "name": "Sylvie Becaert Biathlon Stadium",
+    "city": null,
+    "countryCode": "FRA",
+    "capacity": 20000,
+    "tenantClubs": []
+  },
+  {
+    "id": "limbe-stadium",
+    "name": "Limbe Stadium",
+    "city": null,
+    "countryCode": "CMR",
+    "capacity": 20000,
+    "tenantClubs": []
+  },
+  {
+    "id": "silli-stadium",
+    "name": "Silli Stadium",
+    "city": null,
+    "countryCode": "IND",
+    "capacity": 20000,
+    "tenantClubs": []
+  },
+  {
+    "id": "rondong-demang-stadium",
+    "name": "Rondong Demang Stadium",
+    "city": "Tenggarong",
+    "countryCode": "IDN",
+    "capacity": 20000,
+    "tenantClubs": [
+      "mitra-kukar-f-c"
+    ]
+  },
+  {
+    "id": "stade-20-aout-1955",
+    "name": "Stade 20 Août 1955",
+    "city": null,
+    "countryCode": "DZA",
+    "capacity": 20000,
+    "tenantClubs": [
+      "ca-bordj-bou-arreridj"
+    ]
+  },
+  {
+    "id": "pingguo-stadium",
+    "name": "Pingguo Stadium",
+    "city": "Baise",
+    "countryCode": "CHN",
+    "capacity": 20000,
+    "tenantClubs": [
+      "guangxi-pingguo-haliao-f-c"
+    ]
+  },
+  {
+    "id": "yatta-international-stadium",
+    "name": "Yatta International Stadium",
+    "city": null,
+    "countryCode": "PSE",
+    "capacity": 20000,
+    "tenantClubs": [
+      "shabab-yatta"
+    ]
+  },
+  {
+    "id": "pairc-esler",
+    "name": "Páirc Esler",
+    "city": null,
+    "countryCode": "GBR",
+    "capacity": 20000,
+    "tenantClubs": []
+  },
+  {
+    "id": "thai-army-sports-stadium",
+    "name": "Thai Army Sports Stadium",
+    "city": "Bangkok",
+    "countryCode": "THA",
+    "capacity": 20000,
+    "tenantClubs": [
+      "army-united-f-c"
+    ]
+  },
+  {
+    "id": "brawijaya-stadium",
+    "name": "Brawijaya Stadium",
+    "city": null,
+    "countryCode": "IDN",
+    "capacity": 20000,
+    "tenantClubs": [
+      "persik-kediri"
+    ]
+  },
+  {
+    "id": "shenzhen-bay-sports-center",
+    "name": "Shenzhen Bay Sports Center",
+    "city": "Shenzhen",
+    "countryCode": "CHN",
+    "capacity": 20000,
+    "tenantClubs": [
+      "2011-summer-universiade"
+    ]
+  },
+  {
+    "id": "king-abdullah-stadium",
+    "name": "King Abdullah Stadium",
+    "city": null,
+    "countryCode": "JOR",
+    "capacity": 20000,
+    "tenantClubs": [
+      "jordan-men-s-national-football-team"
+    ]
+  },
+  {
+    "id": "yuanshen-sports-centre-stadium",
+    "name": "Yuanshen Sports Centre Stadium",
+    "city": "Shanghai",
+    "countryCode": "CHN",
+    "capacity": 20000,
+    "tenantClubs": [
+      "shanghai-shenxin-f-c"
+    ]
+  },
+  {
+    "id": "alfred-kunze-sportpark",
+    "name": "Alfred-Kunze-Sportpark",
+    "city": null,
+    "countryCode": "DEU",
+    "capacity": 20000,
+    "tenantClubs": [
+      "bsg-chemie-leipzig",
+      "fc-sachsen-leipzig",
+      "q14855286",
+      "q22813494",
+      "sc-lokomotive-leipzig",
+      "tura-leipzig"
+    ]
+  },
+  {
+    "id": "witbank-stadium",
+    "name": "Witbank Stadium",
+    "city": null,
+    "countryCode": "ZAF",
+    "capacity": 20000,
+    "tenantClubs": [
+      "mpumalanga-black-aces-f-c"
+    ]
+  },
+  {
+    "id": "seisa-ramabodu-stadium",
+    "name": "Seisa Ramabodu Stadium",
+    "city": null,
+    "countryCode": "ZAF",
+    "capacity": 20000,
+    "tenantClubs": [
+      "bloemfontein-celtic-f-c"
+    ]
+  },
+  {
+    "id": "estadio-municipal-de-la-linea-de-la-concepcion",
+    "name": "Estadio Municipal de La Línea de la Concepción",
+    "city": null,
+    "countryCode": "ESP",
+    "capacity": 20000,
+    "tenantClubs": [
+      "rb-linense"
+    ]
+  },
+  {
+    "id": "paul-greifzu-stadium",
+    "name": "Paul Greifzu Stadium",
+    "city": "Dessau-Roßlau",
+    "countryCode": "DEU",
+    "capacity": 20000,
+    "tenantClubs": [
+      "1-lac-dessau",
+      "sv-dessau-05"
+    ]
+  },
+  {
+    "id": "zhongshan-soccer-stadium",
+    "name": "Zhongshan Soccer Stadium",
+    "city": null,
+    "countryCode": "TWN",
+    "capacity": 20000,
+    "tenantClubs": [
+      "chinese-taipei-men-s-national-football-team"
+    ]
+  },
+  {
+    "id": "claro-arena",
+    "name": "Claro Arena",
+    "city": null,
+    "countryCode": "CHL",
+    "capacity": 20000,
+    "tenantClubs": [
+      "club-deportivo-universidad-catolica"
+    ]
+  },
+  {
+    "id": "estadio-roberto-natalio-carminatti",
+    "name": "Estadio Roberto Natalio Carminatti",
+    "city": null,
+    "countryCode": "ARG",
+    "capacity": 20000,
+    "tenantClubs": [
+      "club-olimpo"
+    ]
+  },
+  {
+    "id": "ibercaja-stadium",
+    "name": "Ibercaja Stadium",
+    "city": null,
+    "countryCode": "ESP",
+    "capacity": 20000,
+    "tenantClubs": [
+      "real-zaragoza"
+    ]
+  },
+  {
+    "id": "tundavala-national-stadium",
+    "name": "Tundavala National Stadium",
+    "city": null,
+    "countryCode": "AGO",
+    "capacity": 20000,
+    "tenantClubs": []
+  },
+  {
+    "id": "estadio-nacional-do-chiazi",
+    "name": "Estádio Nacional do Chiazi",
+    "city": "Cabinda",
+    "countryCode": "AGO",
+    "capacity": 20000,
+    "tenantClubs": []
+  },
+  {
+    "id": "hoegeng-stadium",
+    "name": "Hoegeng Stadium",
+    "city": null,
+    "countryCode": "IDN",
+    "capacity": 20000,
+    "tenantClubs": [
+      "persip-pekalongan"
+    ]
+  },
+  {
+    "id": "national-cricket-stadium",
+    "name": "National Cricket Stadium",
+    "city": null,
+    "countryCode": "GRD",
+    "capacity": 20000,
+    "tenantClubs": []
+  },
+  {
+    "id": "miki-athletic-stadium",
+    "name": "Miki Athletic Stadium",
+    "city": null,
+    "countryCode": "JPN",
+    "capacity": 20000,
+    "tenantClubs": []
   }
 ]

--- a/tools/fetch-venues.ps1
+++ b/tools/fetch-venues.ps1
@@ -15,16 +15,18 @@ $UA = 'FantasyFootball-VenueFetch/0.1 (https://github.com/StepKie/FantasyFootbal
 $OutPath = 'src/FantasyFootball.Core/Resources/Data/venues.json'
 $MinCapacity = 20000
 
-# Football stadiums (Q483110 and subclasses) with a known capacity, optional city,
-# country (via ISO-3166-1 alpha-3 code), and tenant club. Multi-tenant venues
-# return multiple rows we coalesce in post-processing.
+# Football stadiums with known capacity. Multi-tenant venues coalesce in post-process. Walks P131* from P276 to a Q515 ancestor — see commit message for the borough-vs-city handling.
 $Query = @"
 SELECT ?stadium ?stadiumLabel ?cityLabel ?countryCode ?capacity ?clubLabel WHERE {
   ?stadium wdt:P31/wdt:P279* wd:Q483110 .
   ?stadium wdt:P1083 ?capacity .
   FILTER(?capacity >= $MinCapacity)
   FILTER NOT EXISTS { ?stadium wdt:P576 ?dissolved . }   # exclude demolished / dissolved stadiums
-  OPTIONAL { ?stadium wdt:P276 ?city. }
+  OPTIONAL {
+    ?stadium wdt:P276 ?location .
+    ?location wdt:P131* ?city .
+    ?city wdt:P31/wdt:P279* wd:Q515 .
+  }
   OPTIONAL { ?stadium wdt:P17 ?country. ?country wdt:P298 ?countryCode. }
   OPTIONAL { ?stadium wdt:P466 ?club. }
   SERVICE wikibase:label { bd:serviceParam wikibase:language "en". }
@@ -60,10 +62,16 @@ function Slugify($name) {
 $venues = $rows | Group-Object { $_.stadium.value } | ForEach-Object {
     $stadium = $_.Group[0]
     $stadiumName = $stadium.stadiumLabel.value
+    # Wikidata's label service falls back to the raw QID when no English label exists. Slugify would happily turn "Q11836159" into a valid-looking "q11836159" slug, so check the raw label first.
+    if ($stadiumName -match '^Q\d+$') { return }
     $stadiumId = Slugify $stadiumName
     if (-not $stadiumId) { return }
 
-    $cityName = $stadium.cityLabel.value
+    # Picks one of potentially multiple Q515 ancestors for a stadium; in practice the SPARQL chain returns a single city for our 34 competition venues. Ordering across endpoint upgrades isn't speced — if a future run flips between candidates, key the venue in $CityOverrides.
+    $cityName = $_.Group |
+        Where-Object { $_.cityLabel -and -not [string]::IsNullOrWhiteSpace($_.cityLabel.value) -and $_.cityLabel.value -notmatch '^Q\d+$' } |
+        Select-Object -First 1 -ExpandProperty cityLabel |
+        Select-Object -ExpandProperty value
     if ([string]::IsNullOrWhiteSpace($cityName)) { $cityName = $null }
 
     $countryCode = $stadium.countryCode.value
@@ -112,6 +120,60 @@ foreach ($v in $venues) {
 }
 
 Write-Host "  $($final.Count) unique stadiums after dedup."
+
+# Wikidata-gap overrides — keys are post-dedup IDs (relies on the higher-capacity venue keeping the base slug when names collide); see commit message for criteria.
+$CityOverrides = @{
+    'westfalenstadion'             = 'Dortmund'
+    'rheinenergie-stadion'         = 'Cologne'
+    'red-bull-arena'               = 'Leipzig'
+    'al-bayt-stadium'              = 'Al Khor'
+    'khalifa-international-stadium' = 'Al Rayyan'
+    'ahmad-bin-ali-stadium'        = 'Al Rayyan'
+    'lusail-stadium'               = 'Lusail'
+    'education-city-stadium'       = 'Al Rayyan'
+    'stadium-974'                  = 'Doha'
+    'banorte-stadium'              = 'Mexico City'
+    'estadio-akron'                = 'Guadalajara'
+    'estadio-monterrey'            = 'Monterrey'
+    'metlife-stadium'              = 'East Rutherford'
+    'gillette-stadium'             = 'Foxborough'
+    'lincoln-financial-field'      = 'Philadelphia'
+    'hard-rock-stadium'            = 'Miami Gardens'
+    'lumen-field'                  = 'Seattle'
+    'ataturk-olympic-stadium'      = 'Istanbul'
+    'melbourne-cricket-ground'     = 'Melbourne'
+    'estadio-monumental-u'         = 'Lima'
+}
+$overrideHits = 0
+foreach ($v in $final) {
+    if ($CityOverrides.ContainsKey($v.id)) {
+        $v.city = $CityOverrides[$v.id]
+        $overrideHits++
+    }
+}
+Write-Host "  Applied $overrideHits city overrides for Wikidata-gap venues."
+if ($overrideHits -ne $CityOverrides.Count) {
+    Write-Warning "  Expected $($CityOverrides.Count) override hits but got $overrideHits — a dedup rename may have suffixed an override target's slug."
+}
+
+# Berlin Olympiastadion: not returned by the SPARQL query (Wikidata classifies it multi-purpose / Olympic, not Q483110); hand-add.
+$berlinId = 'olympiastadion-berlin'
+if (-not ($final | Where-Object { $_.id -eq $berlinId })) {
+    $berlin = [PSCustomObject]@{
+        id           = $berlinId
+        name         = 'Olympiastadion'
+        city         = 'Berlin'
+        countryCode  = 'DEU'
+        capacity     = 74475
+        tenantClubs  = @('hertha-bsc')
+    }
+    $final.Add($berlin)
+    # Re-sort capacity-desc with the new entry in place.
+    $sorted = $final | Sort-Object capacity -Descending
+    $final = New-Object System.Collections.Generic.List[Object]
+    foreach ($v in $sorted) { $final.Add($v) }
+    Write-Host "  Hand-added Berlin Olympiastadion."
+}
 
 $json = $final | ConvertTo-Json -Depth 4
 Set-Content -Path $OutPath -Value $json -Encoding UTF8


### PR DESCRIPTION
## Summary

Follow-up to PR #54's known caveat: replace the borough-level / null cities for many venues used by the three bundled competitions with the proper city name.

### SPARQL change

`fetch-venues.ps1`'s city-selection clause was a bare `?stadium wdt:P276 ?city` — which on Wikidata often points at the deepest admin entity (a borough or quarter, e.g. Freimann for Allianz Arena). Replaced with a `P131*` admin-walk that climbs the location chain to the first ancestor typed as Q515 (city). Picks the right city for ~16 venues that previously resolved to a borough.

### Hand-supplement, baked into the script

Two flavors of remaining gap:

1. **Venues with no `P276` at all** — most US WC 2026 hosts (MetLife, Gillette, Lincoln Financial, Hard Rock, Lumen), the 5 still-null Qatar 2022 venues (Al Bayt, Khalifa, Ahmad bin Ali, Lusail, Stadium 974), and three German grounds (Westfalenstadion, RheinEnergieStadion, Red Bull Arena). The SPARQL walk has nothing to climb from. Hand-coded into a `$CityOverrides` hashtable in the script with a clear "drop these once Wikidata fills P276" comment.
2. **Borough-level municipalities subsumed by metro names** — Zapopan→Guadalajara, Guadalupe→Monterrey. Wikidata is technically correct (both are Q515 cities) but tournament context calls for the metro name. Overridden via the same hashtable.

Berlin Olympiastadion is also hand-added: its Wikidata entity isn't typed as `wd:Q483110` (association football stadium) — primary classification is multi-purpose / Olympic, so it falls outside the SPARQL type filter.

### Why not a SPARQL-only fix?

Tried a `P276 ∪ P131` UNION fallback to catch the no-`P276` venues automatically. The public Wikidata endpoint times out at 60s on it. The hand-supplement is the pragmatic path; the script's comments name the conditions under which each override can be removed.

## Test plan

- [x] All 161 tests pass.
- [x] Spot-check: all 34 venues used across WC 2026 / WC 2022 / Euro 2024 now resolve to the recognized city name (`venues.json[id=allianz-arena].city == "Munich"`, etc.). Verified in script.
- [ ] Visual: click any game in any of the three competitions, the popover Venue row reads `<stadium> · <city> · cap. <N>` with no borough leakage.