### PR TITLE
Per-competition EloSet picker (closes #59)

### DIFF
--- a/src/FantasyFootball.Core/Models/Competition.cs
+++ b/src/FantasyFootball.Core/Models/Competition.cs
@@ -73,4 +73,13 @@ public sealed class Competition
 
 	/// <summary>All games, in chronological order.</summary>
 	public required Game[] Games { get; init; }
+
+	/// <summary>
+	/// Name of the <see cref="EloSet"/> the simulator should use for this
+	/// competition (e.g. <c>"2018"</c>, <c>"Current"</c>, <c>"Germany-OP"</c>).
+	/// Null = use the legacy fallback chain (year-matched if it exists,
+	/// otherwise the UI's active EloSet). Set by the setup picker; persists
+	/// across saves so the sim path is deterministic per competition.
+	/// </summary>
+	public string? EloSetName { get; set; }
 }

--- a/src/FantasyFootball.Core/Models/CompetitionSpec.cs
+++ b/src/FantasyFootball.Core/Models/CompetitionSpec.cs
@@ -35,6 +35,9 @@ namespace FantasyFootball.Models;
 public abstract record class CompetitionSpec
 {
 	public required string DefinitionId { get; init; }
+
+	/// <summary>EloSet name to bake onto the materialized Competition (defaults to null = legacy fallback chain).</summary>
+	public string? EloSetName { get; init; }
 }
 
 /// <summary>

--- a/src/FantasyFootball.Core/Services/BulkSimRunner.cs
+++ b/src/FantasyFootball.Core/Services/BulkSimRunner.cs
@@ -28,17 +28,20 @@ public sealed class BulkSimRunner
 	readonly CompetitionSimulator _simulator;
 	readonly ICompetitionRepository _repo;
 	readonly IRepository _entityRepo;
+	readonly ICompetitionDefinitionStore _definitions;
 
 	public BulkSimRunner(
 		CompetitionFactory factory,
 		CompetitionSimulator simulator,
 		ICompetitionRepository repo,
-		IRepository entityRepo)
+		IRepository entityRepo,
+		ICompetitionDefinitionStore definitions)
 	{
 		_factory = factory;
 		_simulator = simulator;
 		_repo = repo;
 		_entityRepo = entityRepo;
+		_definitions = definitions;
 	}
 
 	public async Task<IReadOnlyList<int>> RunAsync(
@@ -52,15 +55,16 @@ public sealed class BulkSimRunner
 			throw new ArgumentOutOfRangeException(nameof(count), count, "Bulk sim needs at least one run.");
 		}
 
-		// HistoricalSpec sims use the year-matched EloSet; resolve once since the snapshot is immutable mid-bulk.
-		IScoreModel? historicalOverride = ResolveHistoricalScoreModel(spec);
+		// Resolve once per bulk run using scalar overload — avoids materializing a Competition, which for RandomLineupSpec would consume the draw RNG and shift all subsequent iterations.
+		var year = _definitions.Load(spec.DefinitionId).Year;
+		IScoreModel? scoreOverride = HistoricalScoreModelResolver.Resolve(spec.EloSetName, year, _entityRepo);
 
 		var ids = new List<int>(count);
 		for (int i = 0; i < count; i++)
 		{
 			cancellationToken.ThrowIfCancellationRequested();
 			var competition = _factory.Create(spec);
-			_simulator.Simulate(competition, historicalOverride);
+			_simulator.Simulate(competition, scoreOverride);
 			var id = await _repo.SaveAsync(competition);
 			ids.Add(id);
 			progress?.Report(i + 1);
@@ -69,20 +73,5 @@ public sealed class BulkSimRunner
 		}
 
 		return ids;
-	}
-
-	IScoreModel? ResolveHistoricalScoreModel(CompetitionSpec spec)
-	{
-		if (spec is not HistoricalSpec) { return null; }
-		// Materialize the spec once to read its Year; cheap relative to the upcoming N runs.
-		var sample = _factory.Create(spec);
-		var year = sample.Year.ToString(CultureInfo.InvariantCulture);
-		var historical = _entityRepo.GetAll<EloSet>().FirstOrDefault(s => s.Name == year);
-		if (historical is null)
-		{
-			Log.Debug("No EloSet named {Year} for HistoricalSpec {DefinitionId}", year, spec.DefinitionId);
-			return null;
-		}
-		return new EloScoreModel(new EloSetTeamRegistry(historical));
 	}
 }

--- a/src/FantasyFootball.Core/Services/CompetitionDefinitionLoader.cs
+++ b/src/FantasyFootball.Core/Services/CompetitionDefinitionLoader.cs
@@ -116,6 +116,7 @@ public static class CompetitionDefinitionLoader
 			Year = raw.Year,
 			DefinitionId = raw.Id,
 			FormatId = raw.FormatId,
+			EloSetName = raw.EloSetName,
 			SimulationStart = raw.SimulationStart,
 			SimulationFinished = raw.SimulationFinished,
 			GroupAssignments = groupAssignments,
@@ -163,6 +164,7 @@ public static class CompetitionDefinitionLoader
 		public required CompetitionType Type { get; init; }
 		public required int Year { get; init; }
 		public required string FormatId { get; init; }
+		public string? EloSetName { get; init; }
 		public DateTime? SimulationStart { get; init; }
 		public DateTime? SimulationFinished { get; init; }
 		public required Stage[] Stages { get; init; }

--- a/src/FantasyFootball.Core/Services/CompetitionFactory.cs
+++ b/src/FantasyFootball.Core/Services/CompetitionFactory.cs
@@ -23,6 +23,7 @@ public sealed class CompetitionFactory
 	public Competition Create(CompetitionSpec spec)
 	{
 		var competition = _definitions.Load(spec.DefinitionId);
+		competition.EloSetName = spec.EloSetName;
 
 		if (competition.GroupAssignments.Length == 0 && spec is not HistoricalSpec)
 		{

--- a/src/FantasyFootball.Core/Services/CompetitionSimulator.cs
+++ b/src/FantasyFootball.Core/Services/CompetitionSimulator.cs
@@ -56,14 +56,14 @@ public sealed class CompetitionSimulator
 	/// <summary>
 	/// Score every unplayed game in the given round, chronological order.
 	/// </summary>
-	public void SimulateRound(Competition c, string roundId)
+	public void SimulateRound(Competition c, string roundId, IScoreModel? scoreModelOverride = null)
 	{
 		var roundGames = c.Games
 			.Where(g => g.RoundId == roundId && g.Result is null)
 			.OrderBy(g => g.PlayedOn);
 		foreach (var game in roundGames)
 		{
-			SimulateGame(c, game);
+			SimulateGame(c, game, scoreModelOverride);
 		}
 	}
 

--- a/src/FantasyFootball.Core/Services/FlatJson.cs
+++ b/src/FantasyFootball.Core/Services/FlatJson.cs
@@ -104,6 +104,7 @@ public static class FlatJson
 			type = c.Type,
 			year = c.Year,
 			formatId = c.FormatId,
+			eloSetName = c.EloSetName,
 			simulationStart = c.SimulationStart,
 			simulationFinished = c.SimulationFinished,
 			stages = c.Stages,

--- a/src/FantasyFootball.Core/Services/HistoricalScoreModelResolver.cs
+++ b/src/FantasyFootball.Core/Services/HistoricalScoreModelResolver.cs
@@ -1,0 +1,45 @@
+namespace FantasyFootball.Services;
+
+/// <summary>
+/// Resolves the <see cref="IScoreModel"/> a sim should use for a given
+/// <see cref="Competition"/>. Priority: explicit <see cref="Competition.EloSetName"/>
+/// (set via the setup picker) → year-matched EloSet (legacy fallback for
+/// competitions saved before the picker) → null (caller uses the DI default,
+/// i.e. the UI's active EloSet).
+///
+/// Returning <c>null</c> lets the call site fall through to its default model,
+/// preserving the current "use whatever's active" behavior for competitions
+/// whose year has no bundled EloSet (wm-2026 today).
+/// </summary>
+public static class HistoricalScoreModelResolver
+{
+	public static IScoreModel? Resolve(Competition competition, IRepository repo) =>
+		Resolve(competition.EloSetName, competition.Year, repo);
+
+	/// <summary>
+	/// Scalar overload — lets callers skip materializing a Competition when all
+	/// they need is the EloSet pick (e.g. <see cref="BulkSimRunner"/> on a
+	/// RandomLineupSpec, where the full factory path would consume the draw
+	/// algorithm's RNG as an unwanted side effect).
+	/// </summary>
+	public static IScoreModel? Resolve(string? eloSetName, int year, IRepository repo)
+	{
+		var sets = repo.GetAll<EloSet>();
+
+		if (eloSetName is { } pinned)
+		{
+			var explicitSet = sets.FirstOrDefault(s => s.Name == pinned);
+			if (explicitSet is not null) { return Build(explicitSet); }
+			Log.Debug("Pinned EloSet {EloSetName} isn't in the repo; trying year-matched fallback", pinned);
+		}
+
+		var yearKey = year.ToString(CultureInfo.InvariantCulture);
+		var yearSet = sets.FirstOrDefault(s => s.Name == yearKey);
+		if (yearSet is not null) { return Build(yearSet); }
+
+		Log.Debug("No EloSet named {Year}; falling back to active set", yearKey);
+		return null;
+	}
+
+	static IScoreModel Build(EloSet set) => new EloScoreModel(new EloSetTeamRegistry(set));
+}

--- a/src/FantasyFootball.Tests/BulkSimRunnerTests.cs
+++ b/src/FantasyFootball.Tests/BulkSimRunnerTests.cs
@@ -20,7 +20,7 @@ public class BulkSimRunnerTests
 	public BulkSimRunnerTests()
 	{
 		_factory = new(_definitions);
-		_runner = new(_factory, _simulator, _repo, _entityRepo);
+		_runner = new(_factory, _simulator, _repo, _entityRepo, _definitions);
 	}
 
 	[Fact]
@@ -127,7 +127,8 @@ public class BulkSimRunnerTests
 			_factory,
 			new CompetitionSimulator(new ThrowOnCallScoreModel()),
 			_repo,
-			_entityRepo);
+			_entityRepo,
+			_definitions);
 
 		string[] wm2018Teams = ["ARG","AUS","BEL","BRA","COL","CRC","CRO","DEN","EGY","ENG","ESP","FRA","GER","IRN","ISL","JPN","KOR","KSA","MAR","MEX","NGA","PAN","PER","POL","POR","RUS","SEN","SRB","SUI","SWE","TUN","URU"];
 		_entityRepo.Save(new EloSet
@@ -141,6 +142,27 @@ public class BulkSimRunnerTests
 		Func<Task> act = () => throwingRunner.RunAsync(spec, count: 1);
 
 		await act.Should().NotThrowAsync("the year-matched override should supply every score, never falling back to the throwing default");
+	}
+
+	[Fact]
+	public async Task Run_ExplicitEloSetName_OverridesYearMatch()
+	{
+		// Picker selected a non-year EloSet — it must win over both the year-match and the active fallback.
+		var throwingRunner = new BulkSimRunner(
+			_factory,
+			new CompetitionSimulator(new ThrowOnCallScoreModel()),
+			_repo,
+			_entityRepo,
+			_definitions);
+
+		string[] wm2018Teams = ["ARG","AUS","BEL","BRA","COL","CRC","CRO","DEN","EGY","ENG","ESP","FRA","GER","IRN","ISL","JPN","KOR","KSA","MAR","MEX","NGA","PAN","PER","POL","POR","RUS","SEN","SRB","SUI","SWE","TUN","URU"];
+		_entityRepo.Save(new EloSet { Name = "Germany-OP", Date = new DateOnly(2026, 1, 1), Snapshot = wm2018Teams.ToDictionary(t => t, _ => 1500) });
+		// Year-matched "2018" is intentionally absent here — only the picked set covers the lineup. If the resolver ignored EloSetName, the test would fall through and the throwing default would fire.
+
+		var spec = new HistoricalSpec { DefinitionId = "wm-2018", Played = false, EloSetName = "Germany-OP" };
+		Func<Task> act = () => throwingRunner.RunAsync(spec, count: 1);
+
+		await act.Should().NotThrowAsync("the explicit EloSetName must resolve, regardless of year-match availability");
 	}
 
 	sealed class ThrowOnCallScoreModel : IScoreModel

--- a/src/FantasyFootball.UI/Pages/CompetitionSetup.razor
+++ b/src/FantasyFootball.UI/Pages/CompetitionSetup.razor
@@ -51,6 +51,16 @@
             <MudSelectItem Value="@year">@year</MudSelectItem>
           }
         </MudSelect>
+        <MudSelect T="string"
+                   Label="Elo set"
+                   Value="ViewModel.SelectedEloSetName"
+                   ValueChanged="@((string v) => ViewModel.SelectedEloSetName = v)"
+                   HelperText="@($"Used as the source of team strengths for this competition.{(ViewModel.SelectedEloSetName == ViewModel.SelectedYear.ToString(System.Globalization.CultureInfo.InvariantCulture) ? " (year-matched default)" : "")}")">
+          @foreach (var name in ViewModel.AvailableEloSetNames)
+          {
+            <MudSelectItem Value="@name">@name</MudSelectItem>
+          }
+        </MudSelect>
 
         <MudSpacer />
 

--- a/src/FantasyFootball.UI/ViewModels/CompetitionDetailViewModel.cs
+++ b/src/FantasyFootball.UI/ViewModels/CompetitionDetailViewModel.cs
@@ -16,15 +16,21 @@ public partial class CompetitionDetailViewModel : ObservableObject
 	readonly ICompetitionRepository _repo;
 	readonly CompetitionSimulator _simulator;
 	readonly CompetitionFactory _factory;
+	readonly IRepository _entityRepo;
+
+	// Resolved when Competition loads; passed to every Simulate* call so the year-matched or pinned EloSet is used.
+	IScoreModel? _scoreOverride;
 
 	public CompetitionDetailViewModel(
 		ICompetitionRepository repo,
 		CompetitionSimulator simulator,
-		CompetitionFactory factory)
+		CompetitionFactory factory,
+		IRepository entityRepo)
 	{
 		_repo = repo;
 		_simulator = simulator;
 		_factory = factory;
+		_entityRepo = entityRepo;
 	}
 
 	/// <summary>
@@ -115,6 +121,8 @@ public partial class CompetitionDetailViewModel : ObservableObject
 		Competition = await _repo.GetAsync(competitionId);
 		if (Competition is null) { return; }
 
+		_scoreOverride = HistoricalScoreModelResolver.Resolve(Competition, _entityRepo);
+
 		var currentGame = Competition.CurrentGame();
 		var currentRoundId = currentGame?.RoundId
 			?? Competition.Rounds.OrderByDescending(r => r.Order).FirstOrDefault()?.Id;
@@ -153,7 +161,7 @@ public partial class CompetitionDetailViewModel : ObservableObject
 		{
 			try
 			{
-				_simulator.SimulateGame(Competition, game);
+				_simulator.SimulateGame(Competition, game, _scoreOverride);
 				await _repo.SaveAsync(Competition);
 			}
 			catch
@@ -239,7 +247,7 @@ public partial class CompetitionDetailViewModel : ObservableObject
 			{
 				lastPlayed.Result = null;
 				ClearUnplayedKoResolutions(Competition);
-				_simulator.SimulateGame(Competition, lastPlayed);
+				_simulator.SimulateGame(Competition, lastPlayed, _scoreOverride);
 				CompetitionSimulator.ResolveAvailableKoTeams(Competition);
 				await _repo.SaveAsync(Competition);
 			}
@@ -316,7 +324,7 @@ public partial class CompetitionDetailViewModel : ObservableObject
 					.Where(g => g.Result is null && g.PlayedOn <= cutoff)
 					.OrderBy(g => g.PlayedOn))
 				{
-					_simulator.SimulateGame(Competition, game);
+					_simulator.SimulateGame(Competition, game, _scoreOverride);
 					played.Add(game);
 				}
 				await _repo.SaveAsync(Competition);
@@ -361,7 +369,7 @@ public partial class CompetitionDetailViewModel : ObservableObject
 		{
 			// Yield so the IsBusy spinner flushes before the synchronous sim hogs the WASM thread.
 			await Task.Yield();
-			_simulator.Simulate(Competition);
+			_simulator.Simulate(Competition, _scoreOverride);
 			await _repo.SaveAsync(Competition);
 		}
 		finally

--- a/src/FantasyFootball.UI/ViewModels/CompetitionSetupViewModel.cs
+++ b/src/FantasyFootball.UI/ViewModels/CompetitionSetupViewModel.cs
@@ -32,6 +32,7 @@ public partial class CompetitionSetupViewModel : ObservableObject
 	readonly CompetitionFactory _factory;
 	readonly ICompetitionRepository _repo;
 	readonly BulkSimRunner _runner;
+	readonly IRepository _entityRepo;
 
 	/// <summary>(Type, Year) for every committed definition; flat list to drive the pickers.</summary>
 	readonly List<(CompetitionType Type, int Year, string DefinitionId)> _catalog;
@@ -45,7 +46,8 @@ public partial class CompetitionSetupViewModel : ObservableObject
 		IDataService dataService,
 		CompetitionFactory factory,
 		ICompetitionRepository repo,
-		BulkSimRunner runner)
+		BulkSimRunner runner,
+		IRepository entityRepo)
 	{
 		_definitions = definitions;
 		_registry = registry;
@@ -53,6 +55,7 @@ public partial class CompetitionSetupViewModel : ObservableObject
 		_factory = factory;
 		_repo = repo;
 		_runner = runner;
+		_entityRepo = entityRepo;
 
 		_catalog = _definitions.AvailableIds
 			.Select(id => _definitions.Load(id))
@@ -70,6 +73,9 @@ public partial class CompetitionSetupViewModel : ObservableObject
 			: _catalog.First();
 		SelectedType = seed.Type;
 		SelectedYear = seed.Year;
+
+		AvailableEloSetNames = LoadEloSetNames();
+		SelectedEloSetName = DefaultEloSetNameFor(SelectedYear);
 	}
 
 	public IReadOnlyList<CompetitionType> AvailableTypes { get; }
@@ -88,6 +94,12 @@ public partial class CompetitionSetupViewModel : ObservableObject
 	[ObservableProperty]
 	[NotifyPropertyChangedFor(nameof(Groups))]
 	public partial int SelectedYear { get; set; }
+
+	[ObservableProperty]
+	public partial IReadOnlyList<string> AvailableEloSetNames { get; set; } = [];
+
+	[ObservableProperty]
+	public partial string? SelectedEloSetName { get; set; }
 
 	[ObservableProperty]
 	[NotifyPropertyChangedFor(nameof(Groups))]
@@ -150,7 +162,22 @@ public partial class CompetitionSetupViewModel : ObservableObject
 	{
 		_drawnLineup = null;
 		CurrentLineup = LineupMode.Original;
+		SelectedEloSetName = DefaultEloSetNameFor(value);
 	}
+
+	// Year-matched ("2018") if a bundled snapshot exists, else "Current". Names come from the live repo so user forks are pickable too.
+	string? DefaultEloSetNameFor(int year)
+	{
+		var yearName = year.ToString(CultureInfo.InvariantCulture);
+		if (AvailableEloSetNames.Contains(yearName)) { return yearName; }
+		return AvailableEloSetNames.Contains(JsonDataService.CurrentEloSetName) ? JsonDataService.CurrentEloSetName : AvailableEloSetNames.FirstOrDefault();
+	}
+
+	IReadOnlyList<string> LoadEloSetNames() => _entityRepo.GetAll<EloSet>()
+		.Select(s => s.Name)
+		.OrderBy(name => name == JsonDataService.CurrentEloSetName ? 0 : 1)
+		.ThenBy(name => name, StringComparer.Ordinal)
+		.ToList();
 
 	public void ResetToOriginal()
 	{
@@ -176,8 +203,8 @@ public partial class CompetitionSetupViewModel : ObservableObject
 	public async Task<int> CreateSingleAsync()
 	{
 		var spec = CurrentLineup == LineupMode.Random && _drawnLineup is not null
-			? (CompetitionSpec)new CustomLineupSpec { DefinitionId = DefinitionId, Groups = _drawnLineup }
-			: new HistoricalSpec { DefinitionId = DefinitionId, Played = false };
+			? (CompetitionSpec)new CustomLineupSpec { DefinitionId = DefinitionId, Groups = _drawnLineup, EloSetName = SelectedEloSetName }
+			: new HistoricalSpec { DefinitionId = DefinitionId, Played = false, EloSetName = SelectedEloSetName };
 
 		var competition = _factory.Create(spec);
 		return await _repo.SaveAsync(competition);
@@ -230,12 +257,13 @@ public partial class CompetitionSetupViewModel : ObservableObject
 			{
 				DefinitionId = DefinitionId,
 				DrawAlgorithm = new UniformDrawFromRegistry(_registry),
+				EloSetName = SelectedEloSetName,
 			};
 		}
 
 		return CurrentLineup == LineupMode.Random && _drawnLineup is not null
-			? new CustomLineupSpec { DefinitionId = DefinitionId, Groups = _drawnLineup }
-			: new HistoricalSpec { DefinitionId = DefinitionId, Played = false };
+			? new CustomLineupSpec { DefinitionId = DefinitionId, Groups = _drawnLineup, EloSetName = SelectedEloSetName }
+			: new HistoricalSpec { DefinitionId = DefinitionId, Played = false, EloSetName = SelectedEloSetName };
 	}
 
 	IReadOnlyList<LineupGroup> BuildGroupsForPreview()

--- a/src/FantasyFootball.UI/ViewModels/CompetitionsViewModel.cs
+++ b/src/FantasyFootball.UI/ViewModels/CompetitionsViewModel.cs
@@ -23,19 +23,22 @@ public partial class CompetitionsViewModel : ObservableObject
 	readonly CompetitionFactory _factory;
 	readonly CompetitionSimulator _simulator;
 	readonly ICompetitionDefinitionStore _definitions;
+	readonly IRepository _entityRepo;
 
 	public CompetitionsViewModel(
 		ICompetitionRepository repo,
 		IDataService dataService,
 		CompetitionFactory factory,
 		CompetitionSimulator simulator,
-		ICompetitionDefinitionStore definitions)
+		ICompetitionDefinitionStore definitions,
+		IRepository entityRepo)
 	{
 		_repo = repo;
 		_dataService = dataService;
 		_factory = factory;
 		_simulator = simulator;
 		_definitions = definitions;
+		_entityRepo = entityRepo;
 
 		// Hydrate from the shared type pref so the chip state survives navigation between list and setup pages.
 		SelectedType = dataService.SelectedCompetitionType;
@@ -227,7 +230,7 @@ public partial class CompetitionsViewModel : ObservableObject
 		{
 			// Yield so the IsBusy spinner flushes before the synchronous sim hogs the WASM thread.
 			await Task.Yield();
-			_simulator.Simulate(comp);
+			_simulator.Simulate(comp, HistoricalScoreModelResolver.Resolve(comp, _entityRepo));
 			await _repo.SaveAsync(comp);
 			await ReloadAsync();
 		}


### PR DESCRIPTION
## Summary

Adds an EloSet picker on the CompetitionSetup page. Default is the year-matched bundled snapshot (e.g. "2018" for em-2018); the user can override to any seeded historical or their own custom fork. Selection persists on the Competition object — sim paths read it back via a shared resolver.

**Closes #59.** Threading the resolver through both bulk and interactive sim paths removes the era-mismatch crash (e.g. wm-1986 with "Current" active → `EloOf("FRG")` crashes) that's been deferred for several PR-58 rounds. The picker is the user-facing surface; the resolver is the infrastructure.

## What changed

- **Model**: `Competition.EloSetName` (nullable string) + matching field on `CompetitionSpec` base. Threaded through `CompetitionFactory.Create`, serialized via FlatJson, parsed back via `CompetitionDefinitionLoader`.
- **Resolver**: new `HistoricalScoreModelResolver.Resolve(Competition, IRepository)` static helper with fallback chain: explicit `Competition.EloSetName` → year-matched (`"{Year}"`) → null (DI default = active set). Returns `IScoreModel?`.
- **Sim paths** all use the resolver:
  - `BulkSimRunner.RunAsync` drops its HistoricalSpec-only `ResolveHistoricalScoreModel`.
  - `CompetitionDetailViewModel` caches the resolved override on `LoadAsync`; passes to every Simulate* call (single-game, undo-then-reroll, round, stage, all).
  - `CompetitionsViewModel.FastForwardAsync` resolves per-call.
- **CompetitionSimulator.SimulateRound** gains the `scoreModelOverride` parameter (Simulate / SimulateGame already had it).
- **UI**: MudSelect "Elo set" picker on the setup page next to Year. Defaults to year-matched on initial load and on Year change. Helper text marks the default state.

## Backwards compat

Legacy competitions saved before this PR have `EloSetName = null`. The resolver's year-match fallback kicks in — same behavior as before for HistoricalSpec bulk runs, and for interactive sims of pre-existing competitions there's now an *improvement* (year-matched elos used where the active set previously was, removing the era-mismatch crash).

## Test plan

- [x] `dotnet test` green (210/210 — added `Run_ExplicitEloSetName_OverridesYearMatch` covering the new resolution branch).
- [ ] On `develop` after merge: New → EM 2024 → confirm picker defaults to "2024"; create + simulate → uses 2024 elos regardless of active selection on Teams page.
- [ ] New → WM 2026 → picker defaults to "Current" (no `elo-2026.json`); confirm.
- [ ] New → WM 1986 with Played=false → picker defaults to "1986" → simulate → no `EloOf("FRG")` crash, sim runs to completion.
- [ ] Open an existing wm-2018 competition saved on develop today → picker isn't visible (detail page), but the loaded comp has `EloSetName=null` → sim falls through to year-matched 2018.