### PR TITLE
Propagate EloSet through replay + popover + Setup picker; URS flag

### DIFF
--- a/src/FantasyFootball.Core/Services/HistoricalScoreModelResolver.cs
+++ b/src/FantasyFootball.Core/Services/HistoricalScoreModelResolver.cs
@@ -24,22 +24,28 @@ public static class HistoricalScoreModelResolver
 	/// </summary>
 	public static IScoreModel? Resolve(string? eloSetName, int year, IRepository repo)
 	{
+		var set = ResolveEloSet(eloSetName, year, repo);
+		return set is null ? null : new EloScoreModel(new EloSetTeamRegistry(set));
+	}
+
+	/// <summary>
+	/// EloSet variant — same priority chain (pinned → year-matched → null), but
+	/// returns the resolved <see cref="EloSet"/> instead of a score model. Used by
+	/// the game-detail popover so display strengths match the period the competition
+	/// was simulated against, not whichever set the user happens to have active.
+	/// </summary>
+	public static EloSet? ResolveEloSet(string? eloSetName, int year, IRepository repo)
+	{
 		var sets = repo.GetAll<EloSet>();
 
 		if (eloSetName is { } pinned)
 		{
 			var explicitSet = sets.FirstOrDefault(s => s.Name == pinned);
-			if (explicitSet is not null) { return Build(explicitSet); }
+			if (explicitSet is not null) { return explicitSet; }
 			Log.Debug("Pinned EloSet {EloSetName} isn't in the repo; trying year-matched fallback", pinned);
 		}
 
 		var yearKey = year.ToString(CultureInfo.InvariantCulture);
-		var yearSet = sets.FirstOrDefault(s => s.Name == yearKey);
-		if (yearSet is not null) { return Build(yearSet); }
-
-		Log.Debug("No EloSet named {Year}; falling back to active set", yearKey);
-		return null;
+		return sets.FirstOrDefault(s => s.Name == yearKey);
 	}
-
-	static IScoreModel Build(EloSet set) => new EloScoreModel(new EloSetTeamRegistry(set));
 }

--- a/src/FantasyFootball.UI/Components/GameViewRow.razor
+++ b/src/FantasyFootball.UI/Components/GameViewRow.razor
@@ -4,6 +4,7 @@
 @using FantasyFootball.Services
 @inject IDataService DataService
 @inject IActiveEloSet ActiveEloSet
+@inject IRepository EntityRepo
 @inject ICompetitionRepository Repo
 @inject IVenueRegistry VenueRegistry
 
@@ -97,9 +98,9 @@
       <div class="game-details-row">
         <span class="game-details-label">Elo</span>
         <span class="game-details-value game-details-value-pair">
-          <span>@ActiveEloSet.EloOf(_homeTeam)</span>
+          <span>@DisplayEloOf(_homeTeam)</span>
           <span class="game-details-sep">—</span>
-          <span>@ActiveEloSet.EloOf(_awayTeam)</span>
+          <span>@DisplayEloOf(_awayTeam)</span>
         </span>
       </div>
       <div class="game-details-row">
@@ -195,7 +196,7 @@
       var fetchAwayId = _awayTeam!.ShortName;
       _lastFetchedHomeId = fetchHomeId;
       _lastFetchedAwayId = fetchAwayId;
-      _prob = MatchProbability.Predict(ActiveEloSet.EloOf(_homeTeam), ActiveEloSet.EloOf(_awayTeam));
+      _prob = MatchProbability.Predict(DisplayEloOf(_homeTeam), DisplayEloOf(_awayTeam));
       // Force a real yield so the popover renders W/D/L + xG immediately while the O(N comps) H2H walk runs. Capture team ids into locals above — they're stable across the suspension; _homeTeam / _awayTeam could be reset by a concurrent OnParametersSetAsync.
       await Task.Yield();
       _h2h = await HeadToHeadLookup.AcrossAsync(Repo, fetchHomeId, fetchAwayId);
@@ -207,6 +208,15 @@
   }
 
   Task HandleRowClick() => OnDetailsToggle.InvokeAsync();
+
+  // Display elos for the popover + probability: match the EloSet this competition is pinned to (or year-matched), falling back to the UI-active set only when neither is available. Otherwise a historical sim's popover shows modern elos for a 1986 game (FRG → 0 if not in the active set).
+  int DisplayEloOf(Team? team)
+  {
+    if (team is null) { return 0; }
+    var set = Competition is null ? null : HistoricalScoreModelResolver.ResolveEloSet(Competition.EloSetName, Competition.Year, EntityRepo);
+    var snapshot = set?.Snapshot ?? ActiveEloSet.Current?.Snapshot;
+    return snapshot?.GetValueOrDefault(team.ShortName) ?? 0;
+  }
 
   // Floor at "<1%": "0%" reads as impossible for a heavy underdog who could still win.
   static string FormatPct(double p) => p > 0 && p < 0.005 ? "<1%" : $"{p * 100:0}%";

--- a/src/FantasyFootball.UI/ViewModels/CompetitionDetailViewModel.cs
+++ b/src/FantasyFootball.UI/ViewModels/CompetitionDetailViewModel.cs
@@ -356,6 +356,7 @@ public partial class CompetitionDetailViewModel : ObservableObject
 		{
 			DefinitionId = Competition.DefinitionId,
 			Groups = Competition.GroupAssignments.Select(g => (string[])g.Clone()).ToArray(),
+			EloSetName = Competition.EloSetName,
 		};
 		var replay = _factory.Create(spec);
 		return await _repo.SaveAsync(replay);

--- a/src/FantasyFootball.UI/ViewModels/CompetitionSetupViewModel.cs
+++ b/src/FantasyFootball.UI/ViewModels/CompetitionSetupViewModel.cs
@@ -1,8 +1,10 @@
 using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Messaging;
 using FantasyFootball.Data;
 using FantasyFootball.Models;
 using FantasyFootball.Repositories;
 using FantasyFootball.Services;
+using static FantasyFootball.Messaging;
 
 namespace FantasyFootball.UI.ViewModels;
 
@@ -76,6 +78,19 @@ public partial class CompetitionSetupViewModel : ObservableObject
 
 		AvailableEloSetNames = LoadEloSetNames();
 		SelectedEloSetName = DefaultEloSetNameFor(SelectedYear);
+
+		// Refresh when the user creates / deletes / switches an EloSet on the Teams page mid-session, so the new name shows up here without a page reload.
+		MessageBus.Register<EloSetChangedMessage>(this, (_, _) => RefreshEloSetNames());
+		MessageBus.Register<DataResetMessage>(this, (_, _) => RefreshEloSetNames());
+	}
+
+	void RefreshEloSetNames()
+	{
+		AvailableEloSetNames = LoadEloSetNames();
+		if (SelectedEloSetName is not null && !AvailableEloSetNames.Contains(SelectedEloSetName))
+		{
+			SelectedEloSetName = DefaultEloSetNameFor(SelectedYear);
+		}
 	}
 
 	public IReadOnlyList<CompetitionType> AvailableTypes { get; }

--- a/src/FantasyFootball.UI/ViewModels/CompetitionsViewModel.cs
+++ b/src/FantasyFootball.UI/ViewModels/CompetitionsViewModel.cs
@@ -253,6 +253,7 @@ public partial class CompetitionsViewModel : ObservableObject
 		{
 			DefinitionId = source.DefinitionId,
 			Groups = source.GroupAssignments.Select(g => (string[])g.Clone()).ToArray(),
+			EloSetName = source.EloSetName,
 		};
 		var replay = _factory.Create(spec);
 		var id = await _repo.SaveAsync(replay);

--- a/src/FantasyFootball.UI/wwwroot/img/flags/urs.svg
+++ b/src/FantasyFootball.UI/wwwroot/img/flags/urs.svg
@@ -8,6 +8,8 @@
    version="1.1"
    width="1200"
    height="600"
+   viewBox="0 0 400 400"
+   preserveAspectRatio="xMidYMid meet"
    id="svg10">
   <metadata
      id="metadata16">


### PR DESCRIPTION
## Summary

Two themed commits — both surfaced by post-#62 live testing.

**1. `ReplayAsync` EloSet propagation (4252750)**
Both replay paths (Detail VM + Competitions VM) built their `CustomLineupSpec` without forwarding `Competition.EloSetName`. Replaying a pinned competition silently dropped to the year-match fallback. Two-line fix.

**2. Three EloSet display issues (c60c701)**
- `GameViewRow`: popover Elo + win/draw/loss probability now resolve the competition's EloSet (pinned → year-matched) rather than reading the UI's active set. A WC 1986 popover with a custom active set was showing FRG = 0; now shows the period-correct 1985 elo.
- `CompetitionSetupViewModel`: subscribes to `EloSetChangedMessage` and `DataResetMessage` so the Setup-page picker refreshes when the user creates / deletes EloSets mid-session. AddScoped VM = stale across navigations without it.
- `urs.svg`: added `viewBox="0 0 400 400"` so the star + hammer-sickle (top-left canton of the 2:1 flag) fall inside the circle clip at small sizes. Was rendering as a solid red circle in standings rows.

New: `HistoricalScoreModelResolver.ResolveEloSet` overload returning the EloSet directly (the existing `Resolve` returns `IScoreModel?` — fine for sim, wrong shape for UI display).

## Test plan
- [x] `dotnet test` — 210 passing
- [x] Live: WC 1986 popover with custom active set shows period elos, not 0/2114
- [x] Live: Save-as a new EloSet on Teams → it appears in the Setup picker immediately
- [x] Live: URS flag in standings shows star + hammer-sickle