### PR TITLE
Rank-priority matching for third-place pool slots

### DIFF
--- a/src/FantasyFootball.Core/Services/CompetitionSimulator.cs
+++ b/src/FantasyFootball.Core/Services/CompetitionSimulator.cs
@@ -121,13 +121,16 @@ public sealed class CompetitionSimulator
 
 	/// <summary>
 	/// Batch-assign 3rd-place pool slots. Globally ranks 3rd-placers across all groups
-	/// referenced by any pool slot, takes the top N (where N = number of pool slots),
-	/// and greedily assigns each to a slot whose <see cref="ThirdPlacePool.EligibleGroups"/>
-	/// includes the team's group letter.
+	/// referenced by any pool slot, then matches teams to slots in rank order via
+	/// augmenting paths (Kuhn's algorithm): a team whose eligible slots are all taken
+	/// may relocate an earlier qualifier to one of its alternative slots. Guarantees
+	/// every slot fills whenever a valid assignment exists, and that the qualifiers
+	/// are exactly the best-ranked assignable teams — first-fit can strand a slot
+	/// whose eligible teams were all diverted into earlier slots.
 	///
-	/// Only fills NULL slots — preserves existing assignments. Subsequent calls hit
-	/// an empty <c>poolSlots</c> and return immediately, keeping the post-sim refresh
-	/// path cheap on every game tick.
+	/// No-op until every referenced group completes, then fills all pool slots in one
+	/// pass; subsequent calls collect no uninitialized pool slots and return
+	/// immediately, keeping the post-sim refresh path cheap on every game tick.
 	/// </summary>
 	static void ResolveThirdPlacePools(Competition c)
 	{
@@ -168,17 +171,44 @@ public sealed class CompetitionSimulator
 			.ThenBy(x => x.Standing.TeamId, StringComparer.Ordinal)
 			.ToList();
 
-		// Greedy best-team-first; if a team's letter isn't in any remaining slot's eligibles we skip it and try the next, until `remaining` is empty.
-		var remaining = new List<(KoGame Game, bool IsHome, ThirdPlacePool Pool)>(poolSlots);
-		foreach (var (letter, standing) in thirdPlacers)
+		// slotTeam[s] = index into thirdPlacers occupying slot s, -1 = free.
+		var slotTeam = new int[poolSlots.Count];
+		Array.Fill(slotTeam, -1);
+
+		// Kuhn's augmenting path: claim a free eligible slot, or recursively relocate its occupant to one of their alternatives.
+		bool TryPlace(int teamIdx, bool[] visited)
 		{
-			if (remaining.Count == 0) { break; }
-			var idx = remaining.FindIndex(s => s.Pool.EligibleGroups.Contains(letter));
-			if (idx < 0) { continue; }
-			var slot = remaining[idx];
-			if (slot.IsHome) { slot.Game.HomeTeamId = standing.TeamId; }
-			else { slot.Game.AwayTeamId = standing.TeamId; }
-			remaining.RemoveAt(idx);
+			for (var s = 0; s < poolSlots.Count; s++)
+			{
+				if (visited[s] || !poolSlots[s].Pool.EligibleGroups.Contains(thirdPlacers[teamIdx].Letter)) { continue; }
+				visited[s] = true;
+				if (slotTeam[s] < 0 || TryPlace(slotTeam[s], visited))
+				{
+					slotTeam[s] = teamIdx;
+					return true;
+				}
+			}
+			return false;
+		}
+
+		var filled = 0;
+		for (var t = 0; t < thirdPlacers.Count && filled < poolSlots.Count; t++)
+		{
+			if (TryPlace(t, new bool[poolSlots.Count])) { filled++; }
+		}
+
+		if (filled < poolSlots.Count)
+		{
+			throw new InvalidOperationException(
+				$"Third-place pools in '{c.DefinitionId}' leave {poolSlots.Count - filled} of {poolSlots.Count} slots unfillable.");
+		}
+
+		for (var s = 0; s < poolSlots.Count; s++)
+		{
+			var (game, isHome, _) = poolSlots[s];
+			var teamId = thirdPlacers[slotTeam[s]].Standing.TeamId;
+			if (isHome) { game.HomeTeamId = teamId; }
+			else { game.AwayTeamId = teamId; }
 		}
 	}
 }

--- a/src/FantasyFootball.Core/Services/QualifierResolver.cs
+++ b/src/FantasyFootball.Core/Services/QualifierResolver.cs
@@ -35,7 +35,9 @@ public static class QualifierResolver
 			GroupPlacement gp => ResolveGroupPlacement(c, gp),
 			GameWinner gw => ResolveGameOutcome(c, gw.GameId, winner: true),
 			GameLoser gl => ResolveGameOutcome(c, gl.GameId, winner: false),
-			ThirdPlacePool pool => ResolveThirdPlacePool(c, pool),
+			// Per-slot pool resolution can duplicate a team across overlapping pools; only the batch resolver in CompetitionSimulator is valid.
+			ThirdPlacePool => throw new InvalidOperationException(
+				$"Qualifier '{qualifierDsl}' is a third-place pool; per-slot resolution is unsupported."),
 			_ => throw new InvalidOperationException($"Unknown qualifier type {q.GetType().Name} for '{qualifierDsl}'."),
 		};
 	}
@@ -74,29 +76,5 @@ public static class QualifierResolver
 				$"Game {gameId} ended in a tie ({r.HomeScore}-{r.AwayScore}); winner/loser qualifiers only apply to games with a decisive result.");
 		}
 		return (winner == r.HomeWon) ? home : away;
-	}
-
-	static string ResolveThirdPlacePool(Competition c, ThirdPlacePool pool)
-	{
-		// Take the 3rd-place finisher from each eligible group, then
-		// rank them across the pool using the same tiebreakers we use
-		// within a group (points → GD → GF → team ID alphabetical).
-		var ranked = pool.EligibleGroups
-			.Select(g => c.Standings(g))
-			.Select(static s =>
-			{
-				if (s.Count < 3)
-				{
-					throw new InvalidOperationException(
-						$"Third-place pool needs a 3rd-place row from each eligible group, but a group has only {s.Count} teams.");
-				}
-				return s[2];
-			})
-			.OrderByDescending(s => s.Points)
-			.ThenByDescending(s => s.GoalDifference)
-			.ThenByDescending(s => s.GoalsFor)
-			.ThenBy(s => s.TeamId, StringComparer.Ordinal)
-			.ToList();
-		return ranked[0].TeamId;
 	}
 }

--- a/src/FantasyFootball.Tests/CompetitionSimulatorTests.cs
+++ b/src/FantasyFootball.Tests/CompetitionSimulatorTests.cs
@@ -121,4 +121,49 @@ public class CompetitionSimulatorTests
 			}
 		}
 	}
+
+	[Fact]
+	public void ResolveAvailableKoTeams_RankingThatStrandsFirstFit_FillsAllPoolSlotsWithTopEight()
+	{
+		// Ranking B, F, E, I, J, … strands slot B/E/F/I/J3 under first-fit: every eligible team gets diverted into an earlier slot.
+		var c = _definitions.Load("wm-2026");
+		string[] rankedLetters = ["B", "F", "E", "I", "J", "A", "C", "D", "G", "H", "K", "L"];
+		for (var i = 0; i < rankedLetters.Length; i++)
+		{
+			ScriptGroup(c, rankedLetters[i], thirdPlaceGoals: 14 - i);
+		}
+
+		CompetitionSimulator.ResolveAvailableKoTeams(c);
+
+		var poolTeams = new List<string>();
+		foreach (var ko in c.Games.OfType<KoGame>())
+		{
+			if (QualifierParser.TryParse(ko.HomeQual, out var qh) && qh is ThirdPlacePool) { poolTeams.Add(ko.HomeTeamId); }
+			if (QualifierParser.TryParse(ko.AwayQual, out var qa) && qa is ThirdPlacePool) { poolTeams.Add(ko.AwayTeamId); }
+		}
+		var topEight = rankedLetters.Take(8).Select(l => c.Standings(l)[2].TeamId);
+
+		poolTeams.Should().BeEquivalentTo(topEight, "the 8 best-ranked 3rd-placers qualify, each in exactly one R32 slot");
+	}
+
+	/// <summary>
+	/// Scripts a group deterministically: the alphabetical 1st beats everyone,
+	/// 2nd beats 3rd and 4th, 3rd beats 4th by <paramref name="thirdPlaceGoals"/> —
+	/// which controls the 3rd-placer's GD/GF and thereby its global pool rank.
+	/// </summary>
+	static void ScriptGroup(Competition c, string letter, int thirdPlaceGoals)
+	{
+		var ordered = c.GroupGames(letter)
+			.SelectMany(g => new[] { g.HomeTeamId, g.AwayTeamId })
+			.Distinct()
+			.OrderBy(t => t, StringComparer.Ordinal)
+			.ToList();
+		foreach (var game in c.GroupGames(letter))
+		{
+			var home = ordered.IndexOf(game.HomeTeamId);
+			var away = ordered.IndexOf(game.AwayTeamId);
+			var goals = Math.Min(home, away) == 2 ? thirdPlaceGoals : 1;
+			game.Result = home < away ? new Result(goals, 0, GameEnd.NORMAL) : new Result(0, goals, GameEnd.NORMAL);
+		}
+	}
 }

--- a/src/FantasyFootball.Tests/QualifierResolverTests.cs
+++ b/src/FantasyFootball.Tests/QualifierResolverTests.cs
@@ -2,16 +2,17 @@ namespace FantasyFootball.Tests;
 
 /// <summary>
 /// Qualifier-resolution sanity: group placement reads from standings,
-/// game-winner/loser walks the chronological chain, third-place pool
-/// ranks across the eligible groups. Drives off the embedded
-/// definitions plus scripted results — no full sim needed.
+/// game-winner/loser walks the chronological chain, third-place pools
+/// refuse per-slot resolution (they resolve only as a batch in
+/// CompetitionSimulator). Drives off the embedded definitions plus
+/// scripted results — no full sim needed.
 /// </summary>
 /// <remarks>
 /// TryResolve semantics pinned by the tests below: GameWinner / GameLoser
-/// fail-closed (return null when the referenced game is unplayed);
-/// GroupPlacement and ThirdPlacePool fail-open (return the
+/// and ThirdPlacePool fail-closed (return null when the referenced game is
+/// unplayed / always, respectively); GroupPlacement fails open (returns the
 /// alphabetical-default team because <c>Standings()</c> doesn't gate on
-/// completion). The fail-open paths are a known limitation — they let
+/// completion). The fail-open path is a known limitation — it lets
 /// ResolveAvailableKoTeams prematurely fill KO slots with the
 /// alphabetical first team during the group stage. A future fix should
 /// gate <c>Standings()</c> on group-stage completion; the tests below
@@ -69,51 +70,12 @@ public class QualifierResolverTests
 	}
 
 	[Fact]
-	public void Resolve_ThirdPlacePool_AllUnplayed_PicksAlphabeticallyEarlierTeam()
+	public void Resolve_ThirdPlacePool_Throws_PoolsAreBatchOnly()
 	{
-		// With nothing scripted, every group's 3rd-place row has 0 pts /
-		// GD 0 / GF 0 — the only discriminator left is team-id alphabetical
-		// (our deterministic stand-in for the FIFA tail).
 		var c = _definitions.Load("wm-2026");
-		var aThird = c.Standings("A")[2].TeamId;
-		var bThird = c.Standings("B")[2].TeamId;
-		var alphaFirst = string.CompareOrdinal(aThird, bThird) < 0 ? aThird : bThird;
-
-		QualifierResolver.Resolve(c, "A/B3").Should().Be(alphaFirst);
-	}
-
-	[Fact]
-	public void Resolve_ThirdPlacePool_PicksHigherPointsTeam()
-	{
-		// Script Group A so its alphabetically-LAST team (originally 4th)
-		// wins one game and rises to 3rd with 3 points. Group B stays
-		// unplayed. Pool should resolve to A's third (3 pts) over B's
-		// third (0 pts).
-		var c = _definitions.Load("wm-2026");
-		var teamsInA = c.GroupAssignments[0];
-		var alphaLastInA = teamsInA.OrderBy(t => t, StringComparer.Ordinal).Last();
-		var alphaFirstInA = teamsInA.OrderBy(t => t, StringComparer.Ordinal).First();
-
-		// Find the A game between those two and give the win to alphaLast.
-		var game = c.GroupGames("A").First(g =>
-			(g.HomeTeamId == alphaLastInA && g.AwayTeamId == alphaFirstInA) ||
-			(g.HomeTeamId == alphaFirstInA && g.AwayTeamId == alphaLastInA));
-		game.Result = game.HomeTeamId == alphaLastInA
-			? new Result(1, 0, GameEnd.NORMAL)
-			: new Result(0, 1, GameEnd.NORMAL);
-
-		// alphaLastInA now has 3 pts (1W). Others in A still have 0 pts
-		// (alphaFirstInA has -1 GD from that loss). So 3rd-place in A is
-		// whichever 0-pt team has alphabetically-earliest id.
-		var aStandings = c.Standings("A");
-		var aThird = aStandings[2].TeamId;
-		aStandings[2].Points.Should().Be(0, "verify scripted standings put a 0-pt team in 3rd");
-		var bThird = c.Standings("B")[2].TeamId;
-
-		// Pool comparison: A's third has 0 pts, B's third has 0 pts —
-		// alphabetical tiebreaker on the two 3rd-place candidates.
-		var expected = string.CompareOrdinal(aThird, bThird) < 0 ? aThird : bThird;
-		QualifierResolver.Resolve(c, "A/B3").Should().Be(expected);
+		Action act = () => QualifierResolver.Resolve(c, "A/B3");
+		act.Should().Throw<InvalidOperationException>()
+			.WithMessage("*third-place pool*");
 	}
 
 	[Fact]
@@ -164,11 +126,10 @@ public class QualifierResolverTests
 	}
 
 	[Fact]
-	public void TryResolve_ThirdPlacePool_BeforeAnyGroupFinishes_FailsOpen()
+	public void TryResolve_ThirdPlacePool_ReturnsNull()
 	{
-		// Same fail-open shape as GroupPlacement — returns the alphabetical best 3rd-placer (all 0-pt).
 		var c = _definitions.Load("wm-2022");
-		QualifierResolver.TryResolve(c, "A/B3").Should().NotBeNull();
+		QualifierResolver.TryResolve(c, "A/B3").Should().BeNull();
 	}
 
 	[Fact]


### PR DESCRIPTION
## Problem

`ResolveThirdPlacePools` assigned 3rd-placers to pool slots greedily: best team first, first eligible slot. Greedy first-fit is not a matching algorithm. With wm-2026's overlapping pools, a global ranking like B, F, E, I, J, … diverts every eligible team of slot `B/E/F/I/J3` into an earlier slot, stranding it — and the per-slot fallback in `ResolveKoTeams` then refilled the stranded slot from that pool's own ranking, duplicating a team across two R32 slots (#46's silent corruption, resurrected through a different path). First-fit also mis-selected the qualifying set: a higher-ranked 3rd-placer could be eliminated while a lower-ranked one advanced (in the scenario above, G's 3rd-placer advanced over A's and C's).

## Fix

- **Rank-priority maximum matching (Kuhn's augmenting paths)** in `ResolveThirdPlacePools`: teams are processed in global rank order; a team whose eligible slots are all taken may relocate an earlier qualifier to one of its alternative slots. Every slot fills whenever a valid assignment exists, and the qualifiers are exactly the best-ranked assignable teams. Brute-force verification over all C(12,8) = 495 qualifying-group combinations of the WC48 format confirms every combination admits a valid assignment (between 3 and 214 of them), so for well-formed definitions the matching never fails; an unfillable slot (malformed definition) now throws.
- **Per-slot pool resolution retired**: `QualifierResolver.Resolve` on a pool DSL now throws, `TryResolve` returns null. Resolving one overlapping pool in isolation ignores the other slots' assignments — it was exactly the duplicate-producing fallback. This also replaces the documented fail-open limitation for pools with fail-closed semantics.
- **Deterministic regression test**: scripts all 12 wm-2026 groups to force the stranding ranking and asserts the 8 pool slots hold exactly the top-8 3rd-placers. Fails under the old greedy, passes now. Full suite 207/207.

## Not in scope

FIFA's actual rule maps the qualified 8 to specific R32 slots via the 495-row table in Annex C of the [FIFA World Cup 26 Regulations](https://digitalhub.fifa.com/m/636f5c9c6f29771f/original/FWC2026_regulations_EN.pdf). This PR guarantees *a* valid assignment, not FIFA's canonical pairing; simulated R32 pairings can differ from the real bracket. Noted on #46.

Closes #46.
