### PR TITLE
Mobile usability: compact game rows, wrap-safe chips, club short names, phone-readable tables

### DIFF
--- a/src/FantasyFootball.Core/Models/Team.cs
+++ b/src/FantasyFootball.Core/Models/Team.cs
@@ -7,6 +7,9 @@ public class Team : NamedUniqueId
 	public TeamType Type { get; init; }
 	[JsonIgnore] public bool IsNationalTeam => Type is TeamType.NATIONAL_MEN or TeamType.NATIONAL_WOMEN;
 	public virtual string ShortName { get; init; }
+
+	/// <summary>Compact display name for narrow layouts ("Gladbach", "Man City"). Null for national teams, whose names compact via hyphenation instead.</summary>
+	public string? CompactName { get; init; }
 	[JsonIgnore] public virtual string Logo => IconStrings.GetTeamLogo(this);
 
 	public int CountryId { get; set; }

--- a/src/FantasyFootball.Core/Resources/Data/clubs.json
+++ b/src/FantasyFootball.Core/Resources/Data/clubs.json
@@ -5,7 +5,8 @@
       "en": "Bayer 04 Leverkusen",
       "de": "Bayer 04 Leverkusen"
     },
-    "country": "GER"
+    "country": "GER",
+    "short": "Leverkusen"
   },
   {
     "code": "BMG",
@@ -13,7 +14,8 @@
       "en": "Borussia Mönchengladbach",
       "de": "Borussia Mönchengladbach"
     },
-    "country": "GER"
+    "country": "GER",
+    "short": "Gladbach"
   },
   {
     "code": "BVB",
@@ -21,7 +23,8 @@
       "en": "Borussia Dortmund",
       "de": "Borussia Dortmund"
     },
-    "country": "GER"
+    "country": "GER",
+    "short": "Dortmund"
   },
   {
     "code": "FCA",
@@ -29,7 +32,8 @@
       "en": "FC Augsburg",
       "de": "FC Augsburg"
     },
-    "country": "GER"
+    "country": "GER",
+    "short": "Augsburg"
   },
   {
     "code": "FCB",
@@ -37,7 +41,8 @@
       "en": "FC Bayern Munich",
       "de": "FC Bayern München"
     },
-    "country": "GER"
+    "country": "GER",
+    "short": "Bayern"
   },
   {
     "code": "FCH",
@@ -45,7 +50,8 @@
       "en": "1. FC Heidenheim",
       "de": "1. FC Heidenheim"
     },
-    "country": "GER"
+    "country": "GER",
+    "short": "Heidenheim"
   },
   {
     "code": "FCU",
@@ -53,7 +59,8 @@
       "en": "1. FC Union Berlin",
       "de": "1. FC Union Berlin"
     },
-    "country": "GER"
+    "country": "GER",
+    "short": "Union Berlin"
   },
   {
     "code": "HSV",
@@ -61,7 +68,8 @@
       "en": "Hamburger SV",
       "de": "Hamburger SV"
     },
-    "country": "GER"
+    "country": "GER",
+    "short": "HSV"
   },
   {
     "code": "KOE",
@@ -69,7 +77,8 @@
       "en": "1. FC Köln",
       "de": "1. FC Köln"
     },
-    "country": "GER"
+    "country": "GER",
+    "short": "Köln"
   },
   {
     "code": "M05",
@@ -77,7 +86,8 @@
       "en": "1. FSV Mainz 05",
       "de": "1. FSV Mainz 05"
     },
-    "country": "GER"
+    "country": "GER",
+    "short": "Mainz"
   },
   {
     "code": "RBL",
@@ -85,7 +95,8 @@
       "en": "RB Leipzig",
       "de": "RB Leipzig"
     },
-    "country": "GER"
+    "country": "GER",
+    "short": "RB Leipzig"
   },
   {
     "code": "SCF",
@@ -93,7 +104,8 @@
       "en": "SC Freiburg",
       "de": "SC Freiburg"
     },
-    "country": "GER"
+    "country": "GER",
+    "short": "Freiburg"
   },
   {
     "code": "SGE",
@@ -101,7 +113,8 @@
       "en": "Eintracht Frankfurt",
       "de": "Eintracht Frankfurt"
     },
-    "country": "GER"
+    "country": "GER",
+    "short": "Frankfurt"
   },
   {
     "code": "STP",
@@ -109,7 +122,8 @@
       "en": "FC St. Pauli",
       "de": "FC St. Pauli"
     },
-    "country": "GER"
+    "country": "GER",
+    "short": "St. Pauli"
   },
   {
     "code": "SVW",
@@ -117,7 +131,8 @@
       "en": "Werder Bremen",
       "de": "Werder Bremen"
     },
-    "country": "GER"
+    "country": "GER",
+    "short": "Werder"
   },
   {
     "code": "TSG",
@@ -125,7 +140,8 @@
       "en": "TSG 1899 Hoffenheim",
       "de": "TSG 1899 Hoffenheim"
     },
-    "country": "GER"
+    "country": "GER",
+    "short": "Hoffenheim"
   },
   {
     "code": "VFB",
@@ -133,7 +149,8 @@
       "en": "VfB Stuttgart",
       "de": "VfB Stuttgart"
     },
-    "country": "GER"
+    "country": "GER",
+    "short": "Stuttgart"
   },
   {
     "code": "WOB",
@@ -141,552 +158,631 @@
       "en": "VfL Wolfsburg",
       "de": "VfL Wolfsburg"
     },
-    "country": "GER"
+    "country": "GER",
+    "short": "Wolfsburg"
   },
   {
     "code": "BOU",
     "name": {
       "en": "AFC Bournemouth"
     },
-    "country": "ENG"
+    "country": "ENG",
+    "short": "Bournemouth"
   },
   {
     "code": "ARS",
     "name": {
       "en": "Arsenal"
     },
-    "country": "ENG"
+    "country": "ENG",
+    "short": "Arsenal"
   },
   {
     "code": "AVL",
     "name": {
       "en": "Aston Villa"
     },
-    "country": "ENG"
+    "country": "ENG",
+    "short": "Aston Villa"
   },
   {
     "code": "BRE",
     "name": {
       "en": "Brentford"
     },
-    "country": "ENG"
+    "country": "ENG",
+    "short": "Brentford"
   },
   {
     "code": "BHA",
     "name": {
       "en": "Brighton & Hove Albion"
     },
-    "country": "ENG"
+    "country": "ENG",
+    "short": "Brighton"
   },
   {
     "code": "BUR",
     "name": {
       "en": "Burnley"
     },
-    "country": "ENG"
+    "country": "ENG",
+    "short": "Burnley"
   },
   {
     "code": "CHE",
     "name": {
       "en": "Chelsea"
     },
-    "country": "ENG"
+    "country": "ENG",
+    "short": "Chelsea"
   },
   {
     "code": "CRY",
     "name": {
       "en": "Crystal Palace"
     },
-    "country": "ENG"
+    "country": "ENG",
+    "short": "Crystal Palace"
   },
   {
     "code": "EVE",
     "name": {
       "en": "Everton"
     },
-    "country": "ENG"
+    "country": "ENG",
+    "short": "Everton"
   },
   {
     "code": "FUL",
     "name": {
       "en": "Fulham"
     },
-    "country": "ENG"
+    "country": "ENG",
+    "short": "Fulham"
   },
   {
     "code": "LEE",
     "name": {
       "en": "Leeds United"
     },
-    "country": "ENG"
+    "country": "ENG",
+    "short": "Leeds"
   },
   {
     "code": "LIV",
     "name": {
       "en": "Liverpool"
     },
-    "country": "ENG"
+    "country": "ENG",
+    "short": "Liverpool"
   },
   {
     "code": "MCI",
     "name": {
       "en": "Manchester City"
     },
-    "country": "ENG"
+    "country": "ENG",
+    "short": "Man City"
   },
   {
     "code": "MUN",
     "name": {
       "en": "Manchester United"
     },
-    "country": "ENG"
+    "country": "ENG",
+    "short": "Man United"
   },
   {
     "code": "NEW",
     "name": {
       "en": "Newcastle United"
     },
-    "country": "ENG"
+    "country": "ENG",
+    "short": "Newcastle"
   },
   {
     "code": "NFO",
     "name": {
       "en": "Nottingham Forest"
     },
-    "country": "ENG"
+    "country": "ENG",
+    "short": "Forest"
   },
   {
     "code": "SUN",
     "name": {
       "en": "Sunderland"
     },
-    "country": "ENG"
+    "country": "ENG",
+    "short": "Sunderland"
   },
   {
     "code": "TOT",
     "name": {
       "en": "Tottenham Hotspur"
     },
-    "country": "ENG"
+    "country": "ENG",
+    "short": "Tottenham"
   },
   {
     "code": "WHU",
     "name": {
       "en": "West Ham United"
     },
-    "country": "ENG"
+    "country": "ENG",
+    "short": "West Ham"
   },
   {
     "code": "WOL",
     "name": {
       "en": "Wolverhampton Wanderers"
     },
-    "country": "ENG"
+    "country": "ENG",
+    "short": "Wolves"
   },
   {
     "code": "MIL",
     "name": {
       "en": "AC Milan"
     },
-    "country": "ITA"
+    "country": "ITA",
+    "short": "Milan"
   },
   {
     "code": "PIS",
     "name": {
       "en": "Pisa"
     },
-    "country": "ITA"
+    "country": "ITA",
+    "short": "Pisa"
   },
   {
     "code": "FIO",
     "name": {
       "en": "Fiorentina"
     },
-    "country": "ITA"
+    "country": "ITA",
+    "short": "Fiorentina"
   },
   {
     "code": "ROM",
     "name": {
       "en": "AS Roma"
     },
-    "country": "ITA"
+    "country": "ITA",
+    "short": "Roma"
   },
   {
     "code": "ATA",
     "name": {
       "en": "Atalanta"
     },
-    "country": "ITA"
+    "country": "ITA",
+    "short": "Atalanta"
   },
   {
     "code": "BOL",
     "name": {
       "en": "Bologna"
     },
-    "country": "ITA"
+    "country": "ITA",
+    "short": "Bologna"
   },
   {
     "code": "CAG",
     "name": {
       "en": "Cagliari"
     },
-    "country": "ITA"
+    "country": "ITA",
+    "short": "Cagliari"
   },
   {
     "code": "COM",
     "name": {
       "en": "Como"
     },
-    "country": "ITA"
+    "country": "ITA",
+    "short": "Como"
   },
   {
     "code": "INT",
     "name": {
       "en": "Inter"
     },
-    "country": "ITA"
+    "country": "ITA",
+    "short": "Inter"
   },
   {
     "code": "GEN",
     "name": {
       "en": "Genoa"
     },
-    "country": "ITA"
+    "country": "ITA",
+    "short": "Genoa"
   },
   {
     "code": "VER",
     "name": {
       "en": "Hellas Verona"
     },
-    "country": "ITA"
+    "country": "ITA",
+    "short": "Verona"
   },
   {
     "code": "JUV",
     "name": {
       "en": "Juventus"
     },
-    "country": "ITA"
+    "country": "ITA",
+    "short": "Juventus"
   },
   {
     "code": "PAR",
     "name": {
       "en": "Parma"
     },
-    "country": "ITA"
+    "country": "ITA",
+    "short": "Parma"
   },
   {
     "code": "LAZ",
     "name": {
       "en": "Lazio"
     },
-    "country": "ITA"
+    "country": "ITA",
+    "short": "Lazio"
   },
   {
     "code": "NAP",
     "name": {
       "en": "Napoli"
     },
-    "country": "ITA"
+    "country": "ITA",
+    "short": "Napoli"
   },
   {
     "code": "TOR",
     "name": {
       "en": "Torino"
     },
-    "country": "ITA"
+    "country": "ITA",
+    "short": "Torino"
   },
   {
     "code": "CRE",
     "name": {
       "en": "Cremonese"
     },
-    "country": "ITA"
+    "country": "ITA",
+    "short": "Cremonese"
   },
   {
     "code": "LEC",
     "name": {
       "en": "Lecce"
     },
-    "country": "ITA"
+    "country": "ITA",
+    "short": "Lecce"
   },
   {
     "code": "SAS",
     "name": {
       "en": "Sassuolo"
     },
-    "country": "ITA"
+    "country": "ITA",
+    "short": "Sassuolo"
   },
   {
     "code": "UDI",
     "name": {
       "en": "Udinese"
     },
-    "country": "ITA"
+    "country": "ITA",
+    "short": "Udinese"
   },
   {
     "code": "ATH",
     "name": {
       "en": "Athletic Bilbao"
     },
-    "country": "ESP"
+    "country": "ESP",
+    "short": "Bilbao"
   },
   {
     "code": "OSA",
     "name": {
       "en": "Osasuna"
     },
-    "country": "ESP"
+    "country": "ESP",
+    "short": "Osasuna"
   },
   {
     "code": "ATM",
     "name": {
       "en": "Atlético Madrid"
     },
-    "country": "ESP"
+    "country": "ESP",
+    "short": "Atlético"
   },
   {
     "code": "ALA",
     "name": {
       "en": "Deportivo Alavés"
     },
-    "country": "ESP"
+    "country": "ESP",
+    "short": "Alavés"
   },
   {
     "code": "ELC",
     "name": {
       "en": "Elche"
     },
-    "country": "ESP"
+    "country": "ESP",
+    "short": "Elche"
   },
   {
     "code": "BAR",
     "name": {
       "en": "Barcelona"
     },
-    "country": "ESP"
+    "country": "ESP",
+    "short": "Barcelona"
   },
   {
     "code": "GET",
     "name": {
       "en": "Getafe"
     },
-    "country": "ESP"
+    "country": "ESP",
+    "short": "Getafe"
   },
   {
     "code": "GIR",
     "name": {
       "en": "Girona"
     },
-    "country": "ESP"
+    "country": "ESP",
+    "short": "Girona"
   },
   {
     "code": "LEV",
     "name": {
       "en": "Levante"
     },
-    "country": "ESP"
+    "country": "ESP",
+    "short": "Levante"
   },
   {
     "code": "CEL",
     "name": {
       "en": "Celta Vigo"
     },
-    "country": "ESP"
+    "country": "ESP",
+    "short": "Celta"
   },
   {
     "code": "ESY",
     "name": {
       "en": "Espanyol"
     },
-    "country": "ESP"
+    "country": "ESP",
+    "short": "Espanyol"
   },
   {
     "code": "MLL",
     "name": {
       "en": "Mallorca"
     },
-    "country": "ESP"
+    "country": "ESP",
+    "short": "Mallorca"
   },
   {
     "code": "RAY",
     "name": {
       "en": "Rayo Vallecano"
     },
-    "country": "ESP"
+    "country": "ESP",
+    "short": "Rayo Vallecano"
   },
   {
     "code": "BET",
     "name": {
       "en": "Real Betis"
     },
-    "country": "ESP"
+    "country": "ESP",
+    "short": "Betis"
   },
   {
     "code": "RMA",
     "name": {
       "en": "Real Madrid"
     },
-    "country": "ESP"
+    "country": "ESP",
+    "short": "Real Madrid"
   },
   {
     "code": "OVI",
     "name": {
       "en": "Real Oviedo"
     },
-    "country": "ESP"
+    "country": "ESP",
+    "short": "Oviedo"
   },
   {
     "code": "RSO",
     "name": {
       "en": "Real Sociedad"
     },
-    "country": "ESP"
+    "country": "ESP",
+    "short": "Sociedad"
   },
   {
     "code": "SEV",
     "name": {
       "en": "Sevilla"
     },
-    "country": "ESP"
+    "country": "ESP",
+    "short": "Sevilla"
   },
   {
     "code": "VAL",
     "name": {
       "en": "Valencia"
     },
-    "country": "ESP"
+    "country": "ESP",
+    "short": "Valencia"
   },
   {
     "code": "VIL",
     "name": {
       "en": "Villarreal"
     },
-    "country": "ESP"
+    "country": "ESP",
+    "short": "Villarreal"
   },
   {
     "code": "AJA",
     "name": {
       "en": "Auxerre"
     },
-    "country": "FRA"
+    "country": "FRA",
+    "short": "Auxerre"
   },
   {
     "code": "ASM",
     "name": {
       "en": "Monaco"
     },
-    "country": "FRA"
+    "country": "FRA",
+    "short": "Monaco"
   },
   {
     "code": "ANG",
     "name": {
       "en": "Angers"
     },
-    "country": "FRA"
+    "country": "FRA",
+    "short": "Angers"
   },
   {
     "code": "LOR",
     "name": {
       "en": "Lorient"
     },
-    "country": "FRA"
+    "country": "FRA",
+    "short": "Lorient"
   },
   {
     "code": "MET",
     "name": {
       "en": "Metz"
     },
-    "country": "FRA"
+    "country": "FRA",
+    "short": "Metz"
   },
   {
     "code": "NAN",
     "name": {
       "en": "Nantes"
     },
-    "country": "FRA"
+    "country": "FRA",
+    "short": "Nantes"
   },
   {
     "code": "LEH",
     "name": {
       "en": "Le Havre"
     },
-    "country": "FRA"
+    "country": "FRA",
+    "short": "Le Havre"
   },
   {
     "code": "LIL",
     "name": {
       "en": "Lille"
     },
-    "country": "FRA"
+    "country": "FRA",
+    "short": "Lille"
   },
   {
     "code": "NIC",
     "name": {
       "en": "Nice"
     },
-    "country": "FRA"
+    "country": "FRA",
+    "short": "Nice"
   },
   {
     "code": "LYO",
     "name": {
       "en": "Lyon"
     },
-    "country": "FRA"
+    "country": "FRA",
+    "short": "Lyon"
   },
   {
     "code": "MAR",
     "name": {
       "en": "Marseille"
     },
-    "country": "FRA"
+    "country": "FRA",
+    "short": "Marseille"
   },
   {
     "code": "PFC",
     "name": {
       "en": "Paris FC"
     },
-    "country": "FRA"
+    "country": "FRA",
+    "short": "Paris FC"
   },
   {
     "code": "PSG",
     "name": {
       "en": "Paris Saint-Germain"
     },
-    "country": "FRA"
+    "country": "FRA",
+    "short": "Paris SG"
   },
   {
     "code": "STR",
     "name": {
       "en": "Strasbourg"
     },
-    "country": "FRA"
+    "country": "FRA",
+    "short": "Strasbourg"
   },
   {
     "code": "LEN",
     "name": {
       "en": "Lens"
     },
-    "country": "FRA"
+    "country": "FRA",
+    "short": "Lens"
   },
   {
     "code": "BRS",
     "name": {
       "en": "Brest"
     },
-    "country": "FRA"
+    "country": "FRA",
+    "short": "Brest"
   },
   {
     "code": "REN",
     "name": {
       "en": "Rennes"
     },
-    "country": "FRA"
+    "country": "FRA",
+    "short": "Rennes"
   },
   {
     "code": "TOU",
     "name": {
       "en": "Toulouse"
     },
-    "country": "FRA"
+    "country": "FRA",
+    "short": "Toulouse"
   }
 ]

--- a/src/FantasyFootball.Core/Services/JsonDataService.cs
+++ b/src/FantasyFootball.Core/Services/JsonDataService.cs
@@ -70,6 +70,7 @@ public class JsonDataService : IDataService
 			Type = TeamType.CLUB_MEN,
 			ShortName = s.Code,
 			Name = s.Name.GetValueOrDefault(_languageId) ?? s.Name.GetValueOrDefault("en") ?? s.Code,
+			CompactName = s.Short,
 			Country = countryByCode3[s.Country],
 		});
 		return nationalTeams.Concat(clubTeams).ToList();
@@ -172,5 +173,6 @@ public class JsonDataService : IDataService
 		public string Code { get; set; } = "";
 		public Dictionary<string, string> Name { get; set; } = [];
 		public string Country { get; set; } = "";
+		public string? Short { get; set; }
 	}
 }

--- a/src/FantasyFootball.Tests/DisplayHyphenationTests.cs
+++ b/src/FantasyFootball.Tests/DisplayHyphenationTests.cs
@@ -1,0 +1,80 @@
+using System.Reflection;
+using System.Text.Json;
+using FantasyFootball.UI.Helpers;
+
+namespace FantasyFootball.Tests;
+
+/// <summary>
+/// Soften is a pure string transform: known long words gain exactly one soft
+/// hyphen, everything else passes through untouched. The corpus test pins the
+/// completeness invariant — every long word in the bundled team-name data has
+/// a curated break point, so no name can silently fall back to a bare
+/// mid-word cut on narrow screens.
+/// </summary>
+public class DisplayHyphenationTests
+{
+	const char Shy = (char)0x00AD;
+
+	[Fact]
+	public void Soften_KnownLongWord_InsertsSoftHyphen()
+	{
+		var softened = DisplayHyphenation.Soften("Netherlands");
+
+		softened.Should().Contain(Shy.ToString());
+		softened.Replace(Shy.ToString(), "").Should().Be("Netherlands", "the marker must be the only change");
+	}
+
+	[Fact]
+	public void Soften_MultiWordName_OnlyMappedWordChanges()
+	{
+		var softened = DisplayHyphenation.Soften("Borussia Mönchengladbach");
+
+		var words = softened.Split(' ');
+		words[0].Should().Be("Borussia");
+		words[1].Should().Contain(Shy.ToString());
+	}
+
+	[Theory]
+	[InlineData("Wales")]
+	[InlineData("HSV")]
+	[InlineData("?")]
+	public void Soften_ShortName_PassesThroughUnchanged(string name)
+	{
+		DisplayHyphenation.Soften(name).Should().Be(name);
+	}
+
+	[Fact]
+	public void Soften_UnmappedLongWord_PassesThroughUnchanged()
+	{
+		DisplayHyphenation.Soften("Qwertzuiopia").Should().Be("Qwertzuiopia");
+	}
+
+	[Fact]
+	public void Soften_EveryLongWordInBundledNames_HasAHyphenationPoint()
+	{
+		// Words with a real hyphen ("Guinea-Bissau") already carry a break point and are exempt.
+		var longWords = LoadEnglishNames()
+			.SelectMany(n => n.Split(' '))
+			.Where(w => w.Length >= 9 && !w.Contains('-'))
+			.Distinct();
+
+		var uncovered = longWords.Where(w => DisplayHyphenation.Soften(w) == w).ToList();
+
+		uncovered.Should().BeEmpty("every long team-name word needs a curated soft-hyphen point or it bare-breaks on narrow screens");
+	}
+
+	static IEnumerable<string> LoadEnglishNames()
+	{
+		var coreAssembly = typeof(Team).Assembly;
+		foreach (var resource in new[] { JsonDataService.CountriesFile, JsonDataService.ClubsFile })
+		{
+			using var stream = coreAssembly.GetManifestResourceStream(resource)
+				?? throw new InvalidOperationException($"{resource} not found in embedded resources.");
+			using var doc = JsonDocument.Parse(stream);
+			foreach (var entry in doc.RootElement.EnumerateArray())
+			{
+				yield return entry.GetProperty("name").GetProperty("en").GetString()!;
+			}
+		}
+	}
+}

--- a/src/FantasyFootball.UI/Components/GameViewRow.razor
+++ b/src/FantasyFootball.UI/Components/GameViewRow.razor
@@ -2,6 +2,7 @@
 @using FantasyFootball.Models
 @using FantasyFootball.Repositories
 @using FantasyFootball.Services
+@using FantasyFootball.UI.Helpers
 @inject IDataService DataService
 @inject IRepository EntityRepo
 @inject ICompetitionRepository Repo
@@ -41,7 +42,7 @@
     @if (_awayTeam is not null) { <FlagIcon Team="_awayTeam" Size="24" /> }
     <span class="scoreboard-team-name">@_awayLabel</span>
   </div>
-  <div class="scoreboard-action" @onclick:stopPropagation="true">
+  <div class="scoreboard-action @(ShowSim || ShowUndo ? "" : "scoreboard-action-empty")" @onclick:stopPropagation="true">
     @if (ShowSim)
     {
       <MudIconButton Icon="@Icons.Material.Filled.PlayArrow"
@@ -171,9 +172,9 @@
     _awayTeam = awayId is null ? null : DataService.AllTeams.FirstOrDefault(t => t.ShortName == awayId && t.IsNationalTeam == isNational);
     _venue = Game.VenueId is { } vid ? VenueRegistry.Get(vid) : null;
 
-    // Resolved team → Name; unresolved KO slot → "Winner of R16 #1"; otherwise raw id.
-    _homeLabel = _homeTeam?.Name ?? LabelForUnresolved(Game, isHome: true) ?? homeId ?? "?";
-    _awayLabel = _awayTeam?.Name ?? LabelForUnresolved(Game, isHome: false) ?? awayId ?? "?";
+    // Resolved team → Name; unresolved KO slot → "Winner of R16 #1"; otherwise raw id. Soften adds soft hyphens so long names wrap cleanly in narrow cells.
+    _homeLabel = DisplayHyphenation.Soften(_homeTeam?.Name ?? LabelForUnresolved(Game, isHome: true) ?? homeId ?? "?");
+    _awayLabel = DisplayHyphenation.Soften(_awayTeam?.Name ?? LabelForUnresolved(Game, isHome: false) ?? awayId ?? "?");
 
     _groupLetter = Game switch
     {

--- a/src/FantasyFootball.UI/Components/GameViewRow.razor
+++ b/src/FantasyFootball.UI/Components/GameViewRow.razor
@@ -176,7 +176,7 @@
     _awayTeam = awayId is null ? null : DataService.AllTeams.FirstOrDefault(t => t.ShortName == awayId && t.IsNationalTeam == isNational);
     _venue = Game.VenueId is { } vid ? VenueRegistry.Get(vid) : null;
 
-    // Resolved team → Name; unresolved KO slot → "Winner of R16 #1"; otherwise raw id. Soften adds soft hyphens so long names wrap cleanly in narrow cells.
+    // Resolved team → Name; unresolved KO slot → "Winner of R16 #1"; otherwise raw id.
     _homeLabel = DisplayHyphenation.Soften(_homeTeam?.Name ?? LabelForUnresolved(Game, isHome: true) ?? homeId ?? "?");
     _awayLabel = DisplayHyphenation.Soften(_awayTeam?.Name ?? LabelForUnresolved(Game, isHome: false) ?? awayId ?? "?");
     _homeCompact = _homeTeam?.CompactName is { } hc ? DisplayHyphenation.Soften(hc) : null;

--- a/src/FantasyFootball.UI/Components/GameViewRow.razor
+++ b/src/FantasyFootball.UI/Components/GameViewRow.razor
@@ -17,7 +17,8 @@
     <span class="scoreboard-group-tag-time">@Game.PlayedOn.ToString("HH:mm")</span>
   </div>
   <div class="scoreboard-team scoreboard-team-home @TeamClass(HomeIsWinner)">
-    <span class="scoreboard-team-name">@_homeLabel</span>
+    <span class="scoreboard-team-name @(_homeCompact is null ? "" : "team-name-full")">@_homeLabel</span>
+    @if (_homeCompact is not null) { <span class="scoreboard-team-name team-name-compact">@_homeCompact</span> }
     @if (_homeTeam is not null) { <FlagIcon Team="_homeTeam" Size="24" /> }
   </div>
   <div class="scoreboard-score @(HasResult ? "" : "scoreboard-pending")">
@@ -40,7 +41,8 @@
   </div>
   <div class="scoreboard-team scoreboard-team-away @TeamClass(AwayIsWinner)">
     @if (_awayTeam is not null) { <FlagIcon Team="_awayTeam" Size="24" /> }
-    <span class="scoreboard-team-name">@_awayLabel</span>
+    <span class="scoreboard-team-name @(_awayCompact is null ? "" : "team-name-full")">@_awayLabel</span>
+    @if (_awayCompact is not null) { <span class="scoreboard-team-name team-name-compact">@_awayCompact</span> }
   </div>
   <div class="scoreboard-action @(ShowSim || ShowUndo ? "" : "scoreboard-action-empty")" @onclick:stopPropagation="true">
     @if (ShowSim)
@@ -156,6 +158,8 @@
   Venue? _venue;
   string _homeLabel = "";
   string _awayLabel = "";
+  string? _homeCompact;
+  string? _awayCompact;
   string _groupLetter = "";
   bool _prevDetailsOpen;
   string? _lastFetchedHomeId;
@@ -175,6 +179,8 @@
     // Resolved team → Name; unresolved KO slot → "Winner of R16 #1"; otherwise raw id. Soften adds soft hyphens so long names wrap cleanly in narrow cells.
     _homeLabel = DisplayHyphenation.Soften(_homeTeam?.Name ?? LabelForUnresolved(Game, isHome: true) ?? homeId ?? "?");
     _awayLabel = DisplayHyphenation.Soften(_awayTeam?.Name ?? LabelForUnresolved(Game, isHome: false) ?? awayId ?? "?");
+    _homeCompact = _homeTeam?.CompactName is { } hc ? DisplayHyphenation.Soften(hc) : null;
+    _awayCompact = _awayTeam?.CompactName is { } ac ? DisplayHyphenation.Soften(ac) : null;
 
     _groupLetter = Game switch
     {

--- a/src/FantasyFootball.UI/Helpers/DisplayHyphenation.cs
+++ b/src/FantasyFootball.UI/Helpers/DisplayHyphenation.cs
@@ -1,0 +1,93 @@
+namespace FantasyFootball.UI.Helpers;
+
+/// <summary>
+/// Inserts a soft hyphen (U+00AD) at one natural break point of known long
+/// display-name words, so a narrow scoreboard cell wraps them with a visible
+/// hyphen ("Nether-lands") instead of a bare mid-word cut. Curated because
+/// browsers deliberately refuse to auto-hyphenate capitalized English words
+/// (proper-noun protection) — which covers every team name. Render-time only;
+/// stored data and lookups stay clean of the marker.
+/// </summary>
+public static class DisplayHyphenation
+{
+	const string Shy = "­";
+
+	// Every word ≥ 9 chars appearing in countries.json (en) or clubs.json names.
+	static readonly Dictionary<string, string> Words = new(StringComparer.Ordinal)
+	{
+		["Afghanistan"] = $"Afghan{Shy}istan",
+		["Barcelona"] = $"Barce{Shy}lona",
+		["Brentford"] = $"Brent{Shy}ford",
+		["Cremonese"] = $"Cremo{Shy}nese",
+		["Deportivo"] = $"Depor{Shy}tivo",
+		["Eintracht"] = $"Ein{Shy}tracht",
+		["Frankfurt"] = $"Frank{Shy}furt",
+		["Hamburger"] = $"Ham{Shy}burger",
+		["Liverpool"] = $"Liver{Shy}pool",
+		["Marseille"] = $"Mar{Shy}seille",
+		["Newcastle"] = $"New{Shy}castle",
+		["Stuttgart"] = $"Stutt{Shy}gart",
+		["Tottenham"] = $"Totten{Shy}ham",
+		["Vallecano"] = $"Valle{Shy}cano",
+		["Wanderers"] = $"Wan{Shy}derers",
+		["Wolfsburg"] = $"Wolfs{Shy}burg",
+		["Argentina"] = $"Argen{Shy}tina",
+		["Australia"] = $"Austra{Shy}lia",
+		["Azerbaijan"] = $"Azer{Shy}baijan",
+		["Bangladesh"] = $"Bangla{Shy}desh",
+		["Bournemouth"] = $"Bourne{Shy}mouth",
+		["Caledonia"] = $"Cale{Shy}donia",
+		["Czechoslovakia"] = $"Czecho{Shy}slovakia",
+		["Dominican"] = $"Domin{Shy}ican",
+		["Equatorial"] = $"Equa{Shy}torial",
+		["Fiorentina"] = $"Fioren{Shy}tina",
+		["Gibraltar"] = $"Gibral{Shy}tar",
+		["Grenadines"] = $"Grena{Shy}dines",
+		["Guatemala"] = $"Guate{Shy}mala",
+		["Heidenheim"] = $"Heiden{Shy}heim",
+		["Herzegovina"] = $"Herze{Shy}govina",
+		["Hoffenheim"] = $"Hoffen{Shy}heim",
+		["Indonesia"] = $"Indo{Shy}nesia",
+		["Kazakhstan"] = $"Kazakh{Shy}stan",
+		["Kyrgyzstan"] = $"Kyrgyz{Shy}stan",
+		["Leverkusen"] = $"Lever{Shy}kusen",
+		["Liechtenstein"] = $"Liechten{Shy}stein",
+		["Lithuania"] = $"Lithu{Shy}ania",
+		["Luxembourg"] = $"Luxem{Shy}bourg",
+		["Macedonia"] = $"Mace{Shy}donia",
+		["Madagascar"] = $"Mada{Shy}gascar",
+		["Manchester"] = $"Man{Shy}chester",
+		["Mauritania"] = $"Mauri{Shy}tania",
+		["Mauritius"] = $"Mauri{Shy}tius",
+		["Mönchengladbach"] = $"Mönchen{Shy}gladbach",
+		["Montenegro"] = $"Monte{Shy}negro",
+		["Montserrat"] = $"Mont{Shy}serrat",
+		["Mozambique"] = $"Mozam{Shy}bique",
+		["Netherlands"] = $"Nether{Shy}lands",
+		["Nicaragua"] = $"Nica{Shy}ragua",
+		["Nottingham"] = $"Notting{Shy}ham",
+		["Palestine"] = $"Pales{Shy}tine",
+		["Philippines"] = $"Philip{Shy}pines",
+		["Seychelles"] = $"Sey{Shy}chelles",
+		["Singapore"] = $"Singa{Shy}pore",
+		["Strasbourg"] = $"Stras{Shy}bourg",
+		["Sunderland"] = $"Sunder{Shy}land",
+		["Swaziland"] = $"Swazi{Shy}land",
+		["Switzerland"] = $"Switzer{Shy}land",
+		["Tajikistan"] = $"Tajik{Shy}istan",
+		["Turkmenistan"] = $"Turkmen{Shy}istan",
+		["Uzbekistan"] = $"Uzbek{Shy}istan",
+		["Venezuela"] = $"Vene{Shy}zuela",
+		["Villarreal"] = $"Villar{Shy}real",
+		["Wolverhampton"] = $"Wolver{Shy}hampton",
+		["Yugoslavia"] = $"Yugo{Shy}slavia",
+	};
+
+	/// <summary>Returns the name with soft hyphens in any known long word; everything else passes through unchanged.</summary>
+	public static string Soften(string name)
+	{
+		if (name.Length < 9) { return name; }
+
+		return string.Join(' ', name.Split(' ').Select(w => Words.GetValueOrDefault(w, w)));
+	}
+}

--- a/src/FantasyFootball.UI/Helpers/DisplayHyphenation.cs
+++ b/src/FantasyFootball.UI/Helpers/DisplayHyphenation.cs
@@ -10,7 +10,7 @@ namespace FantasyFootball.UI.Helpers;
 /// </summary>
 public static class DisplayHyphenation
 {
-	const string Shy = "­";
+	const string Shy = "\u00AD";
 
 	// Every word ≥ 9 chars appearing in countries.json (en) or clubs.json names.
 	static readonly Dictionary<string, string> Words = new(StringComparer.Ordinal)

--- a/src/FantasyFootball.UI/Pages/CompetitionDetail.razor
+++ b/src/FantasyFootball.UI/Pages/CompetitionDetail.razor
@@ -94,6 +94,7 @@ else
             var isSelected = s.Id == ViewModel.SelectedStageId;
             var isCurrent  = s.Id == ViewModel.CurrentStageId;
             var isDone     = ViewModel.IsStageDone(s);
+            @* Chip + its play-arrow share one cell so a line break can't orphan the arrow. *@
             <div class="timeline-cell">
               <MudChip T="string"
                        Variant="@(isSelected ? Variant.Filled : Variant.Outlined)"
@@ -104,18 +105,16 @@ else
                        OnClick="@(() => ViewModel.SelectedStageId = stageForChip.Id)">
                 @s.Name@(isDone ? " ✓" : "")
               </MudChip>
-            </div>
-            @if (!isDone)
-            {
-              <div class="timeline-cell">
+              @if (!isDone)
+              {
                 <MudIconButton Icon="@Icons.Material.Filled.PlayArrow"
                                Size="Size.Small"
                                Color="Color.Primary"
                                OnClick="@(async () => await ViewModel.SimulateStage(stageForChip.Id))"
                                Disabled="ViewModel.IsBusy"
                                title="@($"Simulate up through {s.Name}")" />
-              </div>
-            }
+              }
+            </div>
           }
         </div>
       </div>
@@ -138,18 +137,16 @@ else
                        OnClick="@(() => ViewModel.SelectedRoundId = roundForChip.Id)">
                 @r.Name@(isDone ? " ✓" : "")
               </MudChip>
-            </div>
-            @if (!isDone)
-            {
-              <div class="timeline-cell">
+              @if (!isDone)
+              {
                 <MudIconButton Icon="@Icons.Material.Filled.PlayArrow"
                                Size="Size.Small"
                                Color="Color.Primary"
                                OnClick="@(async () => await ViewModel.SimulateRound(roundForChip.Id))"
                                Disabled="ViewModel.IsBusy"
                                title="@($"Simulate up through {r.Name}")" />
-              </div>
-            }
+              }
+            </div>
           }
         </div>
       </div>

--- a/src/FantasyFootball.UI/Pages/CompetitionDetail.razor
+++ b/src/FantasyFootball.UI/Pages/CompetitionDetail.razor
@@ -31,26 +31,29 @@ else
     @* Title + main sim controls *@
     <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2" Wrap="Wrap.Wrap">
       <CompetitionTypeIcon Type="@ViewModel.Competition.Type" Size="36" />
-      <MudText Typo="Typo.h5" HtmlTag="h1">
+      <MudText Typo="Typo.h5" HtmlTag="h1" Class="comp-heading">
         @ViewModel.Competition.Title <span style="opacity:0.6;">#@ViewModel.Competition.Id</span>
       </MudText>
-      @if (!ViewModel.IsFinished)
-      {
-        <MudIconButton Icon="@Icons.Material.Filled.DoubleArrow"
-                       Size="Size.Small"
-                       OnClick="ViewModel.SimulateAll"
-                       Disabled="ViewModel.IsBusy"
-                       title="Simulate tournament (T)" />
-        <MudIconButton Icon="@Icons.Material.Filled.MyLocation"
-                       Size="Size.Small"
-                       OnClick="JumpToCurrent"
-                       Disabled="ViewModel.IsBusy || ViewModel.Competition.CurrentGame() is null"
-                       title="Jump to the current round" />
-      }
-      @if (ViewModel.IsBusy)
-      {
-        <MudProgressCircular Size="Size.Small" Indeterminate="true" />
-      }
+      @* Action icons share one non-wrapping cluster so a narrow header can't orphan them one per line. *@
+      <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="0">
+        @if (!ViewModel.IsFinished)
+        {
+          <MudIconButton Icon="@Icons.Material.Filled.DoubleArrow"
+                         Size="Size.Small"
+                         OnClick="ViewModel.SimulateAll"
+                         Disabled="ViewModel.IsBusy"
+                         title="Simulate tournament (T)" />
+          <MudIconButton Icon="@Icons.Material.Filled.MyLocation"
+                         Size="Size.Small"
+                         OnClick="JumpToCurrent"
+                         Disabled="ViewModel.IsBusy || ViewModel.Competition.CurrentGame() is null"
+                         title="Jump to the current round" />
+        }
+        @if (ViewModel.IsBusy)
+        {
+          <MudProgressCircular Size="Size.Small" Indeterminate="true" />
+        }
+      </MudStack>
       @if (ViewModel.IsFinished && ViewModel.WinnerTeamId is { } winnerId)
       {
         var winnerTeam = DataService.AllTeams.FirstOrDefault(t => t.ShortName == winnerId && t.IsNationalTeam == ViewModel.Competition.IsNationalTeamCompetition());

--- a/src/FantasyFootball.UI/Pages/Competitions.razor
+++ b/src/FantasyFootball.UI/Pages/Competitions.razor
@@ -5,6 +5,7 @@
 @using FantasyFootball.Models
 @using FantasyFootball.Services
 @using FantasyFootball.UI.Components
+@using FantasyFootball.UI.Helpers
 @using FantasyFootball.UI.ViewModels
 @inject CompetitionsViewModel ViewModel
 @inject IDataService DataService
@@ -170,37 +171,41 @@ else
   {
     <MudExpansionPanels Class="mt-4">
       <MudExpansionPanel Text="@($"Overall standings ({overallRecords.Count} teams)")">
-        <MudTable Items="overallRecords" Dense="true" Hover="true" T="TeamRecord">
+        @* Breakpoint.None: keep the real table on phones — the stacked label/value fallback can't be scanned as standings. *@
+        <div class="overall-standings">
+        <MudTable Items="overallRecords" Dense="true" Hover="true" Breakpoint="Breakpoint.None" T="TeamRecord">
           <HeaderContent>
             <MudTh><MudTableSortLabel SortBy="new Func<TeamRecord, object>(r => r.Team.Name)" T="TeamRecord">Team</MudTableSortLabel></MudTh>
-            <MudTh><MudTableSortLabel SortBy="new Func<TeamRecord, object>(r => r.CompetitionWins)" T="TeamRecord">Titles</MudTableSortLabel></MudTh>
-            <MudTh><MudTableSortLabel SortBy="new Func<TeamRecord, object>(r => r.MatchesPlayed)" T="TeamRecord">P</MudTableSortLabel></MudTh>
-            <MudTh><MudTableSortLabel SortBy="new Func<TeamRecord, object>(r => r.Wins)" T="TeamRecord">W</MudTableSortLabel></MudTh>
-            <MudTh><MudTableSortLabel SortBy="new Func<TeamRecord, object>(r => r.Draws)" T="TeamRecord">D</MudTableSortLabel></MudTh>
-            <MudTh><MudTableSortLabel SortBy="new Func<TeamRecord, object>(r => r.Losses)" T="TeamRecord">L</MudTableSortLabel></MudTh>
-            <MudTh><MudTableSortLabel SortBy="new Func<TeamRecord, object>(r => r.GoalsFor)" T="TeamRecord">GF</MudTableSortLabel></MudTh>
-            <MudTh><MudTableSortLabel SortBy="new Func<TeamRecord, object>(r => r.GoalsAgainst)" T="TeamRecord">GA</MudTableSortLabel></MudTh>
-            <MudTh><MudTableSortLabel SortBy="new Func<TeamRecord, object>(r => r.GoalDifference)" T="TeamRecord">GD</MudTableSortLabel></MudTh>
-            <MudTh><MudTableSortLabel SortBy="new Func<TeamRecord, object>(r => r.Points)" T="TeamRecord" InitialDirection="SortDirection.Descending">Pts</MudTableSortLabel></MudTh>
+            <MudTh Class="standings-num"><MudTableSortLabel SortBy="new Func<TeamRecord, object>(r => r.CompetitionWins)" T="TeamRecord">Titles</MudTableSortLabel></MudTh>
+            <MudTh Class="standings-num"><MudTableSortLabel SortBy="new Func<TeamRecord, object>(r => r.MatchesPlayed)" T="TeamRecord">P</MudTableSortLabel></MudTh>
+            <MudTh Class="standings-num"><MudTableSortLabel SortBy="new Func<TeamRecord, object>(r => r.Wins)" T="TeamRecord">W</MudTableSortLabel></MudTh>
+            <MudTh Class="standings-num"><MudTableSortLabel SortBy="new Func<TeamRecord, object>(r => r.Draws)" T="TeamRecord">D</MudTableSortLabel></MudTh>
+            <MudTh Class="standings-num"><MudTableSortLabel SortBy="new Func<TeamRecord, object>(r => r.Losses)" T="TeamRecord">L</MudTableSortLabel></MudTh>
+            <MudTh Class="standings-num"><MudTableSortLabel SortBy="new Func<TeamRecord, object>(r => r.GoalsFor)" T="TeamRecord">GF</MudTableSortLabel></MudTh>
+            <MudTh Class="standings-num"><MudTableSortLabel SortBy="new Func<TeamRecord, object>(r => r.GoalsAgainst)" T="TeamRecord">GA</MudTableSortLabel></MudTh>
+            <MudTh Class="standings-num"><MudTableSortLabel SortBy="new Func<TeamRecord, object>(r => r.GoalDifference)" T="TeamRecord">GD</MudTableSortLabel></MudTh>
+            <MudTh Class="standings-num"><MudTableSortLabel SortBy="new Func<TeamRecord, object>(r => r.Points)" T="TeamRecord" InitialDirection="SortDirection.Descending">Pts</MudTableSortLabel></MudTh>
           </HeaderContent>
           <RowTemplate>
             <MudTd DataLabel="Team">
               <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2">
                 <FlagIcon Team="context.Team" Size="20" />
-                <span>@context.Team.Name</span>
+                <span class="@(context.Team.CompactName is null ? "" : "team-name-full")">@DisplayHyphenation.Soften(context.Team.Name)</span>
+                @if (context.Team.CompactName is { } compact) { <span class="team-name-compact">@DisplayHyphenation.Soften(compact)</span> }
               </MudStack>
             </MudTd>
-            <MudTd DataLabel="Titles">@context.CompetitionWins</MudTd>
-            <MudTd DataLabel="P">@context.MatchesPlayed</MudTd>
-            <MudTd DataLabel="W">@context.Wins</MudTd>
-            <MudTd DataLabel="D">@context.Draws</MudTd>
-            <MudTd DataLabel="L">@context.Losses</MudTd>
-            <MudTd DataLabel="GF">@context.GoalsFor</MudTd>
-            <MudTd DataLabel="GA">@context.GoalsAgainst</MudTd>
-            <MudTd DataLabel="GD">@context.GoalDifference</MudTd>
-            <MudTd DataLabel="Pts"><strong>@context.Points</strong></MudTd>
+            <MudTd DataLabel="Titles" Class="standings-num">@context.CompetitionWins</MudTd>
+            <MudTd DataLabel="P" Class="standings-num">@context.MatchesPlayed</MudTd>
+            <MudTd DataLabel="W" Class="standings-num">@context.Wins</MudTd>
+            <MudTd DataLabel="D" Class="standings-num">@context.Draws</MudTd>
+            <MudTd DataLabel="L" Class="standings-num">@context.Losses</MudTd>
+            <MudTd DataLabel="GF" Class="standings-num">@context.GoalsFor</MudTd>
+            <MudTd DataLabel="GA" Class="standings-num">@context.GoalsAgainst</MudTd>
+            <MudTd DataLabel="GD" Class="standings-num">@context.GoalDifference</MudTd>
+            <MudTd DataLabel="Pts" Class="standings-num"><strong>@context.Points</strong></MudTd>
           </RowTemplate>
         </MudTable>
+        </div>
       </MudExpansionPanel>
     </MudExpansionPanels>
   }

--- a/src/FantasyFootball.UI/Pages/Competitions.razor
+++ b/src/FantasyFootball.UI/Pages/Competitions.razor
@@ -75,16 +75,17 @@ else if (ViewModel.FilteredCompetitions.Count == 0)
 }
 else
 {
-  @* Sortable competitions table *@
-  <MudTable Items="ViewModel.FilteredCompetitions" Dense="true" Hover="true"
+  @* Sortable competitions table. Breakpoint.None: keep one row per competition on phones — the stacked label/value fallback can't be scanned as a list. *@
+  <div class="competitions-list">
+  <MudTable Items="ViewModel.FilteredCompetitions" Dense="true" Hover="true" Breakpoint="Breakpoint.None"
             OnRowClick="@(EventCallback.Factory.Create<TableRowClickEventArgs<Competition>>(this, args => Nav.NavigateTo($"competitions/{args.Item!.Id}")))"
             T="Competition">
     <HeaderContent>
       <MudTh style="width:1%;"><MudTableSortLabel SortBy="new Func<Competition, object>(c => c.Id)" T="Competition">#</MudTableSortLabel></MudTh>
       <MudTh><MudTableSortLabel SortBy="new Func<Competition, object>(c => c.Title)" T="Competition">Title</MudTableSortLabel></MudTh>
-      <MudTh><MudTableSortLabel SortBy="new Func<Competition, object>(c => c.SimulationStart ?? DateTime.MinValue)" T="Competition" InitialDirection="SortDirection.Descending">Started</MudTableSortLabel></MudTh>
-      <MudTh><MudTableSortLabel SortBy="new Func<Competition, object>(c => StateOrder(c))" T="Competition">State</MudTableSortLabel></MudTh>
+      <MudTh Class="comp-started"><MudTableSortLabel SortBy="new Func<Competition, object>(c => c.SimulationStart ?? DateTime.MinValue)" T="Competition" InitialDirection="SortDirection.Descending">Started</MudTableSortLabel></MudTh>
       <MudTh><MudTableSortLabel SortBy="new Func<Competition, object>(c => c.WinnerTeamId() ?? string.Empty)" T="Competition">Winner</MudTableSortLabel></MudTh>
+      <MudTh><MudTableSortLabel SortBy="new Func<Competition, object>(c => StateOrder(c))" T="Competition">State</MudTableSortLabel></MudTh>
       <MudTh style="width:1%;"></MudTh>
     </HeaderContent>
     <RowTemplate>
@@ -98,10 +99,10 @@ else
       <MudTd DataLabel="Title">
         <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1">
           <CompetitionTypeIcon Type="@context.Type" Size="20" />
-          <span>@context.Title</span>
+          <span class="comp-title">@context.Title</span>
         </MudStack>
       </MudTd>
-      <MudTd DataLabel="Started">
+      <MudTd DataLabel="Started" Class="comp-started">
         @if (context.SimulationStart is { } start)
         {
           <span title="@start.ToString("yyyy-MM-dd HH:mm 'UTC'")">@start.ToLocalTime().ToString(start.ToLocalTime().Year < DateTime.Now.Year ? "MMM d, yyyy" : "MMM d, HH:mm")</span>
@@ -109,6 +110,17 @@ else
         else
         {
           <span style="opacity:0.5;">—</span>
+        }
+      </MudTd>
+      <MudTd DataLabel="Winner">
+        @if (isFinished && context.WinnerTeamId() is { } winnerId)
+        {
+          var winner = DataService.AllTeams.FirstOrDefault(t => t.ShortName == winnerId && t.IsNationalTeam == context.IsNationalTeamCompetition());
+          <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2">
+            <FlagIcon Team="winner" Code="@winnerId" Size="20" />
+            <span class="@(winner?.CompactName is null ? "" : "team-name-full")">@DisplayHyphenation.Soften(winner?.Name ?? winnerId)</span>
+            @if (winner?.CompactName is { } winnerCompact) { <span class="team-name-compact">@DisplayHyphenation.Soften(winnerCompact)</span> }
+          </MudStack>
         }
       </MudTd>
       <MudTd DataLabel="State">
@@ -123,16 +135,6 @@ else
         else
         {
           <span style="opacity:0.5;">scheduled</span>
-        }
-      </MudTd>
-      <MudTd DataLabel="Winner">
-        @if (isFinished && context.WinnerTeamId() is { } winnerId)
-        {
-          var winner = DataService.AllTeams.FirstOrDefault(t => t.ShortName == winnerId && t.IsNationalTeam == context.IsNationalTeamCompetition());
-          <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2">
-            <FlagIcon Team="winner" Code="@winnerId" Size="20" />
-            <span>@(winner?.Name ?? winnerId)</span>
-          </MudStack>
         }
       </MudTd>
       <MudTd Style="text-align:right;">
@@ -165,6 +167,7 @@ else
       </MudTd>
     </RowTemplate>
   </MudTable>
+  </div>
 
   @* Overall standings — aggregate across every finished competition in the current filter; capture once so the OverallRecords getter only walks comps × games once per render. *@
   @if (ViewModel.OverallRecords is var overallRecords && overallRecords.Count > 0)

--- a/src/FantasyFootball.Web/wwwroot/app.css
+++ b/src/FantasyFootball.Web/wwwroot/app.css
@@ -138,6 +138,7 @@ body {
    outlined variant) doesn't have to win a specificity fight with MudBlazor. */
 .timeline-cell {
   display: inline-flex;
+  align-items: center;
   background-color: var(--mud-palette-background);
   border-radius: 999px;
   position: relative;
@@ -520,9 +521,14 @@ body {
 }
 
 /* Phone-only: unbound the cards' inner scroll — nested scroll traps the drag
-   gesture inside the games card, making the standings card below hard to reach. */
+   gesture inside the games card, making the standings card below hard to reach.
+   Timeline: flatten the round indent and drop the dashed backdrop, which strikes
+   through the chips once they wrap to multiple lines. */
 @media (max-width: 599px) {
   .bounded-scroll-card { max-height: none; overflow-y: visible; }
+  .timeline-row-round { padding-left: 0.75rem; }
+  .timeline-label { min-width: 2.75rem; }
+  .timeline-chips::before { display: none; }
 }
 
 /* Day-grouping divider for the games panel when a round spans multiple PlayedOn dates. */

--- a/src/FantasyFootball.Web/wwwroot/app.css
+++ b/src/FantasyFootball.Web/wwwroot/app.css
@@ -254,6 +254,33 @@ body {
   flex-shrink: 0;
 }
 
+/* Clubs carry a compact display name ("Gladbach"); compact containers swap it in for the full name. */
+.team-name-compact {
+  display: none;
+}
+
+/* Overall-standings table responds to its own width like the scoreboard cards do. */
+.overall-standings {
+  container-type: inline-size;
+}
+
+/* Numeric columns hug their content right-aligned; the Team column absorbs the slack. */
+.overall-standings .standings-num {
+  text-align: right;
+  width: 1%;
+  white-space: nowrap;
+  font-variant-numeric: tabular-nums;
+}
+
+/* The (hover-revealed) sort icon reserves width inside each header; flip it left of the text so the header text stays flush with the right-aligned numbers below. */
+.overall-standings th.standings-num .mud-table-sort-label {
+  flex-direction: row-reverse;
+}
+
+.overall-standings .mud-table-cell {
+  padding: 6px 10px;
+}
+
 .scoreboard-score {
   font-family: 'Barlow Condensed', 'Inter', sans-serif;
   font-weight: 700;
@@ -518,6 +545,9 @@ body {
   .scoreboard-action { flex-basis: 100%; justify-content: flex-end; min-width: 0; }
   .scoreboard-action .mud-icon-button { padding: 2px; }
   .scoreboard-action-empty { display: none; }
+  .team-name-full { display: none; }
+  .team-name-compact { display: inline; }
+  .overall-standings .mud-table-cell { padding: 4px 6px; font-size: 0.8rem; }
 }
 
 /* Phone-only: unbound the cards' inner scroll — nested scroll traps the drag

--- a/src/FantasyFootball.Web/wwwroot/app.css
+++ b/src/FantasyFootball.Web/wwwroot/app.css
@@ -232,14 +232,25 @@ body {
   text-align: left;
 }
 
-/* Team name: never truncate with ellipsis. Long names (e.g. "Bosnia and
-   Herzegovina") wrap to two lines inside the cell — row grows taller for
-   that game, but the team stays fully readable. Most names fit on one line. */
+/* Team name: never truncate with ellipsis; long names wrap at word boundaries
+   ("Bosnia and Herzegovina" → two lines), a too-wide single word hyphenates at
+   a dictionary point ("Nether-lands", en dictionary via html[lang]), and
+   `break-word` is the last resort for words the dictionary can't split. All
+   need min-width: 0 — a flex item otherwise floors at the word's min-content
+   width and clips instead of wrapping. `anywhere` stays banned: it collapses
+   to one char per line. */
 .scoreboard-team-name {
   white-space: normal;
-  overflow-wrap: anywhere;
-  word-break: break-word;
+  -webkit-hyphens: auto;
+  hyphens: auto;
+  overflow-wrap: break-word;
+  min-width: 0;
   line-height: 1.2;
+}
+
+/* Flags keep their size when the name span shrinks. */
+.scoreboard-team img {
+  flex-shrink: 0;
 }
 
 .scoreboard-score {
@@ -484,6 +495,34 @@ body {
 .scoreboard-group-tag-time {
   font-size: 0.7rem;
   font-variant-numeric: tabular-nums;
+}
+
+/* Scoreboard density responds to the CARD's width, not the viewport: phones get
+   a narrow card directly, tablets get one via the two-column md grid. Compact
+   mode drops the desktop alignment reservations so two names, two flags and the
+   score fit — the always-reserved action column (5rem for buttons only 1-2 rows
+   have) is the main win. */
+.bounded-scroll-card {
+  container-type: inline-size;
+}
+
+@container (max-width: 520px) {
+  .scoreboard-row { gap: 0.4rem; padding: 0.4rem 0.5rem; flex-wrap: wrap; }
+  .scoreboard-team { gap: 0.35rem; overflow: hidden; }
+  .scoreboard-team-name { font-size: 0.875rem; }
+  .scoreboard-score { min-width: 3.25rem; font-size: 1.15rem; }
+  .scoreboard-group-tag { min-width: 2rem; }
+  /* Sim/undo buttons wrap to a line of their own, so the score and flag
+     columns stay aligned with the button-less rows. */
+  .scoreboard-action { flex-basis: 100%; justify-content: flex-end; min-width: 0; }
+  .scoreboard-action .mud-icon-button { padding: 2px; }
+  .scoreboard-action-empty { display: none; }
+}
+
+/* Phone-only: unbound the cards' inner scroll — nested scroll traps the drag
+   gesture inside the games card, making the standings card below hard to reach. */
+@media (max-width: 599px) {
+  .bounded-scroll-card { max-height: none; overflow-y: visible; }
 }
 
 /* Day-grouping divider for the games panel when a round spans multiple PlayedOn dates. */

--- a/src/FantasyFootball.Web/wwwroot/app.css
+++ b/src/FantasyFootball.Web/wwwroot/app.css
@@ -570,6 +570,7 @@ body {
   .timeline-row-round { padding-left: 0.75rem; }
   .timeline-label { min-width: 2.75rem; }
   .timeline-chips::before { display: none; }
+  .comp-heading { font-size: 1.15rem; }
 }
 
 /* Day-grouping divider for the games panel when a round spans multiple PlayedOn dates. */

--- a/src/FantasyFootball.Web/wwwroot/app.css
+++ b/src/FantasyFootball.Web/wwwroot/app.css
@@ -259,8 +259,9 @@ body {
   display: none;
 }
 
-/* Overall-standings table responds to its own width like the scoreboard cards do. */
-.overall-standings {
+/* Overall-standings table and competitions list respond to their own width like the scoreboard cards do. */
+.overall-standings,
+.competitions-list {
   container-type: inline-size;
 }
 
@@ -277,7 +278,8 @@ body {
   flex-direction: row-reverse;
 }
 
-.overall-standings .mud-table-cell {
+/* Specificity must match MudBlazor's own `.mud-table-dense * .mud-table-row .mud-table-cell` — app.css loads later, so equal specificity wins. */
+.overall-standings .mud-table-row .mud-table-cell {
   padding: 6px 10px;
 }
 
@@ -547,7 +549,16 @@ body {
   .scoreboard-action-empty { display: none; }
   .team-name-full { display: none; }
   .team-name-compact { display: inline; }
-  .overall-standings .mud-table-cell { padding: 4px 6px; font-size: 0.8rem; }
+  .overall-standings .mud-table-row .mud-table-cell,
+  .competitions-list .mud-table-row .mud-table-cell { padding: 4px 6px; font-size: 0.8rem; }
+  /* Hidden-but-space-reserving sort icons cost 24px per header; without them the tables fit and stop crushing the Team column. */
+  .overall-standings .mud-table-sort-label .mud-svg-icon,
+  .competitions-list .mud-table-sort-label .mud-svg-icon { display: none; }
+  /* One line per competition: drop the Started column, ellipsize long titles, tighten chips and buttons. */
+  .competitions-list .comp-started { display: none; }
+  .competitions-list .comp-title { white-space: nowrap; overflow: hidden; text-overflow: ellipsis; max-width: 9rem; }
+  .competitions-list .mud-chip { margin: 0; }
+  .competitions-list .mud-icon-button { padding: 2px; }
 }
 
 /* Phone-only: unbound the cards' inner scroll — nested scroll traps the drag

--- a/tools/fetch-leagues.ps1
+++ b/tools/fetch-leagues.ps1
@@ -33,7 +33,7 @@ $UA           = 'FantasyFootball-LeagueFetch/0.1 (https://github.com/StepKie/Fan
 $ClubEloName  = 'Clubs 2025-2026'
 $ClubEloDate  = '2025-08-15'   # one ClubElo snapshot near the 2025-26 season start, covering every league
 
-# Roster columns, pipe-delimited:  CODE | openfootball name | clubelo name | crest filename (no .png) | display name (en)
+# Roster columns, pipe-delimited:  CODE | openfootball name | clubelo name | crest filename (no .png) | display name (en) | short display name (optional; defaults to the clubelo name)
 # Codes are unique among clubs; collisions with national-team codes are fine (records aggregate per (isNational, code)).
 # Avoid Windows reserved device names as codes (CON, PRN, AUX, NUL, COM1-9, LPT1-9) — the lowercase {code}.png crest is unwritable. (AJ Auxerre is AJA, not AUX.)
 $Leagues = @(
@@ -57,9 +57,9 @@ FCA|FC Augsburg|Augsburg|FC Augsburg|FC Augsburg
 SVW|SV Werder Bremen|Werder|SV Werder Bremen|Werder Bremen
 TSG|TSG 1899 Hoffenheim|Hoffenheim|TSG 1899 Hoffenheim|TSG 1899 Hoffenheim
 FCH|1. FC Heidenheim 1846|Heidenheim|1.FC Heidenheim 1846|1. FC Heidenheim
-STP|FC St. Pauli 1910|St Pauli|FC St. Pauli|FC St. Pauli
-HSV|Hamburger SV|Hamburg|Hamburger SV|Hamburger SV
-KOE|1. FC Köln|Koeln|1.FC Köln|1. FC Köln
+STP|FC St. Pauli 1910|St Pauli|FC St. Pauli|FC St. Pauli|St. Pauli
+HSV|Hamburger SV|Hamburg|Hamburger SV|Hamburger SV|HSV
+KOE|1. FC Köln|Koeln|1.FC Köln|1. FC Köln|Köln
 '@
     },
     @{
@@ -123,8 +123,8 @@ UDI|Udinese Calcio|Udinese|Udinese Calcio|Udinese
         Roster = @'
 ATH|Athletic Club|Bilbao|Athletic Bilbao|Athletic Bilbao
 OSA|CA Osasuna|Osasuna|CA Osasuna|Osasuna
-ATM|Club Atlético de Madrid|Atletico|Atlético de Madrid|Atlético Madrid
-ALA|Deportivo Alavés|Alaves|Deportivo Alavés|Deportivo Alavés
+ATM|Club Atlético de Madrid|Atletico|Atlético de Madrid|Atlético Madrid|Atlético
+ALA|Deportivo Alavés|Alaves|Deportivo Alavés|Deportivo Alavés|Alavés
 ELC|Elche CF|Elche|Elche CF|Elche
 BAR|FC Barcelona|Barcelona|FC Barcelona|Barcelona
 GET|Getafe CF|Getafe|Getafe CF|Getafe
@@ -199,7 +199,7 @@ function ConvertTo-Roster {
         $line = $line.Trim()
         if ([string]::IsNullOrWhiteSpace($line)) { continue }
         $p = $line -split '\|'
-        $map[$p[0]] = @{ Code = $p[0]; OpenFootball = $p[1]; Elo = $p[2]; Crest = $p[3]; En = $p[4] }
+        $map[$p[0]] = @{ Code = $p[0]; OpenFootball = $p[1]; Elo = $p[2]; Crest = $p[3]; En = $p[4]; Short = ($p.Length -ge 6 -and $p[5]) ? $p[5] : $p[2] }
     }
     return $map
 }
@@ -300,7 +300,7 @@ foreach ($lg in $Leagues) {
     }
     Write-Host "  -> crests: $okCrests/$($roster.Count)" -ForegroundColor Green
 
-    foreach ($r in $roster.Values) { $newClubs[$r.Code] = @{ En = $r.En; Country = $lg.Country } }
+    foreach ($r in $roster.Values) { $newClubs[$r.Code] = @{ En = $r.En; Country = $lg.Country; Short = $r.Short } }
 }
 
 # --- Combined club EloSet: one ClubElo snapshot covering every league's clubs ---
@@ -340,7 +340,8 @@ if ($toAdd) {
     "name": {
       "en": "$en"
     },
-    "country": "$($_.Value.Country)"
+    "country": "$($_.Value.Country)",
+    "short": "$($_.Value.Short)"
   }
 "@
     }


### PR DESCRIPTION
First batch for #70 — usability on small phone screens. Verified at 360×740 / 375×667 / 390×844 emulation plus tablet (two-column) widths.

## Game rows (scoreboard)

- Compact mode keys on the **card's** width via `@container` query — phones get a narrow card directly, tablets via the two-column `md` grid. Tighter gaps/min-widths; the empty action column collapses (it reserved 5rem on every row for buttons only 1–2 rows have); sim/undo buttons wrap to a line of their own so score/flag columns stay aligned across rows.
- Team names: word-boundary wrap first, then a curated soft-hyphen break ("Nether-lands"). Browsers deliberately refuse to auto-hyphenate capitalized English words (proper-noun protection), so `DisplayHyphenation` injects U+00AD at render time from a word map; `overflow-wrap: break-word` stays as last resort. The old `overflow-wrap: anywhere` — the cause of the one-character-per-line name columns — is gone.
- Clubs additionally carry a compact display name ("Gladbach", "Man City") sourced from the ClubElo column already in the fetch-leagues rosters, with hand overrides where ClubElo strips diacritics or abbreviates oddly (Köln, St. Pauli, HSV, Atlético, Alavés). `clubs.json` gains `"short"`, `Team` gains `CompactName`; both name spans render and the container query picks one — no resize logic in C#.

## Timeline chips

- Each chip and its play-arrow are fused into one cell, so a line break can never orphan an arrow.
- Phone: round-row indent flattened; dashed backdrop dropped (a single mid-height pseudo-element can't follow a wrapped chip flow).

## Tables

- Competitions list and overall standings keep the real table layout on phones (`Breakpoint.None`) — MudTable's stacked label/value fallback can't be scanned as a list.
- Numeric columns right-aligned and content-hugging (tabular numerals). Sort icons hide at compact width (tap still sorts): their invisible 24px-per-header reservation overflowed the table, and an overflowing table collapses the Team column to its soft-hyphen min-content — the mysterious "Netherlands wraps despite ample space".
- Competitions list: one row each — Started column hidden at compact width, long titles ellipsized, Winner moved before State.
- Table padding overrides now match MudBlazor's `.mud-table-dense * .mud-table-row .mud-table-cell` specificity; the earlier two-class selectors silently lost the cascade.

## Scroll + header

- Phone: cards lose their bounded inner scroll — nested scrolling trapped the drag gesture inside the games card, making the standings card below it hard to reach.
- Detail header: action icons share one non-wrapping cluster; the heading drops to 1.15rem below 600px.

## Notes

- `Team.CompactName` comes from seed data — existing localStorage needs a data reset to pick it up (consistent with the no-legacy-data policy: reset and re-sim).
- Tests: 207/207 locally (develop-targeted PRs run auto-review only, no CI build).

Part of #70 — the umbrella issue stays open for the next batch.
