### PR TITLE
Release 0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## [0.7.0](https://github.com/StepKie/FantasyFootball/releases/tag/0.7.0) — 2026-06-08
+
+### New Features
+
+- **Phone-friendly layout** ([PR #71](https://github.com/StepKie/FantasyFootball/pull/71)) — game cards, standings, the competitions list and detail headers all reflow for narrow screens. Game rows stay on one line; long club names like "Borussia Mönchengladbach" use a compact form ("Gladbach") on small cards and break at curated points when the full name still has to fit. Standings tables stay real tables on phones instead of collapsing to stacked label/value rows, and the competitions list shows one row per competition.
+
+### Bugfixes
+
+- **Third-place qualifiers no longer duplicate across knockout slots** ([PR #69](https://github.com/StepKie/FantasyFootball/pull/69)) — in WC48-style formats with overlapping third-place pools, the previous resolver could assign the same team to two Round-of-32 slots and silently corrupt the bracket. Slots now fill via a true matching: every slot gets a team whenever a valid assignment exists, and the qualifiers are exactly the best-ranked teams. An unfillable slot fails loudly instead of silently.
+
 ## [0.6.0](https://github.com/StepKie/FantasyFootball/releases/tag/0.6.0) — 2026-06-02
 
 ### New Features

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,7 +10,7 @@
 
       Bump this on each release; do not put <Version> in individual .csproj files.
     -->
-    <Version>0.6.0</Version>
+    <Version>0.7.0</Version>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
Release-prep PR: version bump to `0.7.0` and changelog entry for the merges since `0.6.0`.

## Changes since 0.6.0

- **#71** — Mobile usability: compact game rows, wrap-safe chips, club short names, phone-readable tables
- **#69** — Rank-priority matching for third-place pool slots (closes #46)

The internal review-prompt tweak in `c7f3690` is not user-facing and isn't in the changelog.

## After merge

`git checkout main && git merge --no-ff develop && git push origin main`, tag `0.7.0` on the merge commit, push tag, then `gh release create 0.7.0` with the new CHANGELOG section as notes.