### PR TITLE
Round-of-32 resolution fixes + scroll polish

### DIFF
--- a/src/FantasyFootball.Core/Services/CompetitionSimulator.cs
+++ b/src/FantasyFootball.Core/Services/CompetitionSimulator.cs
@@ -83,31 +83,28 @@ public sealed class CompetitionSimulator
 	}
 
 	/// <summary>
-	/// Best-effort pass over every KO game. Non-pool qualifiers
-	/// (<see cref="GroupPlacement"/>, <see cref="GameWinner"/>,
-	/// <see cref="GameLoser"/>) resolve per-slot via <see cref="QualifierResolver"/>.
+	/// Best-effort pass over every KO game. For each <b>unplayed</b> KO game, non-pool
+	/// qualifiers (<see cref="GroupPlacement"/>, <see cref="GameWinner"/>,
+	/// <see cref="GameLoser"/>) re-resolve per-slot via <see cref="QualifierResolver"/>
+	/// — the slot tracks the current standings/upstream-game outcome until that source
+	/// is final, so R32 shows a live preview during group stage instead of locking to
+	/// whoever was leading after game 1. Played KO games stay frozen.
 	/// 3rd-place pools resolve as a batch via <see cref="ResolveThirdPlacePools"/>
 	/// — a single team per slot, no duplicates across overlapping pools.
 	/// Silent on slots whose prerequisites aren't ready.
 	/// </summary>
 	public static void ResolveAvailableKoTeams(Competition c)
 	{
-		// Hot-path skip: all KO slots already assigned → nothing to do.
-		var anyUnresolved = false;
 		foreach (var ko in c.Games.OfType<KoGame>())
 		{
-			if (!ko.IsFullyInitialized) { anyUnresolved = true; break; }
-		}
-		if (!anyUnresolved) { return; }
-
-		foreach (var ko in c.Games.OfType<KoGame>())
-		{
-			if (!ko.IsHomeInitialized && IsNonPool(ko.HomeQual))
+			// Played games are frozen — changing their teams now would orphan the recorded Result.
+			if (ko.Result is not null) { continue; }
+			if (IsNonPool(ko.HomeQual))
 			{
 				var resolved = QualifierResolver.TryResolve(c, ko.HomeQual);
 				if (resolved is not null) { ko.HomeTeamId = resolved; }
 			}
-			if (!ko.IsAwayInitialized && IsNonPool(ko.AwayQual))
+			if (IsNonPool(ko.AwayQual))
 			{
 				var resolved = QualifierResolver.TryResolve(c, ko.AwayQual);
 				if (resolved is not null) { ko.AwayTeamId = resolved; }

--- a/src/FantasyFootball.Tests/CompetitionSimulatorTests.cs
+++ b/src/FantasyFootball.Tests/CompetitionSimulatorTests.cs
@@ -123,6 +123,24 @@ public class CompetitionSimulatorTests
 	}
 
 	[Fact]
+	public void Wm2026_IncrementalPlay_DoesNotLockKoSlotsWithMidGroupStandings()
+	{
+		// UI flow: every game triggers RefreshAfterSim → ResolveAvailableKoTeams, which must not lock GroupPlacement slots to partial standings (collides with the pool resolver later).
+		var c = _definitions.Load("wm-2026");
+		foreach (var game in c.Games.OrderBy(g => g.PlayedOn).ToList())
+		{
+			_simulator.SimulateGame(c, game, _scoreModel);
+			CompetitionSimulator.ResolveAvailableKoTeams(c);
+		}
+
+		var r32Teams = c.RoundGames("r32")
+			.OfType<KoGame>()
+			.SelectMany(g => new[] { g.HomeTeamId, g.AwayTeamId })
+			.ToList();
+		r32Teams.Should().OnlyHaveUniqueItems("R32 must have each team in at most one slot, even under per-game resolve");
+	}
+
+	[Fact]
 	public void ResolveAvailableKoTeams_RankingThatStrandsFirstFit_FillsAllPoolSlotsWithTopEight()
 	{
 		// Ranking B, F, E, I, J, … strands slot B/E/F/I/J3 under first-fit: every eligible team gets diverted into an earlier slot.

--- a/src/FantasyFootball.UI/Pages/CompetitionDetail.razor
+++ b/src/FantasyFootball.UI/Pages/CompetitionDetail.razor
@@ -347,9 +347,11 @@ else
       if (ViewModel.RecentlyFinishedGameId is { } rfid && rfid != _lastScrolledJustFinishedId)
       {
         _lastScrolledJustFinishedId = rfid;
-        // Bump so the post-pulse render doesn't re-scroll to current and yank the result out of view.
-        _lastScrolledCurrentGameId = ViewModel.Competition?.CurrentGame()?.Id;
-        await JS.InvokeVoidAsync("ffScroll.toElement", "just-finished-game");
+        // Bump to where SelectedRoundId is *going* to be after RefreshAfterSim — CurrentGame.RoundId — not where it is right now; the post-pulse render lands after that update.
+        var nextCurrent = ViewModel.Competition?.CurrentGame();
+        _lastScrolledCurrentGameId = nextCurrent?.Id;
+        _lastScrolledRoundId = nextCurrent?.RoundId ?? ViewModel.SelectedRoundId;
+        await JS.InvokeVoidAsync("ffScroll.toElement", "just-finished-game", "center");
         return;
       }
 
@@ -357,7 +359,7 @@ else
       if (currentGame is { Id: var cgid } && cgid != _lastScrolledCurrentGameId)
       {
         _lastScrolledCurrentGameId = cgid;
-        await JS.InvokeVoidAsync("ffScroll.toElement", "current-game");
+        await JS.InvokeVoidAsync("ffScroll.toElement", "current-game", "center");
         return;
       }
 

--- a/src/FantasyFootball.UI/ViewModels/CompetitionDetailViewModel.cs
+++ b/src/FantasyFootball.UI/ViewModels/CompetitionDetailViewModel.cs
@@ -130,6 +130,9 @@ public partial class CompetitionDetailViewModel : ObservableObject
 		_scoreModel = HistoricalScoreModelResolver.Resolve(Competition, _entityRepo)
 			?? throw new InvalidOperationException($"Cannot resolve EloSet '{Competition.EloSetName}' for competition '{Competition.DefinitionId}'.");
 
+		// SimulateGame saves before RefreshAfterSim — a comp saved on the last group game lands here with unresolved R32 slots.
+		CompetitionSimulator.ResolveAvailableKoTeams(Competition);
+
 		var currentGame = Competition.CurrentGame();
 		var currentRoundId = currentGame?.RoundId
 			?? Competition.Rounds.OrderByDescending(r => r.Order).FirstOrDefault()?.Id;

--- a/src/FantasyFootball.Web/wwwroot/js/scroll.js
+++ b/src/FantasyFootball.Web/wwwroot/js/scroll.js
@@ -1,8 +1,8 @@
 // Tiny scroll helper for the variant-B whole-stage games panel.
-// Round chips invoke this to jump to a round's <section id="round-N"> anchor.
+// 'start' aligns the element top with the viewport top (round headers); 'center' puts it mid-viewport so context shows above + below (just-finished / current game).
 window.ffScroll = {
-    toElement: (id) => {
+    toElement: (id, block) => {
         const el = document.getElementById(id);
-        if (el) { el.scrollIntoView({ behavior: 'smooth', block: 'start' }); }
+        if (el) { el.scrollIntoView({ behavior: 'smooth', block: block || 'start' }); }
     }
 };


### PR DESCRIPTION
## Summary

- **Fix R32 duplicate teams** (a team appearing in two R32 slots, the symptom reported on 0.7.0 — Japan twice). `ResolveAvailableKoTeams` was locking non-pool slots on the first successful resolve via `!IsHomeInitialized`. During incremental UI play (every game triggers `RefreshAfterSim`), R32 GroupPlacement slots like `A2`/`B2`/`F2` got locked to partial-standings team IDs after game 1 and never refreshed — then the pool resolver later assigned the same team's actual 3rd-place finisher into a pool slot. Drop the guard so non-pool slots re-resolve every pass; freeze played games via `Result != null`. R32 now shows a live predicted matchup during group play, updating as standings shift.
- **Resolve KO teams on load.** `SimulateGame` saves *before* `RefreshAfterSim` runs, so a comp persisted after the last group game lands with unresolved R32 (placeholder text on reopen). Call `ResolveAvailableKoTeams` in `LoadAsync` — idempotent, cheap.
- **Center just-finished game in viewport on play.** `scrollIntoView({block:'start'})` was sliding the row behind the sticky MudAppBar on phone. Switch to `block:'center'` for game rows; round-section header scroll stays `'start'`.
- **Stop the post-pulse round-jump.** End of a round: the just-finished render fired before `RefreshAfterSim` updated `SelectedRoundId`, so the `_lastScrolledRoundId` bump captured the stale value and the next render's round-scroll branch yanked the page. Bump to where `SelectedRoundId` is *going* (the new `CurrentGame.RoundId`) instead of where it is.

## Test plan

- [x] `dotnet test` — 215/215 passing (new regression test: `Wm2026_IncrementalPlay_DoesNotLockKoSlotsWithMidGroupStandings`).
- [x] Manually: fresh WM-2026, simulate group stage round-by-round, confirm R32 has no team in two slots.
- [x] Manually: open an existing competition saved at end of group stage — R32 shows resolved team names, not placeholders.
- [x] Manually on phone: play a game, just-finished row lands mid-viewport with context above and below.
- [x] Manually: play last game of a round, post-pulse render does not yank to the next round.

## Caveats

Existing competitions in users' LocalStorage that were corrupted by the pre-fix algorithm (R32 slots literally containing duplicate team IDs) still need to be deleted + re-simulated — `ResolveThirdPlacePools` only fills uninitialized pool slots, it doesn't heal wrong-team-already-baked-in state.