### PR TITLE
Game-details popover perf + bottom-center mobile play FAB

### DIFF
--- a/src/FantasyFootball.Core/Services/HeadToHeadLookup.cs
+++ b/src/FantasyFootball.Core/Services/HeadToHeadLookup.cs
@@ -4,10 +4,10 @@ using FantasyFootball.Repositories;
 namespace FantasyFootball.Services;
 
 /// <summary>
-/// Cross-competition head-to-head tally for the Competition store.
-/// Walks every stored Competition's finished games once. Matches teams
-/// by their ShortName id — works regardless of whether games are KO (with
-/// resolved <c>HomeTeamId</c> / <c>AwayTeamId</c>) or group (with init-only ids).
+/// Cross-competition head-to-head tally for the Competition store. Walks every
+/// stored competition's finished games once, matching teams by their ShortName id —
+/// works for both KO (resolved <c>HomeTeamId</c> / <c>AwayTeamId</c>) and group
+/// (init-only id) games. The repo caches the bulk load, so repeat lookups are cheap.
 /// </summary>
 public static class HeadToHeadLookup
 {

--- a/src/FantasyFootball.UI/Components/GameViewRow.razor
+++ b/src/FantasyFootball.UI/Components/GameViewRow.razor
@@ -162,6 +162,9 @@
   string? _awayCompact;
   string _groupLetter = "";
   bool _prevDetailsOpen;
+  int _resolvedGameId = -1;
+  string? _resolvedHomeId;
+  string? _resolvedAwayId;
   string? _lastFetchedHomeId;
   string? _lastFetchedAwayId;
   MatchProbability.Prediction _prob;
@@ -172,9 +175,16 @@
     var homeId = Game.HomeTeamId;
     var awayId = Game.AwayTeamId;
     var isNational = Competition?.IsNationalTeamCompetition() ?? true;
-    _homeTeam = homeId is null ? null : DataService.AllTeams.FirstOrDefault(t => t.ShortName == homeId && t.IsNationalTeam == isNational);
-    _awayTeam = awayId is null ? null : DataService.AllTeams.FirstOrDefault(t => t.ShortName == awayId && t.IsNationalTeam == isNational);
-    _venue = Game.VenueId is { } vid ? VenueRegistry.Get(vid) : null;
+    // Team lookups scan AllTeams (O(teams)); they only change with the game's teams, so skip them when unchanged — else a popover toggle re-scans every row in a 300+-game league.
+    if (homeId != _resolvedHomeId || awayId != _resolvedAwayId || Game.Id != _resolvedGameId)
+    {
+      _resolvedHomeId = homeId;
+      _resolvedAwayId = awayId;
+      _resolvedGameId = Game.Id;
+      _homeTeam = homeId is null ? null : DataService.AllTeams.FirstOrDefault(t => t.ShortName == homeId && t.IsNationalTeam == isNational);
+      _awayTeam = awayId is null ? null : DataService.AllTeams.FirstOrDefault(t => t.ShortName == awayId && t.IsNationalTeam == isNational);
+      _venue = Game.VenueId is { } vid ? VenueRegistry.Get(vid) : null;
+    }
 
     // Resolved team → Name; unresolved KO slot → "Winner of R16 #1"; otherwise raw id.
     _homeLabel = DisplayHyphenation.Soften(_homeTeam?.Name ?? LabelForUnresolved(Game, isHome: true) ?? homeId ?? "?");

--- a/src/FantasyFootball.UI/Components/PrimaryActionFab.razor
+++ b/src/FantasyFootball.UI/Components/PrimaryActionFab.razor
@@ -1,0 +1,21 @@
+@* Primary thumb-zone action — fixed bottom-center so it's reachable one-handed on phones. De-emphasized on desktop, where Space / inline controls drive play. *@
+<div class="primary-action-fab @(MobileOnly ? "primary-action-fab-mobile-only" : "")">
+  <MudFab Color="Color.Primary"
+          Size="Size.Large"
+          StartIcon="@Icon"
+          Href="@Href"
+          OnClick="OnClick"
+          Disabled="Disabled"
+          title="@Title" />
+</div>
+
+@code {
+  [Parameter] public string Icon { get; set; } = Icons.Material.Filled.PlayArrow;
+  [Parameter] public string? Href { get; set; }
+  [Parameter] public EventCallback OnClick { get; set; }
+  [Parameter] public string? Title { get; set; }
+  [Parameter] public bool Disabled { get; set; }
+
+  /// <summary>Show only on phones — for actions that already have a keyboard / inline equivalent on desktop (e.g. Space to play).</summary>
+  [Parameter] public bool MobileOnly { get; set; }
+}

--- a/src/FantasyFootball.UI/Pages/CompetitionDetail.razor
+++ b/src/FantasyFootball.UI/Pages/CompetitionDetail.razor
@@ -73,16 +73,18 @@ else
 
     @if (ViewModel.IsFinished)
     {
-      @* Big circular Replay button — mirrors the Play FAB on /competitions and /competitions/setup
-         so the click-through visually flows. Lands on the new (scheduled) competition's detail page. *@
-      <MudStack AlignItems="AlignItems.Center" Class="my-2">
-        <MudFab Color="Color.Primary"
-                Size="Size.Large"
-                StartIcon="@Icons.Material.Filled.Refresh"
-                OnClick="HandleReplay"
-                Disabled="ViewModel.IsBusy"
-                title="Replay (clone this competition with the same teams)" />
-      </MudStack>
+      <PrimaryActionFab Icon="@Icons.Material.Filled.Refresh"
+                        OnClick="HandleReplay"
+                        Disabled="ViewModel.IsBusy"
+                        Title="Replay (clone this competition with the same teams)" />
+    }
+    else
+    {
+      @* Play-next: a phone-only thumb affordance — desktop uses Space / the inline play buttons. *@
+      <PrimaryActionFab OnClick="ViewModel.SimulateGame"
+                        Disabled="ViewModel.IsBusy"
+                        Title="Play the next game"
+                        MobileOnly="true" />
     }
 
     @* Hierarchical timeline pickers: Stage chips on top, Round chips below.
@@ -343,6 +345,9 @@ else
         await JS.InvokeVoidAsync("ffKeyboard.registerDocumentHandler", _selfRef);
         await JS.InvokeVoidAsync("ffPopover.registerOutsideClickHandler", _selfRef);
       }
+
+      // Skip auto-scroll mid-sim: the games have advanced but the just-finished pulse isn't set yet, so scrolling now lands on the next game and then again on the result — the double-jump.
+      if (ViewModel.IsBusy) { return; }
 
       if (ViewModel.RecentlyFinishedGameId is { } rfid && rfid != _lastScrolledJustFinishedId)
       {

--- a/src/FantasyFootball.UI/Pages/CompetitionSetup.razor
+++ b/src/FantasyFootball.UI/Pages/CompetitionSetup.razor
@@ -19,13 +19,15 @@
 
 <MudStack Spacing="3">
 
-  @* Top row: 3 equal-height columns.
-     Left  = pickers above, lineup-mode buttons at bottom (so the column matches the right column's height).
-     Center = round Play FAB, vertically + horizontally centered (mirrors the FAB on /competitions).
-     Right = bulk panel. *@
+  <PrimaryActionFab OnClick="HandleCreateSingle"
+                    Disabled="@(ViewModel.IsRunning || ViewModel.Groups.Count == 0)"
+                    Title="Start the competition for interactive play" />
+
+  @* Two equal-height columns: left = pickers + lineup-mode buttons, right = bulk panel.
+     The single-competition Play action is the shared bottom-center FAB above. *@
   <MudGrid Spacing="3" AlignItems="AlignItems.Stretch">
 
-    <MudItem xs="12" md="4">
+    <MudItem xs="12" md="6">
       <MudStack Spacing="2" Style="height:100%;">
         <MudSelect T="CompetitionType"
                    Label="Competition"
@@ -82,18 +84,7 @@
       </MudStack>
     </MudItem>
 
-    <MudItem xs="12" md="4">
-      <div style="display:flex; align-items:center; justify-content:center; height:100%; min-height:12rem;">
-        <MudFab Color="Color.Primary"
-                Size="Size.Large"
-                StartIcon="@Icons.Material.Filled.PlayArrow"
-                OnClick="HandleCreateSingle"
-                Disabled="@(ViewModel.IsRunning || ViewModel.Groups.Count == 0)"
-                title="Start the competition for interactive play" />
-      </div>
-    </MudItem>
-
-    <MudItem xs="12" md="4">
+    <MudItem xs="12" md="6">
       <MudPaper Class="pa-3" Outlined="true" Style="background-color: transparent; height:100%;">
         <MudStack Spacing="1" Style="height:100%;">
           <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1">

--- a/src/FantasyFootball.UI/Pages/Competitions.razor
+++ b/src/FantasyFootball.UI/Pages/Competitions.razor
@@ -16,13 +16,7 @@
 
 <MudText Typo="Typo.h5" HtmlTag="h1" Class="mb-3">Competitions</MudText>
 
-<MudStack AlignItems="AlignItems.Center" Class="mb-4">
-  <MudFab Color="Color.Primary"
-          Size="Size.Large"
-          StartIcon="@Icons.Material.Filled.PlayArrow"
-          Href="competitions/setup"
-          title="Set up a new competition" />
-</MudStack>
+<PrimaryActionFab Href="competitions/setup" Title="Set up a new competition" />
 
 <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1" Wrap="Wrap.Wrap" Class="mb-3">
   <MudText Typo="Typo.subtitle2" Class="mr-2">Type</MudText>

--- a/src/FantasyFootball.Web/Services/IndexedDbCompetitionRepository.cs
+++ b/src/FantasyFootball.Web/Services/IndexedDbCompetitionRepository.cs
@@ -27,6 +27,9 @@ public sealed class IndexedDbCompetitionRepository : ICompetitionRepository
 	// Monotonic id counter; seeded once from existing keys, then bumped synchronously before each async write so a concurrent save (bulk sim + user click) can't collide on an id.
 	int _nextId;
 
+	// Cache of the bulk read (overall standings + cross-competition H2H); cleared on any write so the next read reflects it.
+	IReadOnlyList<Competition>? _cachedAll;
+
 	public IndexedDbCompetitionRepository(IJSRuntime js)
 	{
 		_js = js;
@@ -49,6 +52,7 @@ public sealed class IndexedDbCompetitionRepository : ICompetitionRepository
 			FlatJson.Serialize(competition, compact: true),
 			SerializeSummary(CompetitionSummary.Of(competition)));
 
+		_cachedAll = null;
 		return competition.Id;
 	}
 
@@ -64,6 +68,7 @@ public sealed class IndexedDbCompetitionRepository : ICompetitionRepository
 
 	public async Task<IReadOnlyList<Competition>> GetAllAsync()
 	{
+		if (_cachedAll is not null) { return _cachedAll; }
 		// One transaction so keys and values are a consistent snapshot — a delete mid-read can't misalign id[i] with payload[i].
 		var entries = await _js.InvokeAsync<JsonElement>("ffIdb.entries");
 		var ids = entries.GetProperty("keys").Deserialize<int[]>()!;
@@ -77,6 +82,7 @@ public sealed class IndexedDbCompetitionRepository : ICompetitionRepository
 			result.Add(c);
 		}
 
+		_cachedAll = result;
 		return result;
 	}
 
@@ -90,8 +96,11 @@ public sealed class IndexedDbCompetitionRepository : ICompetitionRepository
 		return summaries;
 	}
 
-	public async Task DeleteAsync(int id) =>
+	public async Task DeleteAsync(int id)
+	{
 		await _js.InvokeVoidAsync("ffIdb.remove", id);
+		_cachedAll = null;
+	}
 
 	public async Task<int> CountAsync() =>
 		(await _js.InvokeAsync<int[]>("ffIdb.summaryKeys")).Length;
@@ -100,6 +109,7 @@ public sealed class IndexedDbCompetitionRepository : ICompetitionRepository
 	{
 		await _js.InvokeVoidAsync("ffIdb.clear");
 		_nextId = 0;
+		_cachedAll = null;
 	}
 
 	// Competitions persisted before the summary store existed have a full payload but no summary. Derive the missing ones once from the full store; every later save keeps both in sync, so this no-ops thereafter.

--- a/src/FantasyFootball.Web/wwwroot/app.css
+++ b/src/FantasyFootball.Web/wwwroot/app.css
@@ -571,6 +571,32 @@ body {
   .timeline-label { min-width: 2.75rem; }
   .timeline-chips::before { display: none; }
   .comp-heading { font-size: 1.15rem; }
+  /* Clearance so the fixed primary-action FAB doesn't cover the last row. */
+  .mud-main-content { padding-bottom: 5rem; }
+}
+
+/* Primary action: centered in-flow on desktop (sits with the content, not floating over it);
+   a fixed bottom-center FAB only on phones, where one-handed thumb reach is the point. */
+.primary-action-fab {
+  display: flex;
+  justify-content: center;
+  margin: 0.5rem 0 1rem;
+}
+@media (max-width: 599px) {
+  .primary-action-fab {
+    position: fixed;
+    left: 0;
+    right: 0;
+    bottom: 1.25rem;
+    margin: 0;
+    z-index: 1100;
+    pointer-events: none; /* the full-width wrapper mustn't block content; the FAB re-enables itself */
+  }
+  .primary-action-fab > * { pointer-events: auto; }
+}
+@media (min-width: 600px) {
+  /* The play FAB is a phone affordance — desktop has Space + inline play buttons. */
+  .primary-action-fab-mobile-only { display: none; }
 }
 
 /* Day-grouping divider for the games panel when a round spans multiple PlayedOn dates. */


### PR DESCRIPTION
Two related pieces from the mobile-usability pass.

## Popover performance (`40e22dd`)
Once IndexedDB let competitions pile up, two costs surfaced in the game-details popover:
- **Dismiss** re-rendered every game row, and each row re-resolved its teams via an `O(AllTeams)` scan (~190k lookups per toggle in a 300-game league). Memoized so a row only re-resolves when its teams actually change.
- The **"H2H (all sims)" stat** deserialized *every* stored competition on each popover open. The repo now caches its bulk read (invalidated on any write), so repeat H2H lookups and the overall-standings panel are instant.

## Primary-action FAB (`ef6c226`)
A shared `PrimaryActionFab`: **fixed bottom-center on phones** (one-handed thumb reach), **centered in-flow on desktop**. Replaces the scattered play / create / replay buttons across the competitions list, setup, and detail pages with one context-aware action — new competition / start / play-next / replay.
- Play-next FAB is **phone-only** (desktop keeps Space + the inline per-game / per-round play buttons).
- Setup: 3-column grid (pickers / center FAB / bulk) collapses to 2 columns now that the action is the FAB.
- Detail: skip the post-sim auto-scroll while a sim is in flight — the FAB's EventCallback otherwise renders mid-sim and scrolled twice; now a single play scrolls once, matching the keyboard path.

## Verification
- 216 unit tests pass; clean build.
- Verified on the dev server (desktop + phone device mode): popover dismiss instant, H2H/standings fast, FAB placement/behavior correct, single scroll on play.

## Follow-ups (not in this PR)
- Mobile game-row reflow when action buttons appear on play (pre-existing phone layout).
- Hold-to-sim (press-and-hold the play FAB) — planned.
- Bottom-nav-bar redesign — separate feature.